### PR TITLE
Simplify logic related to retrieving `meta`

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -3128,6 +3128,11 @@
         }
       }
     },
+    "filter-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.0.tgz",
+      "integrity": "sha512-1zxy6OITvz/RlubpDlY6GG/eb38WAmSdy1j+LqxaqHhXYcFh/qIaLa+9usO2gaNSeVz8KgFUYubuX2gZhboziQ=="
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -30,6 +30,7 @@
     "cpy": "^7.2.0",
     "del": "^4.1.1",
     "execa": "^2.0.3",
+    "filter-obj": "^2.0.0",
     "is-invalid-path": "^1.0.2",
     "lodash.isplainobject": "^4.0.6",
     "make-dir": "^3.0.0",


### PR DESCRIPTION
This is a small refactoring of the logic related to retrieving `meta`. The behavior is the same, there's just less code thanks to using the `filter-obj` library.