### PR TITLE
Improve `plugin.scopes` validation

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -424,25 +424,6 @@ const getApiClient = function({ netlifyToken, name, scopes }) {
 
   /* Redact API methods to scopes. Default scopes '*'... revisit */
   if (scopes && !scopes.includes('*')) {
-    const apiMethods = Object.getPrototypeOf(apiClient)
-    const apiMethodArray = Object.keys(apiMethods)
-
-    /* validate scopes */
-    scopes.forEach((scopeName, i) => {
-      if (scopeName !== '*' && !apiMethodArray.includes(scopeName)) {
-        console.log(chalk.redBright(`Invalid scope "${scopeName}" in "${name}" plugin.`))
-        console.log(chalk.white.bold(`Please use a valid event name. One of:`))
-        console.log(
-          `${['*']
-            .concat(apiMethodArray)
-            .map(n => `"${n}"`)
-            .join(', ')}`
-        )
-        console.log()
-        throw new Error(`Invalid scope "${scopeName}" in "${name}" plugin.`)
-      }
-    })
-
     Object.keys(API.prototype)
       .filter(method => !scopes.includes(method))
       .forEach(method => {

--- a/packages/@netlify-build/src/build/validate.js
+++ b/packages/@netlify-build/src/build/validate.js
@@ -1,3 +1,4 @@
+const API = require('netlify')
 const chalk = require('chalk')
 const isPlainObj = require('is-plain-obj')
 
@@ -18,7 +19,7 @@ const validateProperty = function(value, propName, pluginName) {
     return
   }
 
-  validateNonMethod(propName, pluginName)
+  validateNonMethod(value, propName, pluginName)
 }
 
 const validateMethod = function(propName, pluginName) {
@@ -27,7 +28,7 @@ const validateMethod = function(propName, pluginName) {
   if (!LIFECYCLE.includes(hook)) {
     console.log(chalk.redBright(`Invalid lifecycle hook '${hook}' in '${pluginName}'.`))
     console.log(`Please use a valid event name. One of:`)
-    console.log(`${LIFECYCLE.map(name => `"${name}"`).join(', ')}`)
+    console.log(serializeList(LIFECYCLE))
     throw new Error(`Invalid lifecycle hook`)
   }
 }
@@ -35,15 +36,46 @@ const validateMethod = function(propName, pluginName) {
 // Hooks can start with `pluginName:` to override another plugin
 const OVERRIDE_REGEXP = /^[^:]+:/
 
-const validateNonMethod = function(propName, pluginName) {
+const validateNonMethod = function(value, propName, pluginName) {
   if (!ALLOWED_PROPERTIES.includes(propName)) {
     console.log(chalk.redBright(`Invalid property '${propName}' in '${pluginName}'.`))
     console.log(`Please use a property name. One of:`)
-    console.log(`${ALLOWED_PROPERTIES.map(name => `"${name}"`).join(', ')}`)
+    console.log(serializeList(ALLOWED_PROPERTIES))
     throw new Error('Invalid plugin property')
+  }
+
+  if (propName === 'scopes') {
+    validateScopes(value, pluginName)
   }
 }
 
 const ALLOWED_PROPERTIES = ['name', 'core', 'scopes']
+
+const validateScopes = function(scopes, pluginName) {
+  const wrongScopes = scopes.filter(scope => !isValidScope(scope))
+  if (wrongScopes.length === 0) {
+    return
+  }
+
+  console.log(chalk.redBright(`Invalid scopes ${serializeList(wrongScopes)} in '${pluginName}'`))
+  console.log(chalk.white.bold(`Please use a valid scope. One of:`))
+  console.log(serializeList(ALLOWED_SCOPES))
+  console.log()
+  throw new Error(`Invalid scopes property`)
+}
+
+const isValidScope = function(scope) {
+  return ALLOWED_SCOPES.includes(scope)
+}
+
+const ALLOWED_SCOPES = ['*', ...Object.keys(API.prototype)]
+
+const serializeList = function(array) {
+  return array.map(quote).join(', ')
+}
+
+const quote = function(string) {
+  return `"${string}"`
+}
 
 module.exports = { validatePlugin }


### PR DESCRIPTION
With #90 we now validate plugins as soon as they are loaded with a separate utility function. This allows plugins validation to be performed outside of a build, e.g. through a CLI utility.

This PR moves the validation of `plugin.scopes` to that utility function.

This also fixes the error message, which was mentioning `event name` instead of `scope`.