### PR TITLE
Fix `BASE_DIR` in 404 plugins

### DIFF
--- a/packages/netlify-plugin-no-more-404/index.js
+++ b/packages/netlify-plugin-no-more-404/index.js
@@ -27,13 +27,13 @@ function netlify404nomore(conf) {
     /* index html files preDeploy */
     preDeploy: async opts => {
       // console.log({ opts })
-      const { BASE_DIR, BUILD_DIR } = opts.constants // where we start from
+      const { BUILD_DIR } = opts.constants // where we start from
 
       // let BUILD_DIR = opts.config.build.publish // build folder from netlify config.. there ought to be a nicer way to get this if set elsewhere
       if (typeof BUILD_DIR === 'undefined') {
         throw new Error('must specify publish dir in netlify config [build] section')
       }
-      const buildFolderPath = path.join(BASE_DIR, BUILD_DIR)
+      const buildFolderPath = path.resolve(BUILD_DIR)
       const prevManifest = store.get(cacheKey) || []
       if (test404plugin) {
         // add missing paths for testing


### PR DESCRIPTION
Currently there is the following error message:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:112:11)
    at Object.join (path.js:1040:7)
    at Object.preDeploy (/home/ether/netlify/build/packages/netlify-plugin-no-more-404/index.js:37:36)
    at Object.run (/home/ether/netlify/build/packages/build/src/plugins/child/run.js:8:24)
    at runChild (/home/ether/netlify/build/packages/build/src/plugins/child/main.js:17:45)
    at Object.<anonymous> (/home/ether/netlify/build/packages/build/src/plugins/child/main.js:29:1)
    at Module._compile (internal/modules/cjs/loader.js:945:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:962:10)
    at Module.load (internal/modules/cjs/loader.js:798:32)
    at Function.Module._load (internal/modules/cjs/loader.js:711:12)
```

This is because `BASE_DIR` was removed by #239: now plugins current directory is always `BASE_DIR`. I.e. `process.cwd()` can be used instead of `BASE_DIR`.