### PR TITLE
Enforce booleans in `pluginConfig.enabled`

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -60,8 +60,8 @@ module.exports = async function build(configPath, cliFlags, token) {
     .filter(plug => {
       /* Load enabled plugins only */
       const name = Object.keys(plug)[0]
-      const pluginConfig = plug[name] || {}
-      return pluginConfig.enabled !== false && pluginConfig.enabled !== 'false'
+      const { enabled = true } = plug[name] || {}
+      return enabled
     })
     .reduce(
       (acc, curr) => {


### PR DESCRIPTION
At the moment we allow `pluginConfig.enabled` to be either `false` or `"false"`. However we allow `true` but not `"true"` which is inconsistent. 

Generally speaking I think allowing only booleans is simpler to document, validate and handle. It's probably easier for the end user to just know that `enabled` is a boolean as opposed to being either a boolean or a string. 

If we allow either booleans or strings, some users might expect being able to use `FALSE` uppercase, `1` or `0`, etc. Using only booleans seems to provide a simpler developer experience IMHO.

It's also more monomorphic, i.e. better for static analysis, typing, etc.