### PR TITLE
Simplify plugins

### DIFF
--- a/packages/build/src/plugins/deploy/index.js
+++ b/packages/build/src/plugins/deploy/index.js
@@ -5,54 +5,52 @@ const readdirp = require('readdirp')
 
 const { CONTEXT } = process.env
 
-module.exports = () => {
-  return {
-    onError: ({ error }) => {
-      console.log('do something with error', error.message)
-      if (error.message.match(/invalid json response body/)) {
-        console.log('Attempt to correct build')
-      }
-    },
-    /* Hook into buildFunctions lifecycle */
-    deploy: async ({ config, constants, api }) => {
-      const { build } = config
-      if (!build || !build.publish) {
-        console.log('No publish directory set. Skipping deploy step')
-        return false
-      }
+module.exports = {
+  onError({ error }) {
+    console.log('do something with error', error.message)
+    if (error.message.match(/invalid json response body/)) {
+      console.log('Attempt to correct build')
+    }
+  },
+  /* Hook into buildFunctions lifecycle */
+  async deploy({ config, constants, api }) {
+    const { build } = config
+    if (!build || !build.publish) {
+      console.log('No publish directory set. Skipping deploy step')
+      return false
+    }
 
-      const publishPath = path.resolve(build.publish)
-      if (!(await pathExists(publishPath))) {
-        console.log(`Publish dir not found`)
-        process.exit(1)
-      }
+    const publishPath = path.resolve(build.publish)
+    if (!(await pathExists(publishPath))) {
+      console.log(`Publish dir not found`)
+      process.exit(1)
+    }
 
-      const files = await readdirp.promise(publishPath)
-      if (!files || !files.length) {
-        console.log(`No files found in publish dir`)
-        process.exit(1)
-      }
+    const files = await readdirp.promise(publishPath)
+    if (!files || !files.length) {
+      console.log(`No files found in publish dir`)
+      process.exit(1)
+    }
 
-      const deployToProduction = CONTEXT === 'production'
+    const deployToProduction = CONTEXT === 'production'
 
-      if (!constants.siteId) {
-        console.log(`No siteId found`)
-        // return false
-      }
+    if (!constants.siteId) {
+      console.log(`No siteId found`)
+      // return false
+    }
 
-      try {
-        console.log('Deploying site...')
-        await api.deploy(constants.siteId, publishPath, {
-          configPath: constants.CONFIG_PATH,
-          fnDir: build.functions,
-          statusCb: () => {},
-          draft: !deployToProduction,
-          message: 'Site deployed from @netlify/build'
-        })
-      } catch (err) {
-        console.log('Deploying site error')
-        throw new Error(err)
-      }
+    try {
+      console.log('Deploying site...')
+      await api.deploy(constants.siteId, publishPath, {
+        configPath: constants.CONFIG_PATH,
+        fnDir: build.functions,
+        statusCb: () => {},
+        draft: !deployToProduction,
+        message: 'Site deployed from @netlify/build'
+      })
+    } catch (err) {
+      console.log('Deploying site error')
+      throw new Error(err)
     }
   }
 }

--- a/packages/build/src/plugins/functions/index.js
+++ b/packages/build/src/plugins/functions/index.js
@@ -10,11 +10,11 @@ const { DEPLOY_PRIME_URL, DEPLOY_ID } = process.env
 
 module.exports = {
   /* Hook into buildFunctions lifecycle */
-  buildFunctions: async ({
+  async buildFunctions({
     config: {
       build: { functions }
     }
-  }) => {
+  }) {
     if (!functions) {
       console.log('No functions directory set. Skipping functions build step')
       return false

--- a/packages/netlify-plugin-cypress/index.js
+++ b/packages/netlify-plugin-cypress/index.js
@@ -1,13 +1,8 @@
-function netlifyCypressPlugin(conf) {
-  return {
-    // Hook into lifecycle
-    postBuild: () => {
-      console.log('running cypress integration tests')
-    },
-    manifest: () => {
-      console.log('manifest thing netlifyCypressPlugin')
-    }
+module.exports = {
+  postBuild() {
+    console.log('running cypress integration tests')
+  },
+  manifest() {
+    console.log('manifest thing netlifyCypressPlugin')
   }
 }
-
-module.exports = netlifyCypressPlugin

--- a/packages/netlify-plugin-encrypted-files/index.js
+++ b/packages/netlify-plugin-encrypted-files/index.js
@@ -1,14 +1,9 @@
 const pluginDecrypt = require('./pluginDecrypt')
 
-function encryptedFilesPlugin(conf) {
-  return {
-    // scopes: ['listSites'],
-    // Hook into lifecycle
-    init: () => {
-      console.log('decrypting files')
-      pluginDecrypt()
-    }
+module.exports = {
+  // scopes: ['listSites'],
+  init() {
+    console.log('decrypting files')
+    pluginDecrypt()
   }
 }
-
-module.exports = encryptedFilesPlugin

--- a/packages/netlify-plugin-example/index.js
+++ b/packages/netlify-plugin-example/index.js
@@ -1,22 +1,17 @@
-function netlifySitemapPlugin(conf) {
-  return {
-    scopes: ['listSites'],
-    // Hook into lifecycle
-    init: ({ api }) => {
-      console.log('init')
-    },
-    finally: async ({ api }) => {
-      if (api === undefined) {
-        return
-      }
+module.exports = {
+  scopes: ['listSites'],
+  init({ api }) {
+    console.log('init')
+  },
+  async finally({ api }) {
+    if (api === undefined) {
+      return
+    }
 
-      console.log('Finally... get site count')
-      const sites = await api.listSites()
-      if (sites) {
-        console.log(`Site count! ${sites.length}`)
-      }
+    console.log('Finally... get site count')
+    const sites = await api.listSites()
+    if (sites) {
+      console.log(`Site count! ${sites.length}`)
     }
   }
 }
-
-module.exports = netlifySitemapPlugin

--- a/packages/netlify-plugin-lighthouse/index.js
+++ b/packages/netlify-plugin-lighthouse/index.js
@@ -7,73 +7,62 @@ const Conf = require('conf') // for simple kv store
 // // TODO: enable this in production
 // const NETLIFY_BUILD_BASE = '/opt/buildhome'
 
-function netlifyLighthousePlugin(conf) {
-  let store
+module.exports = {
   // users will be tempted to use semver, but we really don't care
-  let { currentVersion, compareWithVersion } = conf
-  if (typeof currentVersion === `undefined`) {
-    console.log(`lighthouseplugin version not specified, auto assigning ${chalk.yellow("currentVersion='init'")}`)
-    currentVersion = 'init'
-  }
-  if (typeof compareWithVersion === `undefined`) compareWithVersion = 'init' // will just come up undefined if doesn't exist
-  return {
+  async postDeploy({ pluginConfig: { site = process.env.SITE, currentVersion, compareWithVersion = 'init' } }) {
+    if (typeof currentVersion === `undefined`) {
+      console.log(`lighthouseplugin version not specified, auto assigning ${chalk.yellow("currentVersion='init'")}`)
+      currentVersion = 'init'
+    }
+
     // kvstore in `${NETLIFY_CACHE_DIR}/${name}.json`
     // we choose to let the user createStore instead of doing it for them
     // bc they may want to set `defaults` and `schema` and `de/serialize`
-    init() {
-      store = new Conf({
-        cwd: resolve('cache'),
-        configName: 'netlify-plugin-lighthouse'
+    const store = new Conf({
+      cwd: resolve('cache'),
+      configName: 'netlify-plugin-lighthouse'
+    })
+
+    // TODO: fetch previous scores from cache
+    await execa.command(`lighthouse-ci ${site}`, { stdio: 'inherit', preferLocal: true })
+
+    // serialize response
+    const curLightHouse = {}
+    const prevLightHouse = store.get(`lighthouse.${compareWithVersion}`)
+    let totalImprovement = 0
+    if (prevLightHouse) {
+      console.log(
+        `Comparing lighthouse results from version: ${chalk.yellow(compareWithVersion)} to version: ${chalk.yellow(
+          currentVersion
+        )}:`
+      )
+      Object.entries(curLightHouse).forEach(([k, v]) => {
+        const prevV = prevLightHouse[k]
+        if (!prevV) return // we should never get here but just in case lighthouse format changes...
+        const improvement = v - prevV
+        if (improvement < 0) {
+          console.log(`- ${chalk.yellow(k)} ${chalk.magenta('regressed')} from ${prevV} to ${v}`)
+        } else if (improvement > 0) {
+          console.log(`- ${chalk.yellow(k)} ${chalk.green('improved')} from ${prevV} to ${v}`)
+        }
+        // TODO: print out links to give suggestions on what to do! lets see what lighthouse-ci gives us
+        totalImprovement += improvement
       })
-    },
-
-    /* Run lighthouse on postDeploy */
-    postDeploy: async () => {
-      const site = conf.site || process.env.SITE
-
-      // TODO: fetch previous scores from cache
-      await execa.command(`lighthouse-ci ${site}`, { stdio: 'inherit', preferLocal: true })
-
-      // serialize response
-      const curLightHouse = {}
-      const prevLightHouse = store.get(`lighthouse.${compareWithVersion}`)
-      let totalImprovement = 0
-      if (prevLightHouse) {
-        console.log(
-          `Comparing lighthouse results from version: ${chalk.yellow(compareWithVersion)} to version: ${chalk.yellow(
-            currentVersion
-          )}:`
-        )
-        Object.entries(curLightHouse).forEach(([k, v]) => {
-          const prevV = prevLightHouse[k]
-          if (!prevV) return // we should never get here but just in case lighthouse format changes...
-          const improvement = v - prevV
-          if (improvement < 0) {
-            console.log(`- ${chalk.yellow(k)} ${chalk.magenta('regressed')} from ${prevV} to ${v}`)
-          } else if (improvement > 0) {
-            console.log(`- ${chalk.yellow(k)} ${chalk.green('improved')} from ${prevV} to ${v}`)
-          }
-          // TODO: print out links to give suggestions on what to do! lets see what lighthouse-ci gives us
-          totalImprovement += improvement
-        })
-        if (Math.abs(totalImprovement) > 2) {
-          // some significance bar
-          const color = totalImprovement > 0 ? chalk.green : chalk.magenta
-          console.log(`${chalk.yellow.bold('Total Improvement')}: ${color(totalImprovement)} points!`)
-        }
-      } else {
-        if (compareWithVersion) {
-          console.warn(
-            `Warning: you set ${chalk.yellow('compareWithVersion') +
-              '=' +
-              chalk.yellow(compareWithVersion)} but that version was not found in our result storage.`
-          )
-        }
+      if (Math.abs(totalImprovement) > 2) {
+        // some significance bar
+        const color = totalImprovement > 0 ? chalk.green : chalk.magenta
+        console.log(`${chalk.yellow.bold('Total Improvement')}: ${color(totalImprovement)} points!`)
       }
-      store.set(`lighthouse.${currentVersion}`, curLightHouse)
-      console.log(`Saved results as version: ${chalk.yellow(currentVersion)}`)
+    } else {
+      if (compareWithVersion) {
+        console.warn(
+          `Warning: you set ${chalk.yellow('compareWithVersion') +
+            '=' +
+            chalk.yellow(compareWithVersion)} but that version was not found in our result storage.`
+        )
+      }
     }
+    store.set(`lighthouse.${currentVersion}`, curLightHouse)
+    console.log(`Saved results as version: ${chalk.yellow(currentVersion)}`)
   }
 }
-
-module.exports = netlifyLighthousePlugin

--- a/packages/netlify-plugin-sitemap/index.js
+++ b/packages/netlify-plugin-sitemap/index.js
@@ -45,24 +45,15 @@ async function makeSitemap(opts = {}) {
   console.log('Sitemap Built!', sitemapFile)
 }
 
-function netlifySitemapPlugin(conf = {}) {
-  return {
-    // Hook into lifecycle
-    postBuild: async () => {
-      const siteUrl = conf.baseUrl || process.env.SITE
-      if (!siteUrl) {
-        throw new Error('Sitemap plugin missing homepage value')
-      }
-      if (!conf.distPath) {
-        throw new Error('Sitemap plugin missing build directory')
-      }
-      console.log('Creating sitemap from files...')
-      await makeSitemap({
-        homepage: siteUrl,
-        distPath: conf.distPath
-      })
+module.exports = {
+  async postBuild({ baseUrl = process.env.SITE, distPath }) {
+    if (!baseUrl) {
+      throw new Error('Sitemap plugin missing homepage value')
     }
+    if (!distPath) {
+      throw new Error('Sitemap plugin missing build directory')
+    }
+    console.log('Creating sitemap from files...')
+    await makeSitemap({ homepage: baseUrl, distPath })
   }
 }
-
-module.exports = netlifySitemapPlugin

--- a/packages/netlify-plugin-svgoptimizer/index.js
+++ b/packages/netlify-plugin-svgoptimizer/index.js
@@ -109,37 +109,33 @@ const svgoinit = new svgo({
   ]
 })
 
-function netlifyPlugin(config) {
-  return {
-    init: ({
-      pluginConfig: {
-        src: { directory: srcDirectory }
-      }
-    }) => {
-      if (!srcDirectory) return console.log(`No src found in ${pkg.name} plugin config`)
-      const directoryPath = resolve(srcDirectory)
+module.exports = {
+  init({
+    pluginConfig: {
+      src: { directory: srcDirectory }
+    }
+  }) {
+    if (!srcDirectory) return console.log(`No src found in ${pkg.name} plugin config`)
+    const directoryPath = resolve(srcDirectory)
 
-      //scanning the directory and then reading each file
-      fs.readdir(directoryPath, (err, files) => {
-        if (err) console.log(`Unable to scan directory: ${err}`)
+    //scanning the directory and then reading each file
+    fs.readdir(directoryPath, (err, files) => {
+      if (err) console.log(`Unable to scan directory: ${err}`)
 
-        files.forEach(function(file) {
-          const filePath = resolve(directoryPath, file)
-          fs.readFile(filePath, 'utf8', function(err, data) {
-            if (err) console.log(err)
+      files.forEach(function(file) {
+        const filePath = resolve(directoryPath, file)
+        fs.readFile(filePath, 'utf8', function(err, data) {
+          if (err) console.log(err)
 
-            svgoinit.optimize(data, { path: filePath }).then(result => {
-              //take the file and rewrite it with the new optimized SVG
-              fs.writeFile(filePath, result.data, err => {
-                if (err) throw err
-                console.log('SVG optimized correctly!')
-              })
+          svgoinit.optimize(data, { path: filePath }).then(result => {
+            //take the file and rewrite it with the new optimized SVG
+            fs.writeFile(filePath, result.data, err => {
+              if (err) throw err
+              console.log('SVG optimized correctly!')
             })
           })
         })
       })
-    }
+    })
   }
 }
-
-module.exports = netlifyPlugin

--- a/packages/netlify-plugin-twiliosms/index.js
+++ b/packages/netlify-plugin-twiliosms/index.js
@@ -13,22 +13,16 @@ const {
 
 const Twilio = require('twilio')
 
-function netlifyTwilioSms() {
-  const client = new Twilio(ACCOUNT_SID, AUTH_TOKEN)
+module.exports = {
+  async finally() {
+    console.log('Finish the build up, prepping to text!')
 
-  return {
-    // Hook into lifecycle
-    async finally() {
-      console.log('Finish the build up, prepping to text!')
-
-      const { sid } = await client.messages.create({
-        body: 'Hi there, we just deployed the site successfully!',
-        to: TO_NUM,
-        from: FROM_NUM
-      })
-      console.log(sid)
-    }
+    const client = new Twilio(ACCOUNT_SID, AUTH_TOKEN)
+    const { sid } = await client.messages.create({
+      body: 'Hi there, we just deployed the site successfully!',
+      to: TO_NUM,
+      from: FROM_NUM
+    })
+    console.log(sid)
   }
 }
-
-module.exports = netlifyTwilioSms


### PR DESCRIPTION
All current 12 plugins (except `netlify-plugin-notifier`) do not need a top-level function they always return the same hook methods.

This PR simplify those by removing the extra top-level function that is not necessary. The logic/behavior remains the same.
  
I think we should try to refrain from using top-level functions in plugins unless needed because they make plugins look more complex than they are. I also think we should document plugin using mostly the simple syntax (no top-level function) except for a dedicated section about the advanced syntax.

Also top-level functions in plugins are creating some issues with other features (such as plugin outputs #186), so the fewer plugins that are using this, the better.