### PR TITLE
Simplify code related to `plugin.meta.scopes`

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -310,7 +310,7 @@ async function engine({ instructions, netlifyConfig, netlifyConfigPath, netlifyT
 
 const runInstruction = async function({
   currentData,
-  instruction: { method, hook, config, name, override, meta = {} },
+  instruction: { method, hook, config, name, override, meta: { scopes } = {} },
   index,
   netlifyConfig,
   netlifyConfigPath,
@@ -339,8 +339,7 @@ const runInstruction = async function({
   if (netlifyToken) {
     apiClient = new API(netlifyToken)
     /* Redact API methods to scopes. Default scopes '*'... revisit */
-    if (meta && meta.scopes) {
-      const scopes = meta.scopes || ['*']
+    if (scopes) {
       const apiMethods = Object.getPrototypeOf(apiClient)
       const apiMethodArray = Object.keys(apiMethods)
       /* validate scopes */


### PR DESCRIPTION
This simplifies the code related to `plugin.meta.scopes`. We default `scopes` to `['*']` but the following statements are noop when `scopes` is `['*']`, i.e. the branch does nothing then. Defaulting to `undefined` instead has the same effect by skipping the branch altogether. 

This just simplifies the code, the behavior is unchanged (both when `scopes` is not defined and when it is defined).