### PR TITLE
fix (build): fix `getConfigPath()`

### DIFF
--- a/packages/@netlify-build/src/build/bin.js
+++ b/packages/@netlify-build/src/build/bin.js
@@ -14,7 +14,7 @@ async function execBuild() {
   console.log(chalk.greenBright.bold(`Starting Netlify Build`))
   console.log()
   // Automatically resolve the config path
-  const configPath = await getConfigPath(process.cwd())
+  const configPath = await getConfigPath()
 
   console.log(chalk.cyanBright.bold(`Using config file:`))
   console.log(configPath)

--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -6,7 +6,7 @@ const execa = require('execa')
 const filterObj = require('filter-obj')
 const API = require('netlify')
 const resolveConfig = require('@netlify/config')
-const { formatUtils, getConfigFile } = require('@netlify/config')
+const { formatUtils, getConfigPath } = require('@netlify/config')
 require('array-flat-polyfill')
 
 const deepLog = require('../utils/deeplog')
@@ -440,4 +440,4 @@ function isNetlifyCI() {
 // Expose Netlify config
 module.exports.netlifyConfig = resolveConfig
 // Expose Netlify config path getter
-module.exports.getConfigFile = getConfigFile
+module.exports.getConfigPath = getConfigPath


### PR DESCRIPTION
This is a follow-up on #103. 

`getConfigPath()` argument now defaults to `process.cwd()` so it can be omitted. Also one `getConfigFile()` was missing.