### PR TITLE
Fix Lighthouse plugin use of Execa

### DIFF
--- a/packages/netlify-plugin-lighthouse/index.js
+++ b/packages/netlify-plugin-lighthouse/index.js
@@ -33,23 +33,10 @@ function netlifyLighthousePlugin(conf) {
     /* Run lighthouse on post deploy */
     postdeploy: async () => {
       const site = conf.site || process.env.SITE
-      /* TODO fetch previous scores from cache */
-      const lighthouseCI = path.join(__dirname, 'node_modules', '.bin', 'lighthouse-ci')
-      let resp
-      try {
-        const subprocess = execa(lighthouseCI, [site], {
-          shell: true
-        })
-        subprocess.stderr.pipe(process.stderr)
-        subprocess.stdout.pipe(process.stdout)
-        resp = await subprocess
-      } catch (err) {
-        console.log(err)
-        throw err
-      }
-      // console.log(resp.stdout)
 
-      if (resp.exitCodeName === 'SUCCESS') {
+      // TODO: fetch previous scores from cache
+      await execa.command(`lighthouse-ci ${site}`, { stdio: 'inherit', preferLocal: true })
+
         // serialize response
         const curLightHouse = {}
         const prevLightHouse = store.get(`lighthouse.${compareWithVersion}`)
@@ -89,7 +76,6 @@ function netlifyLighthousePlugin(conf) {
         store.set(`lighthouse.${currentVersion}`, curLightHouse)
         console.log(`Saved results as version: ${chalk.yellow(currentVersion)}`)
       }
-    }
   }
 }
 


### PR DESCRIPTION
This fixes the invocation of `lighthouse-ci` through `execa`:
  - the `preferLocal: true` option can be used instead of finding `node_modules/.bin/`
  - the `shell: true` option is not needed. The `shell` option [should be avoided](https://github.com/sindresorhus/execa#shell) unless absolutely necessary
  - mixing streams and promises is not recommended, and the `stdio: 'inherit'` achieves the same result
  - there's no need to check for `exitCodeName`. If `exitCodeName` is not `SUCCESS`, `execa()` [will throw an error](https://github.com/sindresorhus/execa/blob/a5bce3a6fc2b3f4ba39a069f0564d1dee403d9b3/index.js#L112)