### PR TITLE
Normalize configuration

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -39,12 +39,6 @@ module.exports = async function build(options = {}) {
       redactedKeys
     })
 
-    if (netlifyConfig.build.lifecycle && netlifyConfig.build.command) {
-      throw new Error(
-        `build.command && build.lifecycle are both defined in config file. Please move build.command to build.lifecycle.build`
-      )
-    }
-
     doDryRun({ buildInstructions, netlifyConfigPath, options })
 
     logLifeCycleStart()

--- a/packages/@netlify-config/index.js
+++ b/packages/@netlify-config/index.js
@@ -5,6 +5,8 @@ const configorama = require('configorama')
 const pathExists = require('path-exists')
 
 const getConfigPath = require('./path')
+const { validateConfig } = require('./validate')
+const { normalizeConfig } = require('./normalize')
 
 async function netlifyConfig(configFile, options) {
   const configPath = resolve(cwd(), configFile)
@@ -35,7 +37,9 @@ async function netlifyConfig(configFile, options) {
     ]
   })
 
-  const configA = Object.assign({ build: {} }, config)
+  validateConfig(config)
+
+  const configA = normalizeConfig(config)
   return configA
 }
 

--- a/packages/@netlify-config/normalize.js
+++ b/packages/@netlify-config/normalize.js
@@ -1,0 +1,40 @@
+const mapObj = require('map-obj')
+const omit = require('omit.js')
+
+// Normalize configuration object
+const normalizeConfig = function(config) {
+  const configA = Object.assign({ build: {} }, config)
+  const configB = normalizeLifecycles(configA)
+  return configB
+}
+
+const normalizeLifecycles = function(config) {
+  const {
+    build,
+    build: { command, lifecycle = {} }
+  } = config
+  const buildA = omit(build, ['command'])
+  const lifecycleA = normalizeCommand(lifecycle, command)
+
+  const lifecycleB = mapObj(lifecycleA, normalizeLifecycle)
+
+  return Object.assign({}, config, {
+    build: Object.assign({}, buildA, { lifecycle: lifecycleB })
+  })
+}
+
+// `build.lifecycle.build` was previously called `build.command`
+const normalizeCommand = function(lifecycle, command) {
+  if (command === undefined) {
+    return lifecycle
+  }
+
+  return { ...lifecycle, build: command }
+}
+
+const normalizeLifecycle = function(hook, value) {
+  const valueA = typeof value === 'string' ? value.trim().split('\n') : value
+  return [hook, valueA]
+}
+
+module.exports = { normalizeConfig }

--- a/packages/@netlify-config/package-lock.json
+++ b/packages/@netlify-config/package-lock.json
@@ -706,6 +706,15 @@
         "estraverse": "^4.1.1"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -873,6 +882,14 @@
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
         "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        }
       }
     },
     "chalk": {
@@ -1195,8 +1212,7 @@
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-      "dev": true
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -2266,10 +2282,9 @@
       }
     },
     "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
     },
     "matcher": {
       "version": "2.0.0",
@@ -2481,6 +2496,14 @@
       "requires": {
         "is-observable": "^2.0.0",
         "symbol-observable": "^1.0.4"
+      }
+    },
+    "omit.js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.2.tgz",
+      "integrity": "sha512-/QPc6G2NS+8d4L/cQhbk6Yit1WTB6Us2g84A7A/1+w9d/eRGHyEqC5kkQtHVoHZ5NFWGG7tUGgrhVZwgZanKrQ==",
+      "requires": {
+        "babel-runtime": "^6.23.0"
       }
     },
     "once": {
@@ -3041,6 +3064,11 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regexp.prototype.flags": {
       "version": "1.2.0",

--- a/packages/@netlify-config/package.json
+++ b/packages/@netlify-config/package.json
@@ -19,7 +19,9 @@
   "dependencies": {
     "configorama": "0.3.4",
     "find-up": "^4.1.0",
+    "map-obj": "^4.1.0",
     "minimist": "^1.2.0",
+    "omit.js": "^1.0.2",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/@netlify-config/tests/config.test.js
+++ b/packages/@netlify-config/tests/config.test.js
@@ -10,7 +10,9 @@ test('Test TOML', async t => {
   t.deepEqual(config, {
     build: {
       publish: 'dist',
-      command: 'npm run build',
+      lifecycle: {
+        build: ['npm run build']
+      },
       functions: 'functions'
     }
   })
@@ -22,7 +24,9 @@ test('Test YAML', async t => {
   t.deepEqual(config, {
     build: {
       publish: 'dist',
-      command: 'npm run build',
+      lifecycle: {
+        build: ['npm run build']
+      },
       functions: 'functions'
     }
   })
@@ -34,7 +38,9 @@ test('Test JSON', async t => {
   t.deepEqual(config, {
     build: {
       publish: 'dist',
-      command: 'npm run build',
+      lifecycle: {
+        build: ['npm run build']
+      },
       functions: 'functions'
     }
   })

--- a/packages/@netlify-config/validate.js
+++ b/packages/@netlify-config/validate.js
@@ -1,0 +1,14 @@
+// Validate the configuration object
+const validateConfig = function(config) {
+  validateOldCommand(config)
+}
+
+const validateOldCommand = function({ build: { command, lifecycle } = {} }) {
+  if (command !== undefined && lifecycle !== undefined) {
+    throw new Error(
+      `'build.command' and 'build.lifecycle' are both defined in the configuration. Please rename 'build.command' to 'build.lifecycle.build'`
+    )
+  }
+}
+
+module.exports = { validateConfig }


### PR DESCRIPTION
This introduces a normalization step when loading the configuration.

Normalizing should make it easier to consume the configuration, whether being it for us or for users, because values that could have several shapes only have a single shape.

At the moment, the following normalizations are performed:
  - add default empty objects for `build` and `build.lifecycle`
  - lifecycles can either be arrays or newline-separated strings. This converts the former to arrays.
  - `build.command` is renamed to `build.lifecycle.build`

The configuration is in normalized form in:
  - `@netlify/config` consumers (such as the code of `@netlify/build`)
  - plugin hooks
  - the `netlify.toml` that we create for the BuildBot at the end of `@netlify/build`

The normalized form is not persisted back on the `netlify.yml`, so this is backward compatible.