### PR TITLE
Rename `finally` lifecycle to `end`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const lifecycle = [
   /* ↓ Outputs manifest of resources created */
   'manifest',
   /* ↓ Build finished */
-  'finally'
+  'end'
 ]
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -53,7 +53,7 @@ const lifecycle = [
   /* ↓ Outputs manifest of resources created */
   'manifest',
   /* ↓ Build finished */
-  'finally'
+  'end'
 ]
 ```
 

--- a/packages/@netlify-build/src/build/lifecycle.js
+++ b/packages/@netlify-build/src/build/lifecycle.js
@@ -22,7 +22,7 @@ const LIFECYCLE = [
   'init',
   ...MAIN_LIFECYCLE,
   /* Build finished */
-  'finally',
+  'end',
   'onError',
   'scopes'
 ]

--- a/packages/netlify-plugin-example/index.js
+++ b/packages/netlify-plugin-example/index.js
@@ -5,7 +5,7 @@ function netlifySitemapPlugin(conf) {
     init: ({ api }) => {
       console.log('init')
     },
-    finally: async ({ api }) => {
+    end: async ({ api }) => {
       if (api === undefined) {
         return
       }


### PR DESCRIPTION
`finally` is a reserved keyword in JavaScript. We use it as a string here so it technically should not create any issues. However I think it might be more cautious to avoid reserved keywords altogether, just to be safe.