### PR TITLE
Fix colors in the buildbot

### DIFF
--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -24,7 +24,8 @@ const getColorLevel = function() {
   }
 
   // Node <9.9.0 does not have `getColorDepth()`. Default to 16 colors then.
-  if (getColorDepth === undefined) {
+  // This also ensure colors are used in the BuildBot
+  if (getColorDepth === undefined || env.DEPLOY_PRIME_URL) {
     return '1'
   }
 


### PR DESCRIPTION
Fixes #215.

This should fix colors in the buildbot. Could you please test it works in production? Thanks!