### PR TITLE
refactor (config): fix how default `config.build` is assigned

### DIFF
--- a/packages/@netlify-config/index.js
+++ b/packages/@netlify-config/index.js
@@ -46,11 +46,8 @@ async function netlifyConfig(configFile, cliFlags) {
     ]
   })
 
-  if (config === undefined) {
-    return { build: {} }
-  }
-
-  return config
+  const configA = Object.assign({ build: {} }, config)
+  return configA
 }
 
 module.exports = netlifyConfig


### PR DESCRIPTION
This is a small refactoring of how the default empty object assigned to `config.build` is performed. This is due to a follow-up PR related to the same code.