### PR TITLE
Fix `example` plugin crashing

### DIFF
--- a/packages/netlify-plugin-example/index.js
+++ b/packages/netlify-plugin-example/index.js
@@ -6,6 +6,10 @@ function netlifySitemapPlugin(conf) {
       console.log('init')
     },
     finally: async ({ api }) => {
+      if (api === undefined) {
+        return
+      }
+
       console.log('Finally... get site count')
       const sites = await api.listSites()
       if (sites) {


### PR DESCRIPTION
The `api` variable might be `undefined` if no `NETLIFY_TOKEN` is set.