### PR TITLE
Improve logic related to plugin overrides

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -1696,6 +1696,11 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
+    "component-props": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz",
+      "integrity": "sha1-+bffm5kntubZfJvScqqGdnDzSUQ="
+    },
     "compress-commons": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
@@ -2967,6 +2972,14 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "group-by": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/group-by/-/group-by-0.0.1.tgz",
+      "integrity": "sha1-hXYgV19nFHhvjYa7Gf0T4YjdaKQ=",
+      "requires": {
+        "to-function": "*"
       }
     },
     "gulp-header": {
@@ -5802,6 +5815,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "to-function": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/to-function/-/to-function-2.0.6.tgz",
+      "integrity": "sha1-fVbNnDuS+o29eyLoPVGSTedA68U=",
+      "requires": {
+        "component-props": "*"
+      }
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -33,6 +33,7 @@
     "execa": "^2.0.3",
     "figures": "^3.0.0",
     "filter-obj": "^2.0.0",
+    "group-by": "0.0.1",
     "is-invalid-path": "^1.0.2",
     "is-plain-obj": "^2.0.0",
     "make-dir": "^3.0.0",

--- a/packages/@netlify-build/src/build/override.js
+++ b/packages/@netlify-build/src/build/override.js
@@ -1,0 +1,19 @@
+// Any plugin hook `name:...` overrides any previous hook `...` of the plugin `name`
+const getOverride = function(hookName) {
+  if (!hookName.includes(':')) {
+    return {}
+  }
+
+  const [name, ...parts] = hookName.split(':')
+  const hook = parts.join(':')
+  return { name, hook }
+}
+
+// Remove plugin hooks that are overriden by a later hook called `name:...`
+const isNotOverridden = function(lifeCycleHook, index, lifeCycleHooks) {
+  return lifeCycleHooks
+    .slice(index + 1)
+    .every(({ override: { hook, name } }) => hook !== lifeCycleHook.hook || name !== lifeCycleHook.name)
+}
+
+module.exports = { getOverride, isNotOverridden }


### PR DESCRIPTION
This improves the logic related to plugin overrides.

This improves performance: by using `map()` instead of `reduce()`, this allows loading plugins in parallel (with `Promise.all()`) instead of serially. At the moment, the plugin loading logic is synchronous but it's going to be async eventually (because of `resolve()` for example).

This also renames `override.target` and `override.method` to `override.name` and `override.hook` to make it clearer that it's meant to match `lifeCycleHook.name` and `lifeCycleHook.hook`.

Finally the allowed characters in `pluginName` and `example:hook` should probably be validated during plugin loading instead of during plugin override. Otherwise the validation would only be performed when there are overrides. Thanks to this point, this PR simplifies how the `pluginName:example:hook` syntax is parsed.