### PR TITLE
Simplify `--dry-run` flag

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -162,7 +162,7 @@ module.exports = async function build(configPath, cliFlags, token) {
     return instruction.hook !== 'onError'
   })
 
-  if (cliFlags.dryRun || cliFlags.plan) {
+  if (cliFlags.dry) {
     console.log()
     console.log(chalk.cyanBright.bold('Netlify Build Steps'))
     console.log()


### PR DESCRIPTION
At the moment, we have two aliases for dry runs: `--dry-run` and `--plan`. Is there a reason? If not, I think having a single flag would provide with a simpler CLI interface.