### PR TITLE
Simplify lifecycles name generation

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -1194,6 +1194,11 @@
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@netlify/config": "^0.0.1",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
+    "array-flat-polyfill": "^1.0.1",
     "chalk": "^2.4.2",
     "clean-stack": "^2.2.0",
     "cpy": "^7.2.0",


### PR DESCRIPTION
This simplifies how the valid names for the lifecycles are being generated.

By making it happen at load-time instead of call-time, this also allows those names to be used as constants by other functions.