### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js: '12'
+dist: bionic
+jobs:
+  include:
+    # TODO: make it work on Windows
+    # - os: windows
+    - os: osx
+    - node_js: '8.12.0'
+    - node_js: '12'
+cache: npm
+# after_success: npm run report

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "engines": {
+    "node": ">=8.12.0"
+  }
 }


### PR DESCRIPTION
This adds Travis CI.

Our current minimum supported Node.js version seems to be at least `8.12.0` based on the dependencies we are using.

Windows testing is currently disabled because our code is not cross-platform at the moment.