### PR TITLE
Move some code to its own file

### DIFF
--- a/packages/@netlify-build/src/build/toml.js
+++ b/packages/@netlify-build/src/build/toml.js
@@ -1,0 +1,31 @@
+const { formatUtils } = require('@netlify/config')
+
+const { writeFile } = require('../utils/fs')
+
+// Write TOML file to support current buildbot
+const tomlWrite = async function(netlifyConfig, baseDir) {
+  if (!isNetlifyCI()) {
+    return
+  }
+
+  const toml = formatUtils.toml.dump(netlifyConfig)
+  const tomlPath = `${baseDir}/netlify.toml`
+  await writeFile(tomlPath, toml)
+
+  logTomlWrite(tomlPath, toml)
+}
+
+// Test if inside netlify build context
+const isNetlifyCI = function() {
+  return Boolean(process.env.DEPLOY_PRIME_URL)
+}
+
+const logTomlWrite = function(tomlPath, toml) {
+  console.log()
+  console.log('TOML output:')
+  console.log()
+  console.log(toml)
+  console.log(`TOML file written to ${tomlPath}`)
+}
+
+module.exports = { tomlWrite }


### PR DESCRIPTION
This moves the code related to `netlify.toml` dumping to its own file. This does not change behavior, only moves lines around.