### PR TITLE
Fix Windows logs

### DIFF
--- a/packages/@netlify-build/src/build/constants.js
+++ b/packages/@netlify-build/src/build/constants.js
@@ -1,1 +1,5 @@
-module.exports.HEADING_PREFIX = '❯'
+const { pointer } = require('figures')
+
+const HEADING_PREFIX = pointer
+
+module.exports = { HEADING_PREFIX }


### PR DESCRIPTION
The `❯` character is not supported on Windows `cmd.exe` by default. This PR fixes it by using the [`figures`](https://github.com/sindresorhus/figures#readme) library which uses `❯` on Unix and `>` on Windows.