### PR TITLE
Fix plugin validation

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -3807,9 +3807,9 @@
       }
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+      "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -4484,6 +4484,13 @@
       "requires": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        }
       }
     },
     "mixin-deep": {

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -32,6 +32,7 @@
     "execa": "^2.0.3",
     "filter-obj": "^2.0.0",
     "is-invalid-path": "^1.0.2",
+    "is-plain-obj": "^2.0.0",
     "lodash.isplainobject": "^4.0.6",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",

--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -7,6 +7,7 @@ const filterObj = require('filter-obj')
 const API = require('netlify')
 const resolveConfig = require('@netlify/config')
 const { formatUtils, getConfigFile } = require('@netlify/config')
+const isPlainObj = require('is-plain-obj')
 
 const deepLog = require('../utils/deeplog')
 const { writeFile } = require('../utils/fs')
@@ -101,11 +102,11 @@ module.exports = async function build(configPath, cliFlags, token) {
           }
         }
 
-        if (typeof code !== 'object' && typeof code !== 'function') {
+        const pluginSrc = typeof code === 'function' ? code(pluginConfig) : code
+
+        if (!isPlainObj(pluginSrc)) {
           throw new Error(`Plugin ${name} is malformed. Must be object or function`)
         }
-
-        const pluginSrc = typeof code === 'function' ? code(pluginConfig) : code
 
         const meta = filterObj(pluginSrc, (key, value) => typeof value !== 'function')
 


### PR DESCRIPTION
We validate that plugins are objects. However the current logic does not work:
  - on plugins that are functions. Those might return invalid plugins too but this is not validated.
  - if plugin is `null`

Note that the PR allows both `{}` and `Object.create(null)`.