### PR TITLE
Simplify code for streams redaction

### DIFF
--- a/packages/@netlify-build/package-lock.json
+++ b/packages/@netlify-build/package-lock.json
@@ -5148,6 +5148,16 @@
       "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
       "integrity": "sha1-gdgax663LX9cSUKt8ml6MiBojY4="
     },
+    "replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "requires": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
     "require-package-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",

--- a/packages/@netlify-build/package.json
+++ b/packages/@netlify-build/package.json
@@ -47,6 +47,7 @@
     "parse-npm-script": "0.0.3",
     "path-exists": "^4.0.0",
     "redact-env": "^0.2.0",
+    "replacestream": "^4.0.3",
     "resolve": "^1.12.0",
     "shell-source": "^1.1.0",
     "stack-utils": "^1.0.2"


### PR DESCRIPTION
This simplifies the code for redacting secrets in streams, by using the [`replacestream` utility](https://github.com/eugeneware/replacestream). That utility has lots of [unit tests](https://github.com/eugeneware/replacestream/blob/master/test/replace.js) so we don't need to test this part of the code ourselves, nor maintain it.

It also does not use object mode, which improves stream buffering. In object mode, `highWaterMark` [defaults to `16` chunks instead of `16KB`](https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options) which works for streams of objects but is not optimal for streams of strings/buffers (which is our case).

The behavior is otherwise the same.