### PR TITLE
Simplify engine method checking

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -289,7 +289,6 @@ async function engine({ instructions, netlifyConfig, netlifyConfigPath, netlifyT
   const returnData = await pReduce(
     instructions,
     async (currentData, { method, hook, config, name, override, meta = {} }, index) => {
-    if (method && typeof method === 'function') {
       const methodTimer = startTimer()
       // reset logs context
       netlifyLogs.reset()
@@ -391,15 +390,11 @@ async function engine({ instructions, netlifyConfig, netlifyConfigPath, netlifyT
         })
         console.log()
         endTimer({ context: name.replace('config.', ''), hook }, methodTimer)
-        if (pluginReturnValue) {
-          return Object.assign({}, currentData, pluginReturnValue)
-        }
+        return Object.assign({}, currentData, pluginReturnValue)
       } catch (error) {
         console.log(chalk.redBright(`Error in ${name} plugin`))
         throw error
       }
-    }
-    return currentData
     },
     {}
   )


### PR DESCRIPTION
The engine checks if hooks have a `method` but this is not necessary:
  - configuration lifecycle hooks [always have a `method`](https://github.com/netlify/build/blob/e01b4222d068e35c65de80a77df188159dfd0cf2/packages/%40netlify-build/src/build/main.js#L129)
  - plugin hooks [always have a `method`](https://github.com/netlify/build/blob/e01b4222d068e35c65de80a77df188159dfd0cf2/packages/%40netlify-build/src/build/main.js#L73)

So this condition always evaluates to `true` and can be safely removed.