### PR TITLE
Fix syntax error in 404 plugin

### DIFF
--- a/packages/netlify-plugin-no-more-404/index.js
+++ b/packages/netlify-plugin-no-more-404/index.js
@@ -148,13 +148,13 @@ const readdir = promisify(fs.readdir)
 var walk = async function(dir, filelist) {
   var files = await readdir(dir)
   filelist = filelist || []
-  files.forEach(function(file) {
+  await Promise.all(files.map(async function(file) {
     const dirfile = path.join(dir, file)
     if (fs.statSync(dirfile).isDirectory()) {
       filelist = await walk(dirfile + '/', filelist)
     } else {
       filelist.push(dirfile)
     }
-  })
+  }))
   return filelist
 }


### PR DESCRIPTION
Fix a syntax error in 404 plugin.

A function was using `await` without using the `async` keyword.

I think we might want to consider replacing that `walk` function with [`readdirp`](https://github.com/paulmillr/readdirp) which does this?