### PR TITLE
Fix example `netlify.yml`

### DIFF
--- a/example/netlify.yml
+++ b/example/netlify.yml
@@ -39,7 +39,7 @@ plugins:
           endpoint: 'https://my-webhook-endpoint.com/api'
           message: 'Your site build failed sorry charlie'
   - netlify-plugin-lighthouse:
-      enabled: ${env:LIGHTHOUSE_ENABLED, true}
+      enabled: ${env:LIGHTHOUSE_ENABLED, false}
       currentVersion: 0.0.4
       compareWithVersion: 0.0.3
   - netlify-plugin-axe:


### PR DESCRIPTION
The `lighthouse` plugin should be disabled by default in the example `netlify.yml` since users won't necessarily have a `site` setup.