### PR TITLE
Fix bug with `plugin.scopes`

### DIFF
--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -401,7 +401,7 @@ const getApiClient = function({ netlifyToken, name, scopes }) {
   const apiClient = new API(netlifyToken)
 
   /* Redact API methods to scopes. Default scopes '*'... revisit */
-  if (scopes) {
+  if (scopes && !scopes.includes('*')) {
     const apiMethods = Object.getPrototypeOf(apiClient)
     const apiMethodArray = Object.keys(apiMethods)
 
@@ -421,26 +421,20 @@ const getApiClient = function({ netlifyToken, name, scopes }) {
       }
     })
 
-    /* If scopes not *, redact the methods not allowed */
-    if (!scopes.includes('*')) {
-      apiMethodArray.forEach(meth => {
-        if (!scopes.includes(meth)) {
-          // TODO figure out if Object.setPrototypeOf will work
-          apiClient.__proto__[meth] = disableApiMethod(name, meth) // eslint-disable-line
-        }
+    Object.keys(API.prototype)
+      .filter(method => !scopes.includes(method))
+      .forEach(method => {
+        apiClient[method] = disabledApiMethod.bind(null, name, method)
       })
-    }
   }
 
   return apiClient
 }
 
-function disableApiMethod(pluginName, method) {
-  return () => {
-    throw new Error(
-      `The "${pluginName}" plugin is not authorized to use "api.${method}". Please update the plugin scopes.`
-    )
-  }
+async function disabledApiMethod(pluginName, method) {
+  throw new Error(
+    `The "${pluginName}" plugin is not authorized to use "api.${method}". Please update the plugin scopes.`
+  )
 }
 
 // Test if inside netlify build context


### PR DESCRIPTION
Currently `plugin.scopes` forbid methods by modifying `apiClient.__proto__`. However `apiClient.__proto__` is shared between each `apiClient` instance. Also each plugin gets its own `apiClient` instance. This means that each `plugin.scopes` restrictions is currently applied to all plugins instead of only one plugin. This PR fixes this by modifying `apiClient.*` instead of `apiClient.__proto__.*`.

This PR also makes the dummy disabled methods async instead of sync, so that the method signature does not change.