### PR TITLE
Simplify code related to executing lifecycles

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -4899,6 +4899,11 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
+    "p-map-series": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-2.1.0.tgz",
+      "integrity": "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q=="
+    },
     "p-timeout": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -39,6 +39,7 @@
     "minimist": "^1.2.0",
     "netlify": "^2.4.8",
     "npm-run-path": "^3.1.0",
+    "p-map-series": "^2.1.0",
     "parse-npm-script": "0.0.3",
     "path-exists": "^4.0.0",
     "redact-env": "^0.2.0",

--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -4,6 +4,7 @@ const { cwd } = require('process')
 const chalk = require('chalk')
 const execa = require('execa')
 const filterObj = require('filter-obj')
+const pMapSeries = require('p-map-series')
 const API = require('netlify')
 const resolveConfig = require('@netlify/config')
 const { formatUtils, getConfigFile } = require('@netlify/config')
@@ -151,14 +152,10 @@ module.exports = async function build(configPath, cliFlags, token) {
               const commands = Array.isArray(configLifecycle[hook])
                 ? configLifecycle[hook]
                 : configLifecycle[hook].split('\n')
-              const doCommands = commands.reduce(async (promiseChain, curr) => {
-                const data = await promiseChain
-                // TODO pass in env vars if not available
-                const stdout = await execCommand(curr, `build.lifecycle.${hook}`, redactedKeys)
-                return Promise.resolve(data.concat(stdout))
-              }, Promise.resolve([]))
+              // TODO pass in env vars if not available
               // TODO return stdout?
-              const output = await doCommands // eslint-disable-line
+              // eslint-disable-next-line no-unused-vars
+              const output = await pMapSeries(commands, command => execCommand(command, redactedKeys))
             }
           }
         : undefined,


### PR DESCRIPTION
This simplifies the code related to executing lifecycles serially by using the `p-map-series` library