### PR TITLE
Use `path-exists` library

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -4061,6 +4061,13 @@
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
       }
     },
     "lodash": {
@@ -4284,6 +4291,14 @@
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "dev": true
+            }
           }
         },
         "p-limit": {
@@ -4984,9 +4999,9 @@
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5337,6 +5352,13 @@
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            }
           }
         },
         "p-limit": {

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -37,6 +37,7 @@
     "netlify": "^2.4.8",
     "npm-run-path": "^3.1.0",
     "parse-npm-script": "0.0.3",
+    "path-exists": "^4.0.0",
     "redact-env": "^0.2.0",
     "shell-source": "^1.1.0",
     "stack-utils": "^1.0.2"

--- a/packages/@netlify-build/src/cache/index.js
+++ b/packages/@netlify-build/src/cache/index.js
@@ -3,9 +3,9 @@ const path = require('path')
 const makeDir = require('make-dir')
 const del = require('del')
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../utils/moveCache')
-const { fileExists } = require('../utils/fs')
 
 // https://github.com/netlify/buildbot/blob/4f9545d11ca266bd58b6de4ff24de132b8338287/script/run-build.sh#L38
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L586
@@ -56,9 +56,9 @@ async function cacheArtifacts(cwd, cacheDir) {
   await moveCache(goCache, path.join(cacheDir, '.gimme_cache'), 'go dependencies')
 
   // cache the version of node installed
-  const cacheNodePath = path.join(cacheDir, 'node_version')
-  const cacheNodePathVersion = path.join(cacheNodePath, NODE_VERSION)
-  if (await fileExists(cacheNodePathVersion)) {
+  const cacheNodePath = `${cacheDir}/node_version`
+  const cacheNodePathVersion = `${cacheNodePath}/${NODE_VERSION}`
+  if (await pathExists(cacheNodePathVersion)) {
     // rm -rf $NETLIFY_CACHE_DIR/node_version
     await del(cacheNodePath, { force: true })
     // mkdir $NETLIFY_CACHE_DIR/node_version
@@ -68,10 +68,10 @@ async function cacheArtifacts(cwd, cacheDir) {
   }
 
   // cache the version of ruby installed
-  const rubyPath = path.join(cacheDir, 'ruby_version')
+  const rubyPath = `${cacheDir}/ruby_version`
   if (CUSTOM_RUBY && CUSTOM_RUBY !== '0') {
-    const rubyCustomVersionPath = path.join(rubyPath, `ruby-${RUBY_VERSION}`)
-    if (await fileExists(rubyCustomVersionPath)) {
+    const rubyCustomVersionPath = `${rubyPath}/ruby-${RUBY_VERSION}`
+    if (await pathExists(rubyCustomVersionPath)) {
       // rm -rf $NETLIFY_CACHE_DIR/ruby_version
       await del(rubyPath, { force: true })
       // mkdir $NETLIFY_CACHE_DIR/ruby_version

--- a/packages/@netlify-build/src/install/go/index.js
+++ b/packages/@netlify-build/src/install/go/index.js
@@ -2,8 +2,9 @@ const path = require('path')
 
 const execa = require('execa')
 const makeDir = require('make-dir')
+const pathExists = require('path-exists')
 
-const { readFile, fileExists, removeFiles } = require('../../utils/fs')
+const { readFile, removeFiles } = require('../../utils/fs')
 const moveCache = require('../../utils/moveCache')
 const source = require('../../utils/source')
 
@@ -12,12 +13,12 @@ module.exports = async function installGo(cwd, cacheDir, version) {
   console.log('INSTALL GO')
   const { GIMME_GO_VERSION, GO_IMPORT_PATH, GOPATH } = process.env
   let installGoVersion = version
-  const goVersionFile = path.join(cwd, '.go-version')
+  const goVersionFile = `${cwd}/.go-version`
 
   // Restore cached go
   await moveCache(path.join(cacheDir, 'gimme_cache'), path.join(cwd, 'gimme_cache'), 'restoring cached go cache')
 
-  if (await fileExists(goVersionFile)) {
+  if (await pathExists(goVersionFile)) {
     const goVersion = await readFile(goVersionFile)
     if (goVersion !== version) {
       installGoVersion = goVersion

--- a/packages/@netlify-build/src/install/java/boot.js
+++ b/packages/@netlify-build/src/install/java/boot.js
@@ -1,18 +1,19 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists, writeFile } = require('../../utils/fs')
+const { writeFile } = require('../../utils/fs')
 const shasum = require('../../utils/shasum')
 const shouldInstallDeps = require('../../utils/shouldInstallDeps')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L426-L445
 module.exports = async function installBoot(cwd, cacheDir) {
   const { JAVA_VERSION } = process.env
-  const bootConfig = path.join(cwd, 'build.boot')
+  const bootConfig = `${cwd}/build.boot`
 
-  if (await fileExists(bootConfig)) {
+  if (await pathExists(bootConfig)) {
     // restore_home_cache ".m2" "maven dependencies"
     await moveCache(path.join(cacheDir, '.m2'), path.join(cwd, '.m2'), 'restoring cached maven dependencies')
     // restore_home_cache ".boot" "boot dependencies"

--- a/packages/@netlify-build/src/install/java/leiningen.js
+++ b/packages/@netlify-build/src/install/java/leiningen.js
@@ -1,18 +1,19 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists, writeFile } = require('../../utils/fs')
+const { writeFile } = require('../../utils/fs')
 const shasum = require('../../utils/shasum')
 const shouldInstallDeps = require('../../utils/shouldInstallDeps')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L406-L424
 module.exports = async function installLeiningen(cwd, cacheDir) {
   const { JAVA_VERSION } = process.env
-  const leiningenConfig = path.join(cwd, 'project.clj')
+  const leiningenConfig = `${cwd}/project.clj`
 
-  if (await fileExists(leiningenConfig)) {
+  if (await pathExists(leiningenConfig)) {
     // restore_home_cache ".m2" "maven dependencies"
     await moveCache(path.join(cacheDir, '.m2'), path.join(cwd, '.m2'), 'restoring cached maven dependencies')
 

--- a/packages/@netlify-build/src/install/misc/cask.js
+++ b/packages/@netlify-build/src/install/misc/cask.js
@@ -1,18 +1,18 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L507-L516
 module.exports = async function installCaskDeps(cwd, cacheDir) {
-  const caskFile = path.join(cwd, 'Cask')
+  const caskFile = `${cwd}/Cask`
 
   const caskCacheFolder = path.join(cacheDir, '.cache')
   const caskFolder = path.join(cwd, '.cache')
 
-  if (await fileExists(caskFile)) {
+  if (await pathExists(caskFile)) {
     // restore_home_cache ".cask" "emacs cask dependencies"
     await moveCache(caskCacheFolder, caskFolder, 'restoring cached emacs cask dependencies')
     // restore_home_cache ".emacs.d" "emacs cache"

--- a/packages/@netlify-build/src/install/misc/wapm.js
+++ b/packages/@netlify-build/src/install/misc/wapm.js
@@ -1,16 +1,16 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L558-L572
 module.exports = async function installWapm(cwd, cacheDir) {
-  const wapmConfig = path.join(cwd, 'wapm.toml')
-  const wapmLock = path.join(cwd, 'wapm.lock')
+  const wapmConfig = `${cwd}/wapm.toml`
+  const wapmLock = `${cwd}/wapm.lock`
 
-  if ((await fileExists(wapmConfig)) || (await fileExists(wapmLock))) {
+  if ((await pathExists(wapmConfig)) || (await pathExists(wapmLock))) {
     // source $HOME/.wasmer/wasmer.sh
     try {
       // @ TODO verify $HOME works here

--- a/packages/@netlify-build/src/install/node/bower.js
+++ b/packages/@netlify-build/src/install/node/bower.js
@@ -1,17 +1,17 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists } = require('../../utils/fs')
 
 const install = require('./utils/install')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L380
 module.exports = async function installBower(cwd, cacheDir) {
-  const bowerFile = path.join(cwd, 'bower.json')
+  const bowerFile = `${cwd}/bower.json`
 
-  if (await fileExists(bowerFile)) {
+  if (await pathExists(bowerFile)) {
     let hasBowerInstalled
     try {
       const { stdout } = await execa('which', ['bower'])

--- a/packages/@netlify-build/src/install/node/install-deps.js
+++ b/packages/@netlify-build/src/install/node/install-deps.js
@@ -1,7 +1,8 @@
 const path = require('path')
 
+const pathExists = require('path-exists')
+
 const moveCache = require('../../utils/moveCache')
-const { fileExists } = require('../../utils/fs')
 
 const runNpm = require('./run-npm')
 const runYarn = require('./run-yarn')
@@ -9,10 +10,10 @@ const runYarn = require('./run-yarn')
 // Install Node project deps
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L366-L378
 module.exports = async function installNodeDeps(cwd, cacheDir, yarnVersion) {
-  const packageJSON = path.join(cwd, 'package.json')
-  const yarnLock = path.join(cwd, 'yarn.lock')
+  const packageJSON = `${cwd}/package.json`
+  const yarnLock = `${cwd}/yarn.lock`
 
-  if (await fileExists(packageJSON)) {
+  if (await pathExists(packageJSON)) {
     // Restory cache node_modules
     await moveCache(
       path.join(cacheDir, 'node_modules'),
@@ -21,7 +22,7 @@ module.exports = async function installNodeDeps(cwd, cacheDir, yarnVersion) {
     )
     console.log('ho')
 
-    if (await fileExists(yarnLock)) {
+    if (await pathExists(yarnLock)) {
       await runYarn(cwd, cacheDir, yarnVersion)
     } else {
       await runNpm(cwd, cacheDir)

--- a/packages/@netlify-build/src/install/node/install-node.js
+++ b/packages/@netlify-build/src/install/node/install-node.js
@@ -1,9 +1,10 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const source = require('../../utils/source')
-const { readFile, writeFile, fileExists, removeFiles, copyFiles } = require('../../utils/fs')
+const { readFile, writeFile, removeFiles, copyFiles } = require('../../utils/fs')
 
 const runNvm = require('./utils/run-nvm')
 
@@ -14,9 +15,9 @@ module.exports = async function installNode(cwd, cacheDir, version) {
 
   await source(`${NVM_DIR}/nvm.sh`)
 
-  const nodeVersionCache = path.join(cacheDir, 'node_version')
-  console.log('cache path', nodeVersionCache)
-  if (await fileExists(nodeVersionCache)) {
+  const nodeVersionCache = `${cacheDir}/node_version`
+  console.log('cache path', path.normalize(nodeVersionCache))
+  if (await pathExists(nodeVersionCache)) {
     // Clear nvm dir
     console.log('Started restoring cached node version')
     await removeFiles([`${NVM_DIR}/versions/node/*`], { force: true })
@@ -25,12 +26,12 @@ module.exports = async function installNode(cwd, cacheDir, version) {
     console.log('Finished restoring cached node version')
   }
 
-  const nvmRcPath = path.join(cwd, 'nvmrc')
-  const nodeVersionPath = path.join(cwd, '.node-version')
-  if (await fileExists(nvmRcPath)) {
+  const nvmRcPath = `${cwd}/nvmrc`
+  const nodeVersionPath = `${cwd}/.node-version`
+  if (await pathExists(nvmRcPath)) {
     NODE_VERSION = await readFile(nvmRcPath)
     console.log(`Attempting node version '${NODE_VERSION}' from .nvmrc`)
-  } else if (await fileExists(nodeVersionPath)) {
+  } else if (await pathExists(nodeVersionPath)) {
     NODE_VERSION = await readFile(nvmRcPath)
     console.log(`Attempting node version '${NODE_VERSION}' from .node-version`)
   }
@@ -62,8 +63,8 @@ module.exports = async function installNode(cwd, cacheDir, version) {
   process.env.NODE_VERSION = NODE_VERSION
 
   // Set NPM token if one set
-  const npmConfigPath = path.join(cwd, 'npmrc')
-  if (NPM_TOKEN && !(await fileExists(npmConfigPath))) {
+  const npmConfigPath = `${cwd}/npmrc`
+  if (NPM_TOKEN && !(await pathExists(npmConfigPath))) {
     await writeFile(npmConfigPath, `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`)
   }
 }

--- a/packages/@netlify-build/src/install/node/run-yarn.js
+++ b/packages/@netlify-build/src/install/node/run-yarn.js
@@ -1,17 +1,18 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists, removeFiles, copyFiles } = require('../../utils/fs')
+const { removeFiles, copyFiles } = require('../../utils/fs')
 
 const setTempDir = require('./utils/set-temp-dir')
 
 module.exports = async function runYarn(cwd, cacheDir, yarnVersion) {
-  const yarnCacheDir = path.join(cacheDir, 'yarn')
-  const yarnHomeDir = path.join(process.env.HOME, '.yarn')
+  const yarnCacheDir = `${cacheDir}/yarn`
+  const yarnHomeDir = `${process.env.HOME}/.yarn`
 
-  if (await fileExists(yarnCacheDir)) {
+  if (await pathExists(yarnCacheDir)) {
     /* What does this do?
     export PATH=$NETLIFY_CACHE_DIR/yarn/bin:$PATH
       verify below code

--- a/packages/@netlify-build/src/install/node/utils/install.js
+++ b/packages/@netlify-build/src/install/node/utils/install.js
@@ -1,13 +1,10 @@
-const path = require('path')
-
 const execa = require('execa')
-
-const { fileExists } = require('../../../utils/fs')
+const pathExists = require('path-exists')
 
 /* Install a dep with yarn or npm */
 module.exports = async function installWithYarnOrNpm(name, cwd) {
-  const yarnLock = path.join(cwd, 'yarn.lock')
-  const hasYarnLock = await fileExists(yarnLock)
+  const yarnLock = `${cwd}/yarn.lock`
+  const hasYarnLock = await pathExists(yarnLock)
 
   const [use, cmd] = hasYarnLock ? ['yarn', 'add'] : ['npm', 'install']
 

--- a/packages/@netlify-build/src/install/php/composer.js
+++ b/packages/@netlify-build/src/install/php/composer.js
@@ -1,14 +1,14 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L518-L523
 module.exports = async function installComposerDeps(cwd, cacheDir) {
-  const composerConfig = path.join(cwd, 'composer.json')
-  if (await fileExists(composerConfig)) {
+  const composerConfig = `${cwd}/composer.json`
+  if (await pathExists(composerConfig)) {
     /* Restore cache */
     await moveCache(path.join(cacheDir, '.composer'), path.join(cwd, '.composer'), 'restoring cached composer deps')
     /* Run composer install */

--- a/packages/@netlify-build/src/install/php/index.js
+++ b/packages/@netlify-build/src/install/php/index.js
@@ -1,14 +1,13 @@
 const path = require('path')
 
 const execa = require('execa')
-
-const { fileExists } = require('../../utils/fs')
+const pathExists = require('path-exists')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L297-L311
 module.exports = async function installPhp(cwd, cacheDir, version) {
   const { HOME } = process.env
-  const phpBinPath = path.resolve(`/usr/bin/php${version}`)
-  if (await fileExists(phpBinPath)) {
+  const phpBinPath = path.normalize(`/usr/bin/php${version}`)
+  if (await pathExists(phpBinPath)) {
     try {
       await execa('ln', ['-sf', phpBinPath, `${HOME}/.php/php`])
     } catch (err) {

--- a/packages/@netlify-build/src/install/python/index.js
+++ b/packages/@netlify-build/src/install/python/index.js
@@ -1,16 +1,18 @@
 const path = require('path')
 
+const pathExists = require('path-exists')
+
 const source = require('../../utils/source')
 const moveCache = require('../../utils/moveCache')
-const { readFile, fileExists } = require('../../utils/fs')
+const { readFile } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L166
 module.exports = async function installPython(cwd, cacheDir) {
   const { HOME } = process.env
-  const pythonRuntimeConfig = path.join(cwd, 'runtime.txt')
-  const pipFilePath = path.join(cwd, 'Pipfile')
+  const pythonRuntimeConfig = `${cwd}/runtime.txt`
+  const pipFilePath = `${cwd}/Pipfile`
   let PYTHON_VERSION = '2.7'
-  if (await fileExists(pythonRuntimeConfig)) {
+  if (await pathExists(pythonRuntimeConfig)) {
     PYTHON_VERSION = await readFile(pythonRuntimeConfig)
     try {
       const env = await source(`${HOME}/python${PYTHON_VERSION}/bin/activate`)
@@ -21,7 +23,7 @@ module.exports = async function installPython(cwd, cacheDir) {
       process.exit(1)
     }
     console.log(`Python version set to ${PYTHON_VERSION}`)
-  } else if (await fileExists(pipFilePath)) {
+  } else if (await pathExists(pipFilePath)) {
     console.log('Found Pipfile restoring Pipenv virtualenv')
     await moveCache(path.join(cacheDir, '.venv'), path.join(cwd, '.venv'), 'restoring cached python virtualenv')
   } else {

--- a/packages/@netlify-build/src/install/python/pip.js
+++ b/packages/@netlify-build/src/install/python/pip.js
@@ -1,26 +1,26 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
-const { fileExists } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L334-L364
 module.exports = async function installPipDeps(cwd, cacheDir) {
   const { PIPENV_RUNTIME, HOME } = process.env
-  const requirementsPath = path.join(cwd, 'requirements.txt')
-  const pipFilePath = path.join(cwd, 'Pipfile')
-  if (await fileExists(requirementsPath)) {
+  const requirementsPath = `${cwd}/requirements.txt`
+  const pipFilePath = `${cwd}/Pipfile`
+  if (await pathExists(requirementsPath)) {
     console.log('Installing pip dependencies')
     await moveCache(path.join(cacheDir, '.cache'), path.join(cwd, '.cache'), 'restoring cached python cached deps')
     try {
-      await execa('pip', ['install', '-r', requirementsPath])
+      await execa('pip', ['install', '-r', path.normalize(requirementsPath)])
     } catch (err) {
       console.log('Error installing pip dependencies')
       process.exit(1)
     }
     console.log('Pip dependencies installed')
-  } else if (await fileExists(pipFilePath)) {
+  } else if (await pathExists(pipFilePath)) {
     console.log('Installing dependencies from Pipfile')
     try {
       await execa(`${HOME}/python${PIPENV_RUNTIME}/bin/pipenv`, ['install'])

--- a/packages/@netlify-build/src/install/ruby/gems.js
+++ b/packages/@netlify-build/src/install/ruby/gems.js
@@ -1,24 +1,25 @@
 const path = require('path')
 
 const execa = require('execa')
+const pathExists = require('path-exists')
 
 const moveCache = require('../../utils/moveCache')
 const shasum = require('../../utils/shasum')
 const shouldInstallDeps = require('../../utils/shouldInstallDeps')
-const { fileExists, writeFile } = require('../../utils/fs')
+const { writeFile } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L313-L332
 module.exports = async function installRubyGems(cwd, cacheDir) {
   const { RUBY_VERSION, BUNDLER_FLAGS } = process.env
-  const gemFile = path.join(cwd, 'Gemfile')
-  const gemBundleDir = path.join(cwd, '.bundle')
-  if (await fileExists(gemFile)) {
+  const gemFile = `${cwd}/Gemfile`
+  const gemBundleDir = `${cwd}/.bundle`
+  if (await pathExists(gemFile)) {
     // restore_cwd_cache ".bundle" "ruby gems"
     await moveCache(path.join(cacheDir, '.bundle'), gemBundleDir, 'restoring cached ruby gems')
 
     const gemLockPath = path.join(cwd, 'Gemfile.lock')
     const previousShaPath = path.join(cacheDir, 'gemfile-sha')
-    if ((await shouldInstallDeps(gemLockPath, RUBY_VERSION, previousShaPath)) || !(await fileExists(gemBundleDir))) {
+    if ((await shouldInstallDeps(gemLockPath, RUBY_VERSION, previousShaPath)) || !(await pathExists(gemBundleDir))) {
       console.log('Installing gem bundle')
       try {
         await execa(

--- a/packages/@netlify-build/src/install/ruby/index.js
+++ b/packages/@netlify-build/src/install/ruby/index.js
@@ -2,9 +2,10 @@ const path = require('path')
 
 const execa = require('execa')
 const del = require('del')
+const pathExists = require('path-exists')
 
 const source = require('../../utils/source')
-const { fileExists, readFile, copyFiles } = require('../../utils/fs')
+const { readFile, copyFiles } = require('../../utils/fs')
 
 // https://github.com/netlify/build-image/blob/9e0f207a27642d0115b1ca97cd5e8cebbe492f63/run-build-functions.sh#L233-L292
 module.exports = async function installRuby(cwd, cacheDir, version) {
@@ -20,8 +21,8 @@ module.exports = async function installRuby(cwd, cacheDir, version) {
   process.env.RUBY_VERSION = version
 
   let druby = process.env.RUBY_VERSION
-  const rubyVersionFile = path.join(cwd, '.ruby-version')
-  if (await fileExists(rubyVersionFile)) {
+  const rubyVersionFile = `${cwd}/.ruby-version`
+  if (await pathExists(rubyVersionFile)) {
     druby = await readFile(rubyVersionFile)
     console.log(`Attempting ruby version ${druby}, read from .ruby-version file`)
   } else {
@@ -50,9 +51,8 @@ module.exports = async function installRuby(cwd, cacheDir, version) {
     process.exit(1)
   }
 
-  const fulldruby = `ruby-${druby}`
-  const fulldrubyPath = path.join(cacheDir, 'ruby_version', fulldruby)
-  if (await fileExists(fulldrubyPath)) {
+  const fulldrubyPath = `${cacheDir}/ruby_version/ruby-${druby}`
+  if (await pathExists(fulldrubyPath)) {
     console.log('Started restoring cached ruby version')
     // rm -rf $RVM_DIR/rubies/${fulldruby}
     await del(fulldrubyPath)

--- a/packages/@netlify-build/src/install/serverless/prep-functions.js
+++ b/packages/@netlify-build/src/install/serverless/prep-functions.js
@@ -1,6 +1,5 @@
 const execa = require('execa')
-
-const { fileExists } = require('../../utils/fs')
+const pathExists = require('path-exists')
 
 module.exports = async function prepFunctions(functionsDir, zisiTempDir) {
   if (!functionsDir) {
@@ -8,7 +7,7 @@ module.exports = async function prepFunctions(functionsDir, zisiTempDir) {
     return false
   }
   console.log(`Function Dir: ${functionsDir}`)
-  if (!(await fileExists(functionsDir))) {
+  if (!(await pathExists(functionsDir))) {
     console.log(`Skipping functions preparation step: ${functionsDir} not found`)
     return false
   }

--- a/packages/@netlify-build/src/plugins/deploy/index.js
+++ b/packages/@netlify-build/src/plugins/deploy/index.js
@@ -1,6 +1,8 @@
 const path = require('path')
 
-const { fileExists, readDir } = require('../../utils/fs')
+const pathExists = require('path-exists')
+
+const { readDir } = require('../../utils/fs')
 const { CONTEXT } = process.env
 
 module.exports = () => {
@@ -23,7 +25,7 @@ module.exports = () => {
       }
 
       const publishPath = path.resolve(build.publish)
-      if (!(await fileExists(publishPath))) {
+      if (!(await pathExists(publishPath))) {
         console.log(`Publish dir not found`)
         process.exit(1)
       }

--- a/packages/@netlify-build/src/plugins/functions/index.js
+++ b/packages/@netlify-build/src/plugins/functions/index.js
@@ -2,9 +2,10 @@ const os = require('os')
 const path = require('path')
 
 const makeDir = require('make-dir')
+const pathExists = require('path-exists')
 const { zipFunctions } = require('@netlify/zip-it-and-ship-it')
 
-const { fileExists, readDir } = require('../../utils/fs')
+const { readDir } = require('../../utils/fs')
 const { DEPLOY_PRIME_URL, DEPLOY_ID } = process.env
 
 module.exports = {
@@ -19,7 +20,7 @@ module.exports = {
       return false
     }
 
-    if (!(await fileExists(build.functions))) {
+    if (!(await pathExists(build.functions))) {
       console.log(`Functions directory "${build.functions}" not found`)
       throw new Error('Functions Build cancelled')
     }
@@ -31,7 +32,7 @@ module.exports = {
       tempFileDir = path.join(os.tmpdir(), `zisi-${DEPLOY_ID}`)
     }
 
-    if (!(await fileExists(tempFileDir))) {
+    if (!(await pathExists(tempFileDir))) {
       console.log(`Temp functions directory "${tempFileDir}" not found`)
       console.log(`Creating tmp dir`, tempFileDir)
       await makeDir(tempFileDir)

--- a/packages/@netlify-build/src/utils/fs.js
+++ b/packages/@netlify-build/src/utils/fs.js
@@ -5,6 +5,7 @@ const { promisify } = require('util')
 const makeDir = require('make-dir')
 const del = require('del')
 const isInvalidFilePath = require('is-invalid-path')
+const pathExists = require('path-exists')
 
 const execAsync = require('./execAsync')
 
@@ -15,8 +16,7 @@ const pStat = promisify(fs.stat)
 
 async function writeFile(filePath, contents) {
   const dir = path.dirname(filePath)
-  const dirExists = await fileExists(dir)
-  if (!dirExists) {
+  if (!(await pathExists(dir))) {
     await makeDir(dir)
   }
   await pWriteFile(filePath, contents)
@@ -25,15 +25,6 @@ async function writeFile(filePath, contents) {
 async function readFile(filePath) {
   const content = await pReadFile(filePath, 'utf8')
   return content
-}
-
-function fileExists(filePath) {
-  return new Promise((resolve, reject) => {
-    fs.access(filePath, fs.F_OK, err => {
-      if (err) return resolve(false)
-      return resolve(true)
-    })
-  })
 }
 
 async function removeFiles(filePaths, opts = {}) {
@@ -51,13 +42,13 @@ async function copyFiles(src, dist) {
     throw new Error('Not a valid file path')
   }
 
-  if (!(await fileExists(src))) {
+  if (!(await pathExists(src))) {
     console.log(`Skipping cache copy for ${src}. It doesnt exist`)
     return false
   }
 
   const dir = path.dirname(dist)
-  const dirExists = await fileExists(dist)
+  const dirExists = await pathExists(dist)
   if (!dirExists) {
     await makeDir(dir)
   }
@@ -78,7 +69,6 @@ async function readDir(dir, allFiles = []) {
 module.exports = {
   writeFile,
   readFile,
-  fileExists,
   copyFiles,
   removeFiles,
   readDir

--- a/packages/@netlify-build/src/utils/shouldInstallDeps.js
+++ b/packages/@netlify-build/src/utils/shouldInstallDeps.js
@@ -1,5 +1,7 @@
+const pathExists = require('path-exists')
+
 const shasum = require('./shasum')
-const { readFile, fileExists } = require('./fs')
+const { readFile } = require('./fs')
 
 /**
  * If shas don't match update deps
@@ -8,7 +10,7 @@ const { readFile, fileExists } = require('./fs')
  * @return {Boolean}
  */
 module.exports = async function shouldInstallDeps(currentPath, postFix, previousPath) {
-  if (!(await fileExists(previousPath))) {
+  if (!(await pathExists(previousPath))) {
     return true
   }
   const currentSha = await shasum(currentPath)

--- a/packages/@netlify-config/utils/hasConfig.js
+++ b/packages/@netlify-config/utils/hasConfig.js
@@ -1,10 +1,11 @@
-const fs = require('fs')
 const path = require('path')
+
+const pathExists = require('path-exists')
 
 const configFileName = 'netlify'
 
 module.exports = async function getConfigPath(dirPath) {
-  if (isNetlifyFile(dirPath) && (await fileExists(dirPath))) {
+  if (isNetlifyFile(dirPath) && (await pathExists(dirPath))) {
     // Full config path supplied exit early
     return dirPath
   }
@@ -12,7 +13,7 @@ module.exports = async function getConfigPath(dirPath) {
   const formats = ['toml', 'yml', 'yaml', 'json', 'js']
 
   const checkForFiles = formats.map(format => {
-    return fileExists(path.join(dirPath, `${configFileName}.${format}`))
+    return pathExists(`${dirPath}/${configFileName}.${format}`)
   })
 
   const files = await Promise.all(checkForFiles)
@@ -39,13 +40,4 @@ module.exports = async function getConfigPath(dirPath) {
 function isNetlifyFile(filePath) {
   const regex = new RegExp(`${configFileName}.(toml|yml|yaml|json|js)$`)
   return filePath.match(regex)
-}
-
-function fileExists(filePath) {
-  return new Promise((resolve, reject) => {
-    fs.access(filePath, fs.F_OK, err => {
-      if (err) return resolve(false)
-      return resolve(true)
-    })
-  })
 }


### PR DESCRIPTION
This replaces our `fileExists()` utility function with the `path-exists` library which does exactly the same thing. Less code to maintain for us :)

This also removes some unnecessary `path.join()` and `path.relative()`. Those methods are only needed when the paths are used in a terminal, printed or output to a file. File paths that solely live within Node.js work just fine with forward slashes (or mixed with backslashes on Windows). This is a [write-up](https://github.com/ehmicky/cross-platform-node-guide/blob/master/docs/3_filesystem/file_paths.md#nodejs-behavior) on the topic. I have made sure each variable where `path.join()` is removed is only used within Node.js and not in the terminal.