### PR TITLE
Improve performance timing

### DIFF
--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -31,6 +31,7 @@
     "cpy": "^7.2.0",
     "del": "^4.1.1",
     "execa": "^2.0.3",
+    "figures": "^3.0.0",
     "filter-obj": "^2.0.0",
     "is-invalid-path": "^1.0.2",
     "is-plain-obj": "^2.0.0",

--- a/packages/@netlify-build/src/utils/patch-logs.js
+++ b/packages/@netlify-build/src/utils/patch-logs.js
@@ -13,21 +13,6 @@ function monkeyPatchLogs(secrets) {
 
       // console.warn('arguments', args)
       // update ARGS
-      const isTimer = args && args[0] && args[0] === '%s: %sms'
-      if (isTimer) {
-        const redactedArgs = args.map((a, i) => {
-          if (i === 0) {
-            return '%s %sms'
-          }
-          if (i === 1) {
-            const check = chalk.green('✔')
-            const msg = chalk.yellowBright(`${trim(a)}`)
-            return `${check} ${msg} completed in`
-          }
-          return a
-        })
-        return Reflect.apply(proxy, context, redactedArgs)
-      }
 
       let prefixSet = false
       const redactedArgs = args.map(a => {

--- a/packages/@netlify-build/src/utils/timer.js
+++ b/packages/@netlify-build/src/utils/timer.js
@@ -1,0 +1,22 @@
+const { hrtime } = require('process')
+
+const { tick } = require('figures')
+const chalk = require('chalk')
+
+// Start a timer
+const startTimer = function() {
+  return hrtime()
+}
+
+// End a timer and prints the result on console
+const endTimer = function(name, [startSecs, startNsecs]) {
+  const [endSecs, endNsecs] = hrtime()
+  const durationNs = (endSecs - startSecs) * NANOSECS_TO_SECS + (endNsecs - startNsecs)
+  const durationMs = Math.ceil(durationNs / NANOSECS_TO_MSECS)
+  console.info(`${chalk.green(tick)} ${chalk.yellowBright(name)} completed in ${durationMs}ms`)
+}
+
+const NANOSECS_TO_SECS = 1e9
+const NANOSECS_TO_MSECS = 1e6
+
+module.exports = { startTimer, endTimer }


### PR DESCRIPTION
This improves console performance timing to use `process.htime()` instead of `console.time()` ~because it's more precise~ to separate measuring the time and printing it on the console. This means we don't need to hook the performance timing to the `console.log()` `Proxy` anymore.

This also makes it work on Windows. `cmd.exe` charset is not UTF-8 and cannot display the tick symbol. This PR uses the [`figures`](https://github.com/sindresorhus/figures) package to make it look nice on Windows.