### PR TITLE
Removes a `console.log()` forgotten in a unit test

### DIFF
--- a/packages/@netlify-config/tests/config.test.js
+++ b/packages/@netlify-config/tests/config.test.js
@@ -7,7 +7,6 @@ const netlifyConfig = require('../index')
 test('Test TOML', async t => {
   const filePath = path.resolve(__dirname, 'fixtures/netlify.toml')
   const config = await netlifyConfig(filePath)
-  console.log('config', config)
 
   t.deepEqual(config, {
     build: {


### PR DESCRIPTION
This removes a `console.log()` that was forgotten in a unit test.