### PR TITLE
Remove duplicate dependency

### DIFF
--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -34,7 +34,6 @@
     "filter-obj": "^2.0.0",
     "is-invalid-path": "^1.0.2",
     "is-plain-obj": "^2.0.0",
-    "lodash.isplainobject": "^4.0.6",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
     "netlify": "^2.4.8",

--- a/packages/@netlify-build/src/utils/redact.js
+++ b/packages/@netlify-build/src/utils/redact.js
@@ -1,7 +1,7 @@
 const stream = require('stream')
 
 const redactEnv = require('redact-env')
-const isPlainObject = require('lodash.isplainobject')
+const isPlainObject = require('is-plain-obj')
 
 function isObject(value) {
   var type = typeof value


### PR DESCRIPTION
I just realized we just two dependencies that do essentially the same thing: `is-plain-obj` and `lodash.isplainobject`. The first one is slightly faster, simpler and it has TypeScript types.