### PR TITLE
Fix colors in buildbot

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -1,3 +1,7 @@
+// eslint-disable-next-line import/order
+const { setColorLevel } = require('../log/colors')
+setColorLevel()
+
 const resolveConfig = require('@netlify/config')
 const { getConfigPath } = require('@netlify/config')
 

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -16,6 +16,11 @@ const setColorLevel = function() {
 }
 
 const getColorLevel = function() {
+  // This also ensure colors are used in the BuildBot
+  if (env.DEPLOY_PRIME_URL) {
+    return '1'
+  }
+
   // If the output is not a console (e.g. redirected to `less` or to a file),
   // we disable colors because ANSI sequences are a problem most of the time in
   // that case
@@ -24,8 +29,7 @@ const getColorLevel = function() {
   }
 
   // Node <9.9.0 does not have `getColorDepth()`. Default to 16 colors then.
-  // This also ensure colors are used in the BuildBot
-  if (getColorDepth === undefined || env.DEPLOY_PRIME_URL) {
+  if (getColorDepth === undefined) {
     return '1'
   }
 

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -4,10 +4,8 @@ const { tick, pointer, arrowDown } = require('figures')
 const omit = require('omit.js')
 
 const { startPatchingLog, stopPatchingLog } = require('./patch')
-const { setColorLevel } = require('./colors')
 const { cleanStack } = require('./stack')
 
-setColorLevel()
 // eslint-disable-next-line import/order
 const { greenBright, cyanBright, redBright, yellowBright, bold } = require('chalk')
 


### PR DESCRIPTION
There was a bug in #222. This PR should now fix colors in the buildbot.

It does the following before requiring `chalk`:

```js
if (process.env.DEPLOY_PRIME_URL) {
  process.env.FORCE_COLOR = '1'
}
```