### PR TITLE
Do not mix default exports and named exports in `@netlify/config`

### DIFF
--- a/packages/@netlify-config/index.js
+++ b/packages/@netlify-config/index.js
@@ -6,7 +6,7 @@ const pathExists = require('path-exists')
 
 const getConfigPath = require('./path')
 
-async function netlifyConfig(configFile, options) {
+async function resolveConfig(configFile, options) {
   const configPath = resolve(cwd(), configFile)
 
   if (!(await pathExists(configPath))) {
@@ -39,7 +39,7 @@ async function netlifyConfig(configFile, options) {
   return configA
 }
 
-module.exports = netlifyConfig
+module.exports.resolveConfig = resolveConfig
 /* Formatting utilities */
 module.exports.formatUtils = configorama.format
 /* Resolve Netlify config path */


### PR DESCRIPTION
Mixing default exports and named exports requires using some minor workaround when converting CommonJS modules to ES modules and/or TypeScript. This is because with ESM and TypeScript default exports are actually named exports called `default` whereas with CommonJS default exports are the top-level exported value. Mixing both is still possible with both ESM and TypeScript but it's simpler when those two are not mixed. 

Also the fact that functions can also behave as objects is a legacy of old JavaScript that creates issues at times. When used as objects, they cannot use all the features of regular objects (for example they cannot be cloned with `{...object}`). When used as constructors, static properties are not inherited by children. Function properties are also lost when the function is cloned (for example with `Function.bind()`) unless using libraries like [`keep-func-props`](https://github.com/ehmicky/keep-func-props).

Finally I think it's easier to learn a library that either use default exports or named exports, but not both, but that might be just me :) Please let me know what you think!

If this is merged, a follow-up PR will need to be done to update `@netlify/build` with the new `@netlify/config` exports.