### PR TITLE
Fix `FORCE_COLORS` environment variable

### DIFF
--- a/packages/build/src/build/colors.js
+++ b/packages/build/src/build/colors.js
@@ -36,4 +36,10 @@ const getColorLevel = function() {
 
 const DEPTH_TO_LEVEL = { 1: '0', 4: '1', 8: '2', 24: '3' }
 
+const hasColors = function() {
+  return env.FORCE_COLOR !== '0' && env.FORCE_COLOR !== 'false'
+}
+
 setColorLevel()
+
+module.exports = { hasColors }

--- a/packages/build/src/build/log.js
+++ b/packages/build/src/build/log.js
@@ -7,7 +7,7 @@ const { tick, pointer } = require('figures')
 const { greenBright, cyanBright, redBright, yellowBright, bold } = require('chalk')
 const omit = require('omit.js')
 
-const deepLog = require('../utils/deeplog')
+const { deepLog } = require('../utils/deeplog')
 const cleanStack = require('../utils/clean-stack')
 const { getSecrets } = require('../utils/redact')
 const { patchLogs } = require('../utils/patch-logs')

--- a/packages/build/src/build/main.js
+++ b/packages/build/src/build/main.js
@@ -1,6 +1,8 @@
 require('./colors')
+
 const resolveConfig = require('@netlify/config')
 const { getConfigPath } = require('@netlify/config')
+
 require('array-flat-polyfill')
 
 const { getPluginsHooks } = require('../plugins/main')

--- a/packages/build/src/utils/deeplog.js
+++ b/packages/build/src/utils/deeplog.js
@@ -1,5 +1,9 @@
-const util = require('util')
+const { inspect } = require('util')
 
-module.exports = function deepLog(obj) {
-  console.log(util.inspect(obj, { showHidden: false, depth: null, colors: true }))
+const { hasColors } = require('../build/colors')
+
+const deepLog = function(obj) {
+  console.log(inspect(obj, { depth: null, colors: hasColors() }))
 }
+
+module.exports = { deepLog }

--- a/packages/build/src/utils/patch-logs.js
+++ b/packages/build/src/utils/patch-logs.js
@@ -4,6 +4,7 @@ const util = require('util')
 const chalk = require('chalk')
 
 const { redactValues } = require('./redact')
+const { deepLog } = require('./deeplog')
 
 let previous = ''
 function monkeyPatchLogs(secrets) {
@@ -16,11 +17,7 @@ function monkeyPatchLogs(secrets) {
       const redactedArgs = args.map(a => {
         const redactedLog = redactValues(a, secrets)
         if (typeof a === 'object') {
-          return util.inspect(redactedLog, {
-            showHidden: false,
-            depth: null,
-            colors: true
-          })
+          return deepLog(redactedLog)
         }
         if (!prefixSet) {
           prefixSet = true


### PR DESCRIPTION
We use `FORCE_COLORS` + automatic detection to determine whether to use colors in most of the code. However `util.inspect()` used in two places does not use this logic. This PR fixes it.