### PR TITLE
Small refactoring of some unit tests

### DIFF
--- a/packages/@netlify-config/tests/config.test.js
+++ b/packages/@netlify-config/tests/config.test.js
@@ -1,12 +1,11 @@
-const path = require('path')
-
 const test = require('ava')
 
-const netlifyConfig = require('../index')
+const netlifyConfig = require('..')
+
+const FIXTURES_DIR = `${__dirname}/fixtures`
 
 test('Test TOML', async t => {
-  const filePath = path.resolve(__dirname, 'fixtures/netlify.toml')
-  const config = await netlifyConfig(filePath)
+  const config = await netlifyConfig(`${FIXTURES_DIR}/netlify.toml`)
 
   t.deepEqual(config, {
     build: {
@@ -18,8 +17,7 @@ test('Test TOML', async t => {
 })
 
 test('Test YAML', async t => {
-  const filePath = path.resolve(__dirname, 'fixtures/netlify.yml')
-  const config = await netlifyConfig(filePath)
+  const config = await netlifyConfig(`${FIXTURES_DIR}/netlify.yml`)
 
   t.deepEqual(config, {
     build: {
@@ -31,8 +29,8 @@ test('Test YAML', async t => {
 })
 
 test('Test JSON', async t => {
-  const filePath = path.resolve(__dirname, 'fixtures/netlify.json')
-  const config = await netlifyConfig(filePath)
+  const config = await netlifyConfig(`${FIXTURES_DIR}/netlify.json`)
+
   t.deepEqual(config, {
     build: {
       publish: 'dist',


### PR DESCRIPTION
This is a small refactoring of the unit tests for `@netlify/config`. `path.resolve()` is not needed in this case. It also requires the root directory instead of `index.js` so we validate the `package.json` `main` field is correct.