### PR TITLE
Fix colors with `util.inspect()` inside plugins

### DIFF
--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -3,21 +3,25 @@ const {
   // eslint-disable-next-line node/no-unsupported-features/node-builtins
   stdout: { isTTY, getColorDepth }
 } = require('process')
+const {
+  inspect: { defaultOptions }
+} = require('util')
 
 const isNetlifyCI = require('../utils/is-netlify-ci')
 
 // Set the amount of colors to use by `chalk` (and underlying `supports-color`)
 // 0 is no colors, 1 is 16 colors, 2 is 256 colors, 3 is 16 million colors.
 const setColorLevel = function() {
-  // Allow user overridding this logic
-  if (env.FORCE_COLOR) {
-    return
-  }
-
   env.FORCE_COLOR = getColorLevel()
+  defaultOptions.colors = hasColors()
 }
 
 const getColorLevel = function() {
+  // Allow user overridding this logic
+  if (env.FORCE_COLOR) {
+    return env.FORCE_COLOR
+  }
+
   // This also ensure colors are used in the BuildBot
   if (isNetlifyCI()) {
     return '1'
@@ -47,4 +51,4 @@ const hasColors = function() {
   return env.FORCE_COLOR !== '0' && env.FORCE_COLOR !== 'false'
 }
 
-module.exports = { setColorLevel, hasColors }
+module.exports = { setColorLevel }

--- a/packages/build/src/log/patch.js
+++ b/packages/build/src/log/patch.js
@@ -3,8 +3,6 @@ const { inspect } = require('util')
 const redactEnv = require('redact-env')
 const replaceStream = require('replacestream')
 
-const { hasColors } = require('./colors')
-
 // Monkey patch console.log() to redact secrets
 const startPatchingLog = function() {
   const redactedKeys = redactEnv.build(SECRETS)
@@ -54,7 +52,7 @@ const monkeyPatchLogs = function(secrets) {
 
 // Serialize non-strings for printing
 const serialize = function(value) {
-  return inspect(value, { depth: Infinity, colors: hasColors() })
+  return inspect(value, { depth: Infinity })
 }
 
 const redactProcess = function(childProcess, redactedKeys) {

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -2,12 +2,15 @@ const { exit } = require('process')
 
 require('../../utils/polyfills')
 const { getMessageFromParent, sendMessageToParent } = require('../ipc')
+const { setColorLevel } = require('../../log/colors')
 
 const { load } = require('./load')
 const { run } = require('./run')
 
 // Main entry point of plugin child processes
 const runChild = async function() {
+  setColorLevel()
+
   const { eventName, message } = getMessageFromParent()
 
   try {


### PR DESCRIPTION
This fixes colors not being enabled when using `util.inspect()` or `console.log(object)` inside plugins