### PR TITLE
Fix empty configuration file

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -108,11 +108,7 @@ module.exports = async function build(configPath, cliFlags, token) {
       return lifeCycleHooks
     }, {})
 
-  if (!netlifyConfig.build) {
-    throw new Error('No build settings found')
-  }
-
-  if (netlifyConfig.build && netlifyConfig.build.lifecycle && netlifyConfig.build.command) {
+  if (netlifyConfig.build.lifecycle && netlifyConfig.build.command) {
     throw new Error(
       `build.command && build.lifecycle are both defined. Please move build.command to build.lifecycle.build`
     )

--- a/packages/@netlify-config/index.js
+++ b/packages/@netlify-config/index.js
@@ -45,6 +45,11 @@ async function netlifyConfig(configFile, cliFlags) {
       }
     ]
   })
+
+  if (config === undefined) {
+    return { build: {} }
+  }
+
   return config
 }
 


### PR DESCRIPTION
At the moment build fails when the `netlify.yml` has no `build` property but not when the `build` property is an empty object. This behavior is not consistent. 

It seems to me omitting the `build` property should have the same behavior as using an empty object, i.e. make the build a noop, which this PR does. 