### PR TITLE
Fix `FORCE_COLOR` environment variable

### DIFF
--- a/packages/@netlify-build/src/build/bin.js
+++ b/packages/@netlify-build/src/build/bin.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-const { FORCE_COLOR } = process.env
-if (FORCE_COLOR !== 'false') {
+if (!process.env.FORCE_COLOR) {
   process.env.FORCE_COLOR = true
-  process.env.colors = true
 }
 const chalk = require('chalk')
 const { getConfigFile } = require('@netlify/config')


### PR DESCRIPTION
When users explicitly set the `FORCE_COLOR` environment variable, we should use it instead of overriding it. That variable can be set not only to `false` but also to `0`, `1`, `2`, `3`.

In the future, we might want to allow users setting this via a CLI flag too.