### PR TITLE
Move all log-related code to its own file

### DIFF
--- a/packages/@netlify-build/src/build/config.js
+++ b/packages/@netlify-build/src/build/config.js
@@ -6,12 +6,8 @@ const {
 
 const resolveConfig = require('@netlify/config')
 const { getConfigPath } = require('@netlify/config')
-const chalk = require('chalk')
-const omit = require('omit.js')
 
-const deepLog = require('../utils/deeplog')
-
-const { HEADING_PREFIX } = require('./constants')
+const { logOptions, logConfigPath, logConfigError } = require('./log')
 
 // Retrieve configuration object
 const loadConfig = async function({ options, options: { token, config } }) {
@@ -27,20 +23,9 @@ const loadConfig = async function({ options, options: { token, config } }) {
     const netlifyConfig = await resolveConfig(netlifyConfigPath, options)
     return { netlifyConfig, netlifyConfigPath, netlifyToken, baseDir }
   } catch (error) {
-    console.log('Netlify Config Error')
+    logConfigError()
     throw error
   }
-}
-
-const logOptions = function(options) {
-  console.log(chalk.cyanBright.bold('Options'))
-  deepLog(omit(options, ['token']))
-  console.log()
-}
-
-const logConfigPath = function(netlifyConfigPath) {
-  console.log(chalk.cyanBright.bold(`${HEADING_PREFIX} Using config file: ${netlifyConfigPath}`))
-  console.log()
 }
 
 const getBaseDir = function(netlifyConfigPath) {

--- a/packages/@netlify-build/src/build/dry.js
+++ b/packages/@netlify-build/src/build/dry.js
@@ -1,8 +1,4 @@
-const path = require('path')
-
-const chalk = require('chalk')
-
-const { HEADING_PREFIX } = require('./constants')
+const { logDryRunStart, logDryRunInstruction, logDryRunEnd } = require('./log')
 
 // If the `dry` option is specified, do a dry run
 const doDryRun = function({ buildInstructions, netlifyConfigPath, options: { dry } }) {
@@ -10,26 +6,16 @@ const doDryRun = function({ buildInstructions, netlifyConfigPath, options: { dry
     return
   }
 
-  console.log()
-  console.log(chalk.cyanBright.bold(`${HEADING_PREFIX} Netlify Build Steps`))
-  console.log()
+  logDryRunStart()
 
   const width = Math.max(...buildInstructions.map(({ hook }) => hook.length))
   buildInstructions.forEach((instruction, index) =>
     logDryRunInstruction({ instruction, index, netlifyConfigPath, width })
   )
 
-  console.log()
-  process.exit(0)
-}
+  logDryRunEnd()
 
-const logDryRunInstruction = function({ instruction: { name, hook }, index, netlifyConfigPath, width }) {
-  const source = name.startsWith('config.build') ? `in ${path.basename(netlifyConfigPath)}` : 'plugin'
-  const count = chalk.cyanBright(`${index + 1}.`)
-  const hookName = chalk.white.bold(`${hook.padEnd(width + 2)} `)
-  const niceName = name.startsWith('config.build') ? name.replace(/^config\./, '') : name
-  const sourceOutput = chalk.white.bold(niceName)
-  console.log(chalk.cyanBright(`${count} ${hookName} source ${sourceOutput} ${source} `))
+  process.exit(0)
 }
 
 module.exports = { doDryRun }

--- a/packages/@netlify-build/src/build/error.js
+++ b/packages/@netlify-build/src/build/error.js
@@ -1,12 +1,5 @@
-const {
-  env: { ERROR_VERBOSE }
-} = require('process')
-
-const chalk = require('chalk')
-
-const cleanStack = require('../utils/clean-stack')
-
 const { runInstructions } = require('./instructions')
+const { logInstructionsError, logErrorInstructions } = require('./log')
 
 // Error handler when an instruction fails
 const handleInstructionError = async function({
@@ -17,7 +10,7 @@ const handleInstructionError = async function({
   baseDir,
   error
 }) {
-  logInstructionError()
+  logInstructionsError()
 
   if (errorInstructions.length !== 0) {
     logErrorInstructions()
@@ -32,38 +25,4 @@ const handleInstructionError = async function({
   }
 }
 
-const logInstructionError = function() {
-  console.log()
-  console.log(chalk.redBright.bold('┌─────────────────────┐'))
-  console.log(chalk.redBright.bold('│  Lifecycle Error!   │'))
-  console.log(chalk.redBright.bold('└─────────────────────┘'))
-}
-
-const logErrorInstructions = function() {
-  console.log()
-  console.log(chalk.cyanBright('Running onError methods'))
-}
-
-const logBuildError = function(error) {
-  console.log()
-  console.log(chalk.redBright.bold('┌─────────────────────────────┐'))
-  console.log(chalk.redBright.bold('│    Netlify Build Error!     │'))
-  console.log(chalk.redBright.bold('└─────────────────────────────┘'))
-  console.log(chalk.bold(` ${error.message}`))
-  console.log()
-  console.log(chalk.yellowBright.bold('┌─────────────────────────────┐'))
-  console.log(chalk.yellowBright.bold('│      Error Stack Trace      │'))
-  console.log(chalk.yellowBright.bold('└─────────────────────────────┘'))
-
-  if (ERROR_VERBOSE) {
-    console.log(error.stack)
-  } else {
-    console.log(` ${chalk.bold(cleanStack(error.stack))}`)
-    console.log()
-    console.log(` Set environment variable ERROR_VERBOSE=true for deep traces`)
-  }
-
-  console.log()
-}
-
-module.exports = { handleInstructionError, logBuildError }
+module.exports = { handleInstructionError }

--- a/packages/@netlify-build/src/build/log.js
+++ b/packages/@netlify-build/src/build/log.js
@@ -1,0 +1,216 @@
+const { basename } = require('path')
+const {
+  env: { ERROR_VERBOSE }
+} = require('process')
+
+const { greenBright, cyanBright, redBright, yellowBright, white, bold } = require('chalk')
+const omit = require('omit.js')
+
+const deepLog = require('../utils/deeplog')
+const cleanStack = require('../utils/clean-stack')
+const { getSecrets } = require('../utils/redact')
+const netlifyLogs = require('../utils/patch-logs')
+
+const { HEADING_PREFIX } = require('./constants')
+
+// Monkey patch console.log() to redact secrets
+const startPatchingLog = function() {
+  const redactedKeys = getSecrets(['SECRET_ENV_VAR', 'MY_API_KEY'])
+  const originalConsoleLog = console.log
+  console.log = netlifyLogs.patch(redactedKeys)
+  return { redactedKeys, originalConsoleLog }
+}
+
+const stopPatchingLog = function(originalConsoleLog) {
+  console.log = originalConsoleLog
+}
+
+const logBuildStart = function() {
+  console.log(greenBright.bold(`${HEADING_PREFIX} Starting Netlify Build`))
+  console.log(`https://github.com/netlify/build`)
+  console.log()
+}
+
+const logOptions = function(options) {
+  console.log(cyanBright.bold('Options'))
+  deepLog(omit(options, ['token']))
+  console.log()
+}
+
+const logConfigPath = function(netlifyConfigPath) {
+  console.log(cyanBright.bold(`${HEADING_PREFIX} Using config file: ${netlifyConfigPath}`))
+  console.log()
+}
+
+const logConfigError = function() {
+  console.log('Netlify Config Error')
+}
+
+const logLifeCycleStart = function() {
+  console.log()
+  console.log(greenBright.bold('Running Netlify Build Lifecycle'))
+  console.log()
+}
+
+const logDryRunStart = function() {
+  console.log()
+  console.log(cyanBright.bold(`${HEADING_PREFIX} Netlify Build Steps`))
+  console.log()
+}
+
+const logDryRunInstruction = function({ instruction: { name, hook }, index, netlifyConfigPath, width }) {
+  const source = name.startsWith('config.build') ? `in ${basename(netlifyConfigPath)}` : 'plugin'
+  const count = cyanBright(`${index + 1}.`)
+  const hookName = white.bold(`${hook.padEnd(width + 2)} `)
+  const niceName = name.startsWith('config.build') ? name.replace(/^config\./, '') : name
+  const sourceOutput = white.bold(niceName)
+  console.log(cyanBright(`${count} ${hookName} source ${sourceOutput} ${source} `))
+}
+
+const logDryRunEnd = function() {
+  console.log()
+}
+
+const logInstruction = function({
+  currentData,
+  method,
+  hook,
+  pluginConfig,
+  name,
+  override,
+  scopes,
+  index,
+  netlifyConfig,
+  netlifyConfigPath,
+  netlifyToken,
+  baseDir,
+  error
+}) {
+  console.log()
+  if (override.hook) {
+    console.log(
+      redBright.bold(`> OVERRIDE: "${override.hook}" method in ${override.name} has been overriden by "${name}"`)
+    )
+  }
+  const lifecycleName = error ? '' : 'lifecycle '
+  const source = name.startsWith('config.build') ? `in ${basename(netlifyConfigPath)} config file` : 'plugin'
+  const niceName = name.startsWith('config.build') ? name.replace(/^config\./, '') : name
+  const logColor = error ? redBright : cyanBright
+  const outputNoChalk = `${index + 1}. Running ${hook} ${lifecycleName}from ${niceName} ${source}`
+  const output = `${index + 1}. Running ${white.bold(hook)} ${lifecycleName}from ${white.bold(niceName)} ${source}`
+  const line = '─'.repeat(outputNoChalk.length + 2)
+  console.log(logColor.bold(`┌─${line}─┐`))
+  console.log(logColor.bold(`│ ${output}   │`))
+  console.log(logColor.bold(`└─${line}─┘`))
+  console.log()
+}
+
+const logCommandStart = function(cmd) {
+  console.log(yellowBright(`Running command "${cmd}"`))
+}
+
+const logCommandError = function(cmd, name, error) {
+  console.log(redBright(`Error from netlify config ${name}:`))
+  console.log(`"${cmd}"`)
+  console.log()
+  console.log(redBright('Error message\n'))
+  console.log(error.stderr)
+  console.log()
+}
+
+const logInstructionSuccess = function() {
+  console.log()
+}
+
+const logInstructionError = function(name) {
+  console.log(redBright(`Error in ${name} plugin`))
+}
+
+const logManifest = function(manifest) {
+  if (Object.keys(manifest).length === 0) {
+    return
+  }
+
+  console.log('Manifest:')
+  deepLog(manifest)
+}
+
+const logTomlWrite = function(tomlPath, toml) {
+  console.log()
+  console.log('TOML output:')
+  console.log()
+  console.log(toml)
+  console.log(`TOML file written to ${tomlPath}`)
+}
+
+const logInstructionsError = function() {
+  console.log()
+  console.log(redBright.bold('┌─────────────────────┐'))
+  console.log(redBright.bold('│  Lifecycle Error!   │'))
+  console.log(redBright.bold('└─────────────────────┘'))
+}
+
+const logErrorInstructions = function() {
+  console.log()
+  console.log(cyanBright('Running onError methods'))
+}
+
+const logBuildError = function(error) {
+  console.log()
+  console.log(redBright.bold('┌─────────────────────────────┐'))
+  console.log(redBright.bold('│    Netlify Build Error!     │'))
+  console.log(redBright.bold('└─────────────────────────────┘'))
+  console.log(bold(` ${error.message}`))
+  console.log()
+  console.log(yellowBright.bold('┌─────────────────────────────┐'))
+  console.log(yellowBright.bold('│      Error Stack Trace      │'))
+  console.log(yellowBright.bold('└─────────────────────────────┘'))
+
+  if (ERROR_VERBOSE) {
+    console.log(error.stack)
+  } else {
+    console.log(` ${bold(cleanStack(error.stack))}`)
+    console.log()
+    console.log(` Set environment variable ERROR_VERBOSE=true for deep traces`)
+  }
+
+  console.log()
+}
+
+const logBuildSuccess = function() {
+  console.log()
+  console.log(greenBright.bold('┌─────────────────────────────┐'))
+  console.log(greenBright.bold('│   Netlify Build Complete!   │'))
+  console.log(greenBright.bold('└─────────────────────────────┘'))
+  console.log()
+}
+
+const logBuildEnd = function() {
+  const sparkles = cyanBright('(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧')
+  console.log(`\n${sparkles} Have a nice day!\n`)
+}
+
+module.exports = {
+  startPatchingLog,
+  stopPatchingLog,
+  logBuildStart,
+  logOptions,
+  logConfigPath,
+  logConfigError,
+  logLifeCycleStart,
+  logDryRunStart,
+  logDryRunInstruction,
+  logDryRunEnd,
+  logInstruction,
+  logCommandStart,
+  logCommandError,
+  logInstructionSuccess,
+  logInstructionError,
+  logManifest,
+  logTomlWrite,
+  logInstructionsError,
+  logErrorInstructions,
+  logBuildError,
+  logBuildSuccess,
+  logBuildEnd
+}

--- a/packages/@netlify-build/src/build/main.js
+++ b/packages/@netlify-build/src/build/main.js
@@ -1,33 +1,43 @@
 require('./colors')
-const chalk = require('chalk')
 const resolveConfig = require('@netlify/config')
 const { getConfigPath } = require('@netlify/config')
 require('array-flat-polyfill')
 
-const deepLog = require('../utils/deeplog')
-const { getSecrets } = require('../utils/redact')
-const netlifyLogs = require('../utils/patch-logs')
 const { getPluginsHooks } = require('../plugins/main')
 const { startTimer, endTimer } = require('../utils/timer')
 
 const { loadConfig } = require('./config')
-const { handleInstructionError, logBuildError } = require('./error')
+const { handleInstructionError } = require('./error')
 const { getInstructions, runInstructions } = require('./instructions')
 const { tomlWrite } = require('./toml')
-const { HEADING_PREFIX } = require('./constants')
 const { doDryRun } = require('./dry')
+const {
+  startPatchingLog,
+  stopPatchingLog,
+  logBuildStart,
+  logLifeCycleStart,
+  logManifest,
+  logBuildError,
+  logBuildSuccess,
+  logBuildEnd
+} = require('./log')
 
 module.exports = async function build(options = {}) {
-  try {
-    const buildTimer = startTimer()
+  const { redactedKeys, originalConsoleLog } = startPatchingLog()
 
-    console.log(chalk.greenBright.bold(`${HEADING_PREFIX} Starting Netlify Build`))
-    console.log(`https://github.com/netlify/build`)
-    console.log()
+  const buildTimer = startTimer()
+
+  try {
+    logBuildStart()
 
     const { netlifyConfig, netlifyConfigPath, netlifyToken, baseDir } = await loadConfig({ options })
 
     const pluginsHooks = getPluginsHooks(netlifyConfig, baseDir)
+    const { buildInstructions, errorInstructions } = getInstructions({
+      pluginsHooks,
+      netlifyConfig,
+      redactedKeys
+    })
 
     if (netlifyConfig.build.lifecycle && netlifyConfig.build.command) {
       throw new Error(
@@ -35,36 +45,18 @@ module.exports = async function build(options = {}) {
       )
     }
 
-    /* Get user set ENV vars and redact */
-    const redactedKeys = getSecrets(['SECRET_ENV_VAR', 'MY_API_KEY'])
-    /* Monkey patch console.log */
-    const originalConsoleLog = console.log
-    console.log = netlifyLogs.patch(redactedKeys)
-
-    const { buildInstructions, errorInstructions } = getInstructions({
-      pluginsHooks,
-      netlifyConfig,
-      redactedKeys
-    })
-
     doDryRun({ buildInstructions, netlifyConfigPath, options })
 
-    /* Execute build with plugins */
-    console.log()
-    console.log(chalk.greenBright.bold('Running Netlify Build Lifecycle'))
-    console.log()
+    logLifeCycleStart()
+
     try {
-      // TODO refactor engine args
       const manifest = await runInstructions(buildInstructions, {
         netlifyConfig,
         netlifyConfigPath,
         netlifyToken,
         baseDir
       })
-      if (Object.keys(manifest).length) {
-        console.log('Manifest:')
-        deepLog(manifest)
-      }
+      logManifest(manifest)
     } catch (error) {
       await handleInstructionError({
         errorInstructions,
@@ -82,25 +74,11 @@ module.exports = async function build(options = {}) {
     logBuildSuccess()
     endTimer({ context: 'Netlify Build' }, buildTimer)
     logBuildEnd()
-
-    // Reset console.log for CLI
-    console.log = originalConsoleLog
   } catch (error) {
     logBuildError(error)
   }
-}
 
-const logBuildSuccess = function() {
-  console.log()
-  console.log(chalk.greenBright.bold('┌─────────────────────────────┐'))
-  console.log(chalk.greenBright.bold('│   Netlify Build Complete!   │'))
-  console.log(chalk.greenBright.bold('└─────────────────────────────┘'))
-  console.log()
-}
-
-const logBuildEnd = function() {
-  const sparkles = chalk.cyanBright('(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧')
-  console.log(`\n${sparkles} Have a nice day!\n`)
+  stopPatchingLog(originalConsoleLog)
 }
 
 // Expose Netlify config

--- a/packages/@netlify-build/src/build/toml.js
+++ b/packages/@netlify-build/src/build/toml.js
@@ -2,6 +2,8 @@ const { formatUtils } = require('@netlify/config')
 
 const { writeFile } = require('../utils/fs')
 
+const { logTomlWrite } = require('./log')
+
 // Write TOML file to support current buildbot
 const tomlWrite = async function(netlifyConfig, baseDir) {
   if (!isNetlifyCI()) {
@@ -18,14 +20,6 @@ const tomlWrite = async function(netlifyConfig, baseDir) {
 // Test if inside netlify build context
 const isNetlifyCI = function() {
   return Boolean(process.env.DEPLOY_PRIME_URL)
-}
-
-const logTomlWrite = function(tomlPath, toml) {
-  console.log()
-  console.log('TOML output:')
-  console.log()
-  console.log(toml)
-  console.log(`TOML file written to ${tomlPath}`)
 }
 
 module.exports = { tomlWrite }


### PR DESCRIPTION
This moves all log-related code to its own file. This does not change logging, behavior nor logic.

Like this we can have a quick grasp of the log/output in a single file, and change colors and logging logic from a single location.