### PR TITLE
Add `package.json` `files` property for `@netlify/build`

### DIFF
--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -6,6 +6,11 @@
   "bin": {
     "netlify-build": "./src/build/bin.js"
   },
+  "files": [
+    "src/**/*.js",
+    "src/**/*.sh",
+    "!tests"
+  ],
   "author": "Netlify Inc.",
   "contributors": [
     "David Wells <hello@davidwells.io> (https://davidwells.io/)",


### PR DESCRIPTION
This adds a `files` property in `package.json` for `@netlify/build` so we only publish source files.