### PR TITLE
Fix conflicting PRs on colors fixing

### DIFF
--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -11,11 +11,8 @@ const setColorLevel = function() {
   if (env.FORCE_COLOR) {
     return
   }
-  const level = getColorLevel()
-  if (level !== '0' && hasColors()) {
-    process.env.colors = true
-  }
-  env.FORCE_COLOR = level
+
+  env.FORCE_COLOR = getColorLevel()
 }
 
 const getColorLevel = function() {


### PR DESCRIPTION
#228 and #229 were both fixing the colors.

#229 should have fixed the buildbot so #228 can be reverted (which this PR does).

The problem with the current code is that:
  - `hasColors()` always evaluates to `true`
  - which means `COLORS` is set to `FORCE_COLOR !== 0`
  - however we should not need to set both of those environment variables. `FORCE_COLOR` should do the job.