### PR TITLE
Improve the security of the API client

### DIFF
--- a/example/netlify.yml
+++ b/example/netlify.yml
@@ -16,7 +16,7 @@ plugins:
           method: GET
   example:
     type: '@netlify/plugin-example'
-    enabled: true
+    enabled: false
   cypress:
     type: '@netlify/plugin-cypress'
     config:

--- a/packages/build/src/core/api.js
+++ b/packages/build/src/core/api.js
@@ -3,27 +3,35 @@ const NetlifyAPI = require('netlify')
 // Retrieve Netlify API client, providing a authentication token was provided
 const getApiClient = function({ token, name, scopes }) {
   if (!token) {
+    if (scopes.length !== 0) {
+      throw new Error(`The "${name}" plugin requires a Netlify API authentication token`)
+    }
+
     return
   }
 
   const api = new NetlifyAPI(token)
 
-  // Redact API methods to scopes
-  if (Array.isArray(scopes) && !scopes.includes('*')) {
-    Object.keys(NetlifyAPI.prototype)
-      .filter(method => !scopes.includes(method))
-      .forEach(method => {
-        api[method] = disabledApiMethod.bind(null, name, method)
-      })
-  }
+  disableApiMethods(api, name, scopes)
 
   return api
 }
 
-const disabledApiMethod = async function(pluginName, method) {
-  throw new Error(
-    `The "${pluginName}" plugin is not authorized to use "api.${method}". Please update the plugin scopes.`
-  )
+// Redact API methods to scopes
+const disableApiMethods = function(api, name, scopes) {
+  if (scopes.includes('*')) {
+    return
+  }
+
+  Object.keys(NetlifyAPI.prototype)
+    .filter(method => !scopes.includes(method))
+    .forEach(method => {
+      api[method] = disabledApiMethod.bind(null, name, method)
+    })
+}
+
+const disabledApiMethod = async function(name, method) {
+  throw new Error(`The "${name}" plugin is not authorized to use "api.${method}". Please update the plugin scopes.`)
 }
 
 module.exports = { getApiClient }

--- a/packages/build/src/core/instructions.js
+++ b/packages/build/src/core/instructions.js
@@ -47,7 +47,7 @@ const getHookInstructions = function({
         execCommand(command, `build.lifecycle.${hook}`, baseDir, redactedKeys)
       )
     },
-    meta: {},
+    meta: { scopes: [] },
     override: {},
     pluginConfig: {}
   }
@@ -82,7 +82,14 @@ const runInstructions = async function(instructions, { config, configPath, token
 // Run a single instruction
 const runInstruction = async function({
   currentData,
-  instruction: { method, hook, pluginConfig, name, override, meta: { scopes } = {} },
+  instruction: {
+    method,
+    hook,
+    pluginConfig,
+    name,
+    override,
+    meta: { scopes }
+  },
   index,
   config,
   configPath,

--- a/packages/build/src/plugins/main.js
+++ b/packages/build/src/plugins/main.js
@@ -58,10 +58,21 @@ const isPluginHook = function(key, value) {
   return typeof value === 'function'
 }
 
-const getPluginHook = function({ hook, type, method, meta, pluginId, pluginConfig }) {
+const getPluginHook = function({
+  hook,
+  type,
+  method,
+  meta,
+  meta: { scopes = DEFAULT_SCOPES },
+  pluginId,
+  pluginConfig
+}) {
+  const metaA = Object.assign({}, meta, { scopes })
   const override = getOverride(hook)
   const hookA = override.hook || hook
-  return { name: pluginId, hook: hookA, type, method, meta, override, pluginConfig }
+  return { name: pluginId, hook: hookA, type, method, meta: metaA, override, pluginConfig }
 }
+
+const DEFAULT_SCOPES = []
 
 module.exports = { defaultPlugins: DEFAULT_PLUGINS, getPluginsHooks }


### PR DESCRIPTION
Fixes #200.

This:
  - defaults `plugin.scopes` to `[]` instead of `['*']`
  - throws an error when `plugin.scopes` is not empty but no API token was specified