### PR TITLE
Improve plugin loading

### DIFF
--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -41,6 +41,7 @@
     "parse-npm-script": "0.0.3",
     "path-exists": "^4.0.0",
     "redact-env": "^0.2.0",
+    "resolve": "^1.12.0",
     "shell-source": "^1.1.0",
     "stack-utils": "^1.0.2"
   },

--- a/packages/@netlify-build/src/build/import.js
+++ b/packages/@netlify-build/src/build/import.js
@@ -1,0 +1,40 @@
+const resolve = require('resolve')
+
+// Import plugin either by module name or by file path
+const importPlugin = function(name, baseDir) {
+  const moduleName = addPackageScope(name)
+  const modulePath = resolvePlugin(moduleName, baseDir)
+
+  try {
+    return require(modulePath)
+  } catch (error) {
+    console.log(`Error loading '${moduleName}' plugin`)
+    throw error
+  }
+}
+
+// YAML does not allow object keys to start with `@`. However npm scoped
+// packages do, so we allow users to omit them.
+const addPackageScope = function(name) {
+  if (!SCOPED_PACKAGE_REGEXP.test(name)) {
+    return name
+  }
+
+  return `@${name}`
+}
+
+const SCOPED_PACKAGE_REGEXP = /^[\w-][\w-.]*\/[\w-.]+$/
+
+// We use `resolve` because `require()` should be relative to `baseDir` not to
+// this `__filename`
+const resolvePlugin = function(moduleName, baseDir) {
+  try {
+    return resolve.sync(moduleName, { basedir: baseDir })
+  } catch (error) {
+    // TODO: if plugin not found, automatically try to `npm install` it
+    console.log(`'${moduleName}' plugin not installed or found`)
+    throw error
+  }
+}
+
+module.exports = { importPlugin }


### PR DESCRIPTION
This improves how plugins are loaded:
  - at the moment modules must be installed in `./node_modules/{moduleName}`. Module resolution should instead follow the same logic as `require()` (looking up directories, etc.). This PR does this by using the [`resolve` module](https://github.com/browserify/resolve).
  - file paths should be relative to the `netlify.yml` directory instead of the current directory. Related to #72.
  - we currently prepend `@` to `netlify/...`. I am assuming this is because YAML does not allow object keys starting with `@` unless escaped. This PR extends this logic to any scoped package, not just `@netlify/...`.
  - the error message when the file path or module name is invalid is now different from the error message when an error is thrown during `require()`