### PR TITLE
Fix example `netlify.yml` for the `functions` plugins

### DIFF
--- a/example/netlify.yml
+++ b/example/netlify.yml
@@ -51,7 +51,7 @@ plugins:
         - 'src/**'
 
 build:
-  functions: functions
+  functions: src/backend
   # command: echo 'hi'
   lifecycle:
     init:


### PR DESCRIPTION
This fixes the example `netlify.yml` because it currently does not point to the right `functions` directory.