### PR TITLE
Fix example `package-lock.json`

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "version": "file:../packages/build",
       "dev": true,
       "requires": {
-        "@netlify/config": "^0.0.1",
+        "@netlify/config": "^0.0.2",
         "@netlify/zip-it-and-ship-it": "^0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^2.4.2",
@@ -17,7 +17,7 @@
         "del": "^4.1.1",
         "execa": "^2.0.3",
         "figures": "^3.0.0",
-        "filter-obj": "^2.0.0",
+        "get-stream": "^5.1.0",
         "group-by": "0.0.1",
         "is-invalid-path": "^1.0.2",
         "is-plain-obj": "^2.0.0",
@@ -40,11 +40,11 @@
       "dependencies": {
         "@ava/babel-plugin-throws-helper": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "@ava/babel-preset-stage-4": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
             "@babel/plugin-proposal-dynamic-import": "^7.5.0",
@@ -55,7 +55,7 @@
         },
         "@ava/babel-preset-transform-test-files": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@ava/babel-plugin-throws-helper": "^4.0.0",
             "babel-plugin-espower": "^3.0.1"
@@ -63,14 +63,14 @@
         },
         "@babel/code-frame": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
         },
         "@babel/core": {
           "version": "7.6.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.6.2",
@@ -157,7 +157,7 @@
         },
         "@babel/generator": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.5.5",
             "jsesc": "^2.5.1",
@@ -168,14 +168,14 @@
         },
         "@babel/helper-annotate-as-pure": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.0.0"
           }
         },
         "@babel/helper-function-name": {
           "version": "7.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-get-function-arity": "^7.0.0",
             "@babel/template": "^7.1.0",
@@ -184,21 +184,21 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.0.0"
           }
         },
         "@babel/helper-module-imports": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.0.0"
           }
         },
         "@babel/helper-module-transforms": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-module-imports": "^7.0.0",
             "@babel/helper-simple-access": "^7.1.0",
@@ -210,18 +210,18 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.0.0",
-          "bundled": true
+          "resolved": false
         },
         "@babel/helper-regex": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lodash": "^4.17.13"
           }
         },
         "@babel/helper-remap-async-to-generator": {
           "version": "7.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.0.0",
             "@babel/helper-wrap-function": "^7.1.0",
@@ -232,7 +232,7 @@
         },
         "@babel/helper-simple-access": {
           "version": "7.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/template": "^7.1.0",
             "@babel/types": "^7.0.0"
@@ -240,14 +240,14 @@
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.4.4"
           }
         },
         "@babel/helper-wrap-function": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-function-name": "^7.1.0",
             "@babel/template": "^7.1.0",
@@ -257,7 +257,7 @@
         },
         "@babel/helpers": {
           "version": "7.6.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/template": "^7.6.0",
             "@babel/traverse": "^7.6.2",
@@ -333,7 +333,7 @@
         },
         "@babel/highlight": {
           "version": "7.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "chalk": "^2.0.0",
             "esutils": "^2.0.2",
@@ -342,11 +342,11 @@
         },
         "@babel/parser": {
           "version": "7.5.5",
-          "bundled": true
+          "resolved": false
         },
         "@babel/plugin-proposal-async-generator-functions": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "@babel/helper-remap-async-to-generator": "^7.1.0",
@@ -355,7 +355,7 @@
         },
         "@babel/plugin-proposal-dynamic-import": {
           "version": "7.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "@babel/plugin-syntax-dynamic-import": "^7.2.0"
@@ -363,7 +363,7 @@
         },
         "@babel/plugin-proposal-optional-catch-binding": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
@@ -371,28 +371,28 @@
         },
         "@babel/plugin-syntax-async-generators": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0"
           }
         },
         "@babel/plugin-syntax-dynamic-import": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0"
           }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0"
           }
         },
         "@babel/plugin-transform-dotall-regex": {
           "version": "7.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "@babel/helper-regex": "^7.4.4",
@@ -401,7 +401,7 @@
         },
         "@babel/plugin-transform-modules-commonjs": {
           "version": "7.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-module-transforms": "^7.4.4",
             "@babel/helper-plugin-utils": "^7.0.0",
@@ -411,7 +411,7 @@
         },
         "@babel/template": {
           "version": "7.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/parser": "^7.4.4",
@@ -420,7 +420,7 @@
         },
         "@babel/traverse": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.5.5",
             "@babel/generator": "^7.5.5",
@@ -450,7 +450,7 @@
         },
         "@babel/types": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -459,18 +459,18 @@
         },
         "@concordance/react": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "arrify": "^1.0.1"
           }
         },
         "@iarna/toml": {
           "version": "2.2.3",
-          "bundled": true
+          "resolved": false
         },
         "@mrmlnc/readdir-enhanced": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "call-me-maybe": "^1.0.1",
@@ -479,7 +479,7 @@
         },
         "@netlify/config": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ava": "^2.4.0",
@@ -4264,12 +4264,12 @@
         },
         "@netlify/open-api": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@netlify/zip-it-and-ship-it": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "archiver": "^3.0.0",
@@ -4315,7 +4315,7 @@
         },
         "@nodelib/fs.scandir": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@nodelib/fs.stat": "2.0.1",
             "run-parallel": "^1.1.9"
@@ -4330,12 +4330,12 @@
         },
         "@nodelib/fs.stat": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@nodelib/fs.walk": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@nodelib/fs.scandir": "2.1.1",
             "fastq": "^1.6.0"
@@ -4343,22 +4343,22 @@
         },
         "@sindresorhus/is": {
           "version": "0.14.0",
-          "bundled": true
+          "resolved": false
         },
         "@szmarczak/http-timer": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "defer-to-connect": "^1.0.1"
           }
         },
         "@types/events": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "@types/glob": {
           "version": "7.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/events": "*",
             "@types/minimatch": "*",
@@ -4367,15 +4367,15 @@
         },
         "@types/minimatch": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": false
         },
         "@types/node": {
           "version": "12.6.9",
-          "bundled": true
+          "resolved": false
         },
         "@typescript-eslint/typescript-estree": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash.unescape": "4.0.1",
@@ -4392,7 +4392,7 @@
         },
         "ansi-align": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "string-width": "^3.0.0"
           },
@@ -4416,36 +4416,36 @@
         },
         "ansi-escapes": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "type-fest": "^0.5.2"
           }
         },
         "ansi-red": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-wrap": "0.1.0"
           }
         },
         "ansi-regex": {
           "version": "4.1.0",
-          "bundled": true
+          "resolved": false
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "ansi-wrap": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "anymatch": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
@@ -4453,7 +4453,7 @@
         },
         "archiver": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "archiver-utils": "^2.1.0",
@@ -4480,7 +4480,7 @@
         },
         "archiver-utils": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.4",
@@ -4497,75 +4497,75 @@
         },
         "argparse": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "sprintf-js": "~1.0.2"
           }
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "array-find-index": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "array-flat-polyfill": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "array-union": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "array-uniq": "^1.0.1"
           }
         },
         "array-uniq": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true
+          "resolved": false
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ast-module-types": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "astral-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "async": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -4573,19 +4573,19 @@
         },
         "atob": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "autolinker": {
           "version": "0.28.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "gulp-header": "^1.7.1"
           }
         },
         "ava": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@ava/babel-preset-stage-4": "^4.0.0",
             "@ava/babel-preset-transform-test-files": "^6.0.0",
@@ -4912,14 +4912,14 @@
         },
         "babel-plugin-dynamic-import-node": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "object.assign": "^4.1.0"
           }
         },
         "babel-plugin-espower": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/generator": "^7.0.0",
             "@babel/parser": "^7.0.0",
@@ -4932,7 +4932,7 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "core-js": "^2.4.0",
@@ -4941,7 +4941,7 @@
         },
         "backoff": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "precond": "0.2"
@@ -4949,11 +4949,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "base": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
@@ -5007,16 +5007,16 @@
         },
         "base64-js": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "binary-extensions": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "bl": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.1"
@@ -5037,15 +5037,15 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true
+          "resolved": false
         },
         "blueimp-md5": {
           "version": "2.11.0",
-          "bundled": true
+          "resolved": false
         },
         "boxen": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-align": "^3.0.0",
             "camelcase": "^5.3.1",
@@ -5086,7 +5086,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5094,7 +5094,7 @@
         },
         "braces": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -5122,7 +5122,7 @@
         },
         "buffer": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -5131,16 +5131,16 @@
         },
         "buffer-crc32": {
           "version": "0.2.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "cache-base": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
@@ -5156,7 +5156,7 @@
         },
         "cacheable-request": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "clone-response": "^1.0.2",
             "get-stream": "^5.1.0",
@@ -5181,7 +5181,7 @@
         },
         "call-matcher": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "core-js": "^2.0.0",
             "deep-equal": "^1.0.0",
@@ -5191,20 +5191,20 @@
         },
         "call-me-maybe": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "call-signature": {
           "version": "0.0.2",
-          "bundled": true
+          "resolved": false
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true
+          "resolved": false
         },
         "camelcase-keys": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "camelcase": "^4.1.0",
             "map-obj": "^2.0.0",
@@ -5220,11 +5220,11 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "bundled": true
+          "resolved": false
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -5233,7 +5233,7 @@
         },
         "chokidar": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "anymatch": "^3.0.1",
             "braces": "^3.0.2",
@@ -5285,19 +5285,19 @@
         },
         "chunkd": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "ci-parallel-vars": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "class-utils": {
           "version": "0.3.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -5319,7 +5319,7 @@
         },
         "clean-deep": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash.isempty": "^4.4.0",
@@ -5329,30 +5329,30 @@
         },
         "clean-stack": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "clean-yaml-object": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "cli-boxes": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "restore-cursor": "^3.1.0"
           }
         },
         "cli-spinners": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "cli-truncate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "slice-ansi": "^2.1.0",
             "string-width": "^4.1.0"
@@ -5360,34 +5360,34 @@
         },
         "cliclopts": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "clone-response": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mimic-response": "^1.0.0"
           }
         },
         "code-excerpt": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "convert-to-spaces": "^1.0.1"
           }
         },
         "coffee-script": {
           "version": "1.12.7",
-          "bundled": true
+          "resolved": false
         },
         "collection-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
@@ -5396,36 +5396,36 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true
+          "resolved": false
         },
         "commander": {
           "version": "2.20.0",
-          "bundled": true
+          "resolved": false
         },
         "common-path-prefix": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "component-emitter": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "component-props": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "compress-commons": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "buffer-crc32": "^0.2.13",
@@ -5436,11 +5436,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "concat-stream": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -5450,7 +5450,7 @@
         },
         "concat-with-sourcemaps": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "source-map": "^0.6.1"
           },
@@ -5464,7 +5464,7 @@
         },
         "concordance": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "date-time": "^2.1.0",
             "esutils": "^2.0.2",
@@ -5491,7 +5491,7 @@
         },
         "configorama": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@iarna/toml": "^2.2.3",
             "dot-prop": "^5.0.0",
@@ -5508,7 +5508,7 @@
         },
         "configstore": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "dot-prop": "^4.1.0",
             "graceful-fs": "^4.1.2",
@@ -5558,7 +5558,7 @@
         },
         "convert-source-map": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safe-buffer": "~5.1.1"
           },
@@ -5572,24 +5572,24 @@
         },
         "convert-to-spaces": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "core-js": {
           "version": "2.6.9",
-          "bundled": true
+          "resolved": false
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "cp-file": {
           "version": "6.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -5613,7 +5613,7 @@
         },
         "cpy": {
           "version": "7.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -5624,7 +5624,7 @@
         },
         "crc": {
           "version": "3.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "buffer": "^5.1.0"
@@ -5632,7 +5632,7 @@
         },
         "crc32-stream": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "crc": "^3.4.4",
@@ -5654,7 +5654,7 @@
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -5666,30 +5666,30 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "currently-unhandled": {
           "version": "0.4.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "array-find-index": "^1.0.1"
           }
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "date-time": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "time-zone": "^1.0.0"
           }
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5697,11 +5697,11 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "decamelize-keys": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "decamelize": "^1.1.0",
             "map-obj": "^1.0.0"
@@ -5716,54 +5716,54 @@
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "decompress-response": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mimic-response": "^1.0.0"
           }
         },
         "deep-equal": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "resolved": false
         },
         "deep-is": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "deepmerge": {
           "version": "1.5.2",
-          "bundled": true
+          "resolved": false
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "clone": "^1.0.2"
           }
         },
         "defer-to-connect": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "define-properties": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "define-property": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -5803,7 +5803,7 @@
         },
         "del": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/glob": "^7.1.1",
             "globby": "^6.1.0",
@@ -5837,7 +5837,7 @@
         },
         "detective-amd": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.3.1",
@@ -5848,7 +5848,7 @@
         },
         "detective-cjs": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.4.0",
@@ -5857,7 +5857,7 @@
         },
         "detective-es6": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "node-source-walk": "^4.0.0"
@@ -5865,7 +5865,7 @@
         },
         "detective-less": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.0.0",
@@ -5892,7 +5892,7 @@
         },
         "detective-postcss": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -5920,7 +5920,7 @@
         },
         "detective-sass": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -5947,7 +5947,7 @@
         },
         "detective-scss": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -5974,12 +5974,12 @@
         },
         "detective-stylus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "detective-typescript": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/typescript-estree": "^1.9.0",
@@ -5989,11 +5989,11 @@
         },
         "diacritics-map": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "dir-glob": {
           "version": "2.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-type": "^3.0.0"
@@ -6001,31 +6001,31 @@
         },
         "dot-prop": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-obj": "^2.0.0"
           }
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false
         },
         "elf-tools": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "emittery": {
           "version": "0.4.1",
-          "bundled": true
+          "resolved": false
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "bundled": true
+          "resolved": false
         },
         "empower-core": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "call-signature": "0.0.2",
             "core-js": "^2.0.0"
@@ -6033,25 +6033,25 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "once": "^1.4.0"
           }
         },
         "equal-length": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "error-ex": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
         "es-abstract": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
@@ -6063,7 +6063,7 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -6072,15 +6072,15 @@
         },
         "es6-error": {
           "version": "4.1.1",
-          "bundled": true
+          "resolved": false
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false
         },
         "escodegen": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "esprima": "^3.1.3",
@@ -6107,11 +6107,11 @@
         },
         "esm": {
           "version": "3.2.25",
-          "bundled": true
+          "resolved": false
         },
         "espower-location-detector": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-url": "^1.2.1",
             "path-is-absolute": "^1.0.0",
@@ -6121,26 +6121,26 @@
         },
         "esprima": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false
         },
         "espurify": {
           "version": "1.8.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "core-js": "^2.0.0"
           }
         },
         "estraverse": {
           "version": "4.2.0",
-          "bundled": true
+          "resolved": false
         },
         "esutils": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": false
         },
         "execa": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -6156,7 +6156,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -6190,7 +6190,7 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fill-range": "^2.1.0"
           },
@@ -6235,7 +6235,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -6255,7 +6255,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -6319,11 +6319,11 @@
         },
         "fast-diff": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "fast-glob": {
           "version": "2.2.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -6336,26 +6336,26 @@
         },
         "fast-levenshtein": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fastq": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "reusify": "^1.0.0"
           }
         },
         "figures": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -6377,24 +6377,23 @@
         },
         "filter-obj": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "locate-path": "^3.0.0"
           }
         },
         "flatten": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "flush-write-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -6416,7 +6415,7 @@
         },
         "folder-walker": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "from2": "^2.1.0"
@@ -6424,11 +6423,11 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
@@ -6436,7 +6435,7 @@
         },
         "from2": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -6445,7 +6444,7 @@
         },
         "from2-array": {
           "version": "0.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "from2": "^2.0.3"
@@ -6453,12 +6452,12 @@
         },
         "fs-constants": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fs-extra": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0",
@@ -6467,15 +6466,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "get-amd-module-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.3.2",
@@ -6484,23 +6483,23 @@
         },
         "get-port": {
           "version": "3.2.0",
-          "bundled": true
+          "resolved": false
         },
         "get-stream": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "git-up": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-ssh": "^1.3.0",
             "parse-url": "^5.0.0"
@@ -6508,14 +6507,14 @@
         },
         "git-url-parse": {
           "version": "11.1.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "git-up": "^4.0.0"
           }
         },
         "glob": {
           "version": "7.1.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6527,7 +6526,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -6547,23 +6546,23 @@
         },
         "glob-to-regexp": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ini": "^1.3.4"
           }
         },
         "globals": {
           "version": "11.12.0",
-          "bundled": true
+          "resolved": false
         },
         "globby": {
           "version": "9.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/glob": "^7.1.1",
@@ -6578,7 +6577,7 @@
         },
         "gonzales-pe": {
           "version": "4.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimist": "1.1.x"
@@ -6594,7 +6593,7 @@
         },
         "got": {
           "version": "9.6.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@sindresorhus/is": "^0.14.0",
             "@szmarczak/http-timer": "^1.1.2",
@@ -6621,11 +6620,11 @@
         },
         "graceful-fs": {
           "version": "4.2.0",
-          "bundled": true
+          "resolved": false
         },
         "gray-matter": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-red": "^0.1.1",
             "coffee-script": "^1.12.4",
@@ -6646,7 +6645,7 @@
         },
         "group-by": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "to-function": "*"
@@ -6654,7 +6653,7 @@
         },
         "gulp-header": {
           "version": "1.8.12",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "concat-with-sourcemaps": "*",
             "lodash.template": "^4.4.0",
@@ -6663,22 +6662,22 @@
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "has-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "get-value": "^2.0.6",
@@ -6688,7 +6687,7 @@
         },
         "has-values": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -6708,11 +6707,11 @@
         },
         "has-yarn": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "hasha": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-stream": "^1.1.0",
             "type-fest": "^0.3.0"
@@ -6732,11 +6731,11 @@
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "bundled": true
+          "resolved": false
         },
         "http-basic": {
           "version": "2.5.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "caseless": "~0.11.0",
             "concat-stream": "^1.4.6",
@@ -6745,29 +6744,29 @@
         },
         "http-cache-semantics": {
           "version": "4.0.3",
-          "bundled": true
+          "resolved": false
         },
         "http-response-object": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "ieee754": {
           "version": "1.1.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ignore": {
           "version": "4.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ignore-by-default": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -6775,11 +6774,11 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "import-local": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pkg-dir": "^4.2.0",
             "resolve-cwd": "^3.0.0"
@@ -6787,20 +6786,20 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false
         },
         "indent-string": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "indexes-of": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -6808,19 +6807,19 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "resolved": false
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "resolved": false
         },
         "irregular-plurals": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -6839,33 +6838,33 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true
+          "resolved": false
         },
         "is-binary-path": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "binary-extensions": "^2.0.0"
           }
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true
+          "resolved": false
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true
+          "resolved": false
         },
         "is-ci": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ci-info": "^2.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -6884,11 +6883,11 @@
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -6906,30 +6905,30 @@
         },
         "is-error": {
           "version": "2.2.2",
-          "bundled": true
+          "resolved": false
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "is-extglob": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-glob": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-extglob": "^2.1.1"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "global-dirs": "^0.1.0",
             "is-path-inside": "^1.0.0"
@@ -6947,20 +6946,20 @@
         },
         "is-invalid-path": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-local-path": {
           "version": "0.1.6",
-          "bundled": true
+          "resolved": false
         },
         "is-npm": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-number": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -6979,116 +6978,116 @@
         },
         "is-obj": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-observable": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-path-cwd": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "is-path-in-cwd": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-path-inside": "^2.1.0"
           }
         },
         "is-path-inside": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "path-is-inside": "^1.0.2"
           }
         },
         "is-plain-obj": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isobject": "^3.0.1"
           }
         },
         "is-promise": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "is-regex": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has": "^1.0.1"
           }
         },
         "is-ssh": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "protocols": "^1.1.0"
           }
         },
         "is-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-url": {
           "version": "1.2.4",
-          "bundled": true
+          "resolved": false
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true
+          "resolved": false
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-yarn-global": {
           "version": "0.3.0",
-          "bundled": true
+          "resolved": false
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true
+          "resolved": false
         },
         "js-string-escape": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "js-tokens": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "js-yaml": {
           "version": "3.13.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -7096,65 +7095,65 @@
         },
         "jsesc": {
           "version": "2.5.2",
-          "bundled": true
+          "resolved": false
         },
         "json-buffer": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "json5": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "minimist": "^1.2.0"
           }
         },
         "jsonfile": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
         },
         "keyv": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "json-buffer": "3.0.0"
           }
         },
         "kind-of": {
           "version": "6.0.2",
-          "bundled": true
+          "resolved": false
         },
         "klaw": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.9"
           }
         },
         "latest-version": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "package-json": "^6.3.0"
           }
         },
         "lazy-cache": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "set-getter": "^0.1.0"
           }
         },
         "lazystream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "readable-stream": "^2.0.5"
@@ -7162,7 +7161,7 @@
         },
         "levn": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -7171,7 +7170,7 @@
         },
         "list-item": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "expand-range": "^1.8.1",
             "extend-shallow": "^2.0.1",
@@ -7207,7 +7206,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^4.0.0",
@@ -7224,7 +7223,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -7239,71 +7238,71 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "bundled": true
+          "resolved": false
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "lodash.camelcase": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true
+          "resolved": false
         },
         "lodash.defaults": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.difference": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.flatten": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
-          "bundled": true
+          "resolved": false
         },
         "lodash.get": {
           "version": "4.4.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isempty": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.islength": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false
         },
         "lodash.isplainobject": {
           "version": "4.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.merge": {
           "version": "4.6.2",
-          "bundled": true
+          "resolved": false
         },
         "lodash.set": {
           "version": "4.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.template": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lodash._reinterpolate": "^3.0.0",
             "lodash.templatesettings": "^4.0.0"
@@ -7311,36 +7310,36 @@
         },
         "lodash.templatesettings": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lodash._reinterpolate": "^3.0.0"
           }
         },
         "lodash.transform": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.unescape": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "log-symbols": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "chalk": "^2.0.1"
           }
         },
         "loud-rejection": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "currently-unhandled": "^0.4.1",
             "signal-exit": "^3.0.2"
@@ -7348,11 +7347,11 @@
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "lru-cache": {
           "version": "4.1.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -7360,7 +7359,7 @@
         },
         "make-dir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "semver": "^6.0.0"
           },
@@ -7374,17 +7373,17 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "map-obj": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
@@ -7392,11 +7391,11 @@
         },
         "markdown-link": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "markdown-magic": {
           "version": "0.1.25",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "commander": "^2.9.0",
             "deepmerge": "^1.3.0",
@@ -7474,7 +7473,7 @@
         },
         "markdown-toc": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "concat-stream": "^1.5.2",
             "diacritics-map": "^0.1.0",
@@ -7492,7 +7491,7 @@
         },
         "matcher": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "escape-string-regexp": "^2.0.0"
           },
@@ -7506,22 +7505,22 @@
         },
         "math-random": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "md5-hex": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "blueimp-md5": "^2.10.0"
           }
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "meow": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
@@ -7547,21 +7546,21 @@
         },
         "merge-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "merge2": {
           "version": "1.2.4",
-          "bundled": true
+          "resolved": false
         },
         "micro-api-client": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -7581,26 +7580,26 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "mimic-response": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "minimist-options": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "arrify": "^1.0.1",
             "is-plain-obj": "^1.1.0"
@@ -7615,7 +7614,7 @@
         },
         "mixin-deep": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -7633,7 +7632,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "minimist": "0.0.8"
           },
@@ -7647,7 +7646,7 @@
         },
         "module-definition": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.4.0",
@@ -7656,12 +7655,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -7679,12 +7678,12 @@
         },
         "nested-error-stacks": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "netlify": {
           "version": "2.4.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@netlify/open-api": "^0.9.0",
@@ -7749,17 +7748,17 @@
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "node-fetch": {
           "version": "2.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "node-source-walk": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@babel/parser": "^7.0.0"
@@ -7767,7 +7766,7 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -7777,20 +7776,20 @@
         },
         "normalize-path": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "normalize-url": {
           "version": "3.3.0",
-          "bundled": true
+          "resolved": false
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-packlist": {
           "version": "1.4.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -7799,7 +7798,7 @@
         },
         "npm-run-path": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -7815,11 +7814,11 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "resolved": false
         },
         "object-copy": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -7849,11 +7848,11 @@
         },
         "object-keys": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "object-visit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isobject": "^3.0.0"
@@ -7861,7 +7860,7 @@
         },
         "object.assign": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-properties": "^1.1.2",
             "function-bind": "^1.1.1",
@@ -7871,7 +7870,7 @@
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -7880,14 +7879,14 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isobject": "^3.0.1"
           }
         },
         "observable-to-promise": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-observable": "^2.0.0",
             "symbol-observable": "^1.0.4"
@@ -7895,7 +7894,7 @@
         },
         "omit.js": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "babel-runtime": "^6.23.0"
@@ -7903,21 +7902,21 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "wrappy": "1"
           }
         },
         "onetime": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mimic-fn": "^2.1.0"
           }
         },
         "optionator": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
@@ -7930,7 +7929,7 @@
         },
         "ora": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "chalk": "^2.4.2",
             "cli-cursor": "^2.1.0",
@@ -7974,11 +7973,11 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "p-all": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-map": "^2.0.0"
@@ -7986,44 +7985,44 @@
         },
         "p-cancelable": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "p-finally": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-limit": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "p-limit": "^2.0.0"
           }
         },
         "p-map": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "p-map-series": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-reduce": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-timeout": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-finally": "^1.0.0"
@@ -8039,11 +8038,11 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "p-wait-for": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-timeout": "^2.0.1"
@@ -8051,7 +8050,7 @@
         },
         "package-hash": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.15",
             "hasha": "^5.0.0",
@@ -8061,7 +8060,7 @@
         },
         "package-json": {
           "version": "6.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "got": "^9.6.0",
             "registry-auth-token": "^4.0.0",
@@ -8078,7 +8077,7 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
@@ -8088,7 +8087,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -8096,16 +8095,16 @@
         },
         "parse-ms": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "parse-npm-script": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "parse-path": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-ssh": "^1.3.0",
             "protocols": "^1.4.0"
@@ -8113,7 +8112,7 @@
         },
         "parse-url": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-ssh": "^1.3.0",
             "normalize-url": "^3.3.0",
@@ -8123,38 +8122,38 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-dirname": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true
+          "resolved": false
         },
         "path-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pify": "^3.0.0"
           },
@@ -8168,26 +8167,26 @@
         },
         "picomatch": {
           "version": "2.0.7",
-          "bundled": true
+          "resolved": false
         },
         "pify": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true
+          "resolved": false
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pinkie": "^2.0.0"
           }
         },
         "pkg-conf": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "find-up": "^3.0.0",
             "load-json-file": "^5.2.0"
@@ -8214,7 +8213,7 @@
         },
         "pkg-dir": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "find-up": "^4.0.0"
           },
@@ -8253,19 +8252,19 @@
         },
         "plur": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "irregular-plurals": "^2.0.0"
           }
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "postcss": {
           "version": "7.0.17",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -8292,7 +8291,7 @@
         },
         "postcss-values-parser": {
           "version": "1.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "flatten": "^1.0.2",
@@ -8302,7 +8301,7 @@
         },
         "precinct": {
           "version": "6.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "commander": "^2.19.0",
@@ -8339,39 +8338,39 @@
         },
         "precond": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "prepend-http": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "pretty-ms": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "parse-ms": "^2.1.0"
           }
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false
         },
         "promise": {
           "version": "7.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "asap": "~2.0.3"
           }
         },
         "promise.prototype.finally": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.13.0",
@@ -8380,15 +8379,15 @@
         },
         "protocols": {
           "version": "1.4.7",
-          "bundled": true
+          "resolved": false
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -8396,15 +8395,15 @@
         },
         "qs": {
           "version": "6.7.0",
-          "bundled": true
+          "resolved": false
         },
         "quick-lru": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "randomatic": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-number": "^4.0.0",
             "kind-of": "^6.0.0",
@@ -8420,7 +8419,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -8430,7 +8429,7 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
@@ -8439,7 +8438,7 @@
         },
         "read-pkg-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "find-up": "^2.0.0",
             "read-pkg": "^3.0.0"
@@ -8494,7 +8493,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -8514,14 +8513,14 @@
         },
         "readdirp": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "picomatch": "^2.0.4"
           }
         },
         "redact-env": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "escape-string-regexp": "^2.0.0"
@@ -8537,7 +8536,7 @@
         },
         "redent": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
@@ -8552,23 +8551,23 @@
         },
         "regenerate": {
           "version": "1.4.0",
-          "bundled": true
+          "resolved": false
         },
         "regenerate-unicode-properties": {
           "version": "8.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "regenerate": "^1.4.0"
           }
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -8577,7 +8576,7 @@
         },
         "regexpu-core": {
           "version": "4.5.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "regenerate": "^1.4.0",
             "regenerate-unicode-properties": "^8.0.2",
@@ -8589,7 +8588,7 @@
         },
         "registry-auth-token": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "rc": "^1.2.8",
             "safe-buffer": "^5.0.1"
@@ -8597,18 +8596,18 @@
         },
         "registry-url": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "rc": "^1.2.8"
           }
         },
         "regjsgen": {
           "version": "0.5.0",
-          "bundled": true
+          "resolved": false
         },
         "regjsparser": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jsesc": "~0.5.0"
           },
@@ -8622,14 +8621,14 @@
         },
         "release-zalgo": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "es6-error": "^4.0.1"
           }
         },
         "remarkable": {
           "version": "1.7.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "argparse": "^1.0.10",
             "autolinker": "~0.28.0"
@@ -8637,19 +8636,19 @@
         },
         "repeat-element": {
           "version": "1.1.3",
-          "bundled": true
+          "resolved": false
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true
+          "resolved": false
         },
         "replaceall": {
           "version": "0.1.6",
-          "bundled": true
+          "resolved": false
         },
         "replacestream": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.3",
@@ -8659,46 +8658,46 @@
         },
         "require-package-name": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "require-precompiled": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "resolve": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "path-parse": "^1.0.6"
           }
         },
         "resolve-cwd": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "resolve-from": "^5.0.0"
           }
         },
         "resolve-from": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "responselike": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lowercase-keys": "^1.0.0"
           }
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
@@ -8706,31 +8705,31 @@
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "reusify": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "run-parallel": {
           "version": "1.1.9",
-          "bundled": true
+          "resolved": false
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "bundled": true
+          "resolved": false
         },
         "safe-regex": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ret": "~0.1.10"
@@ -8738,29 +8737,29 @@
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true
+          "resolved": false
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "semver": "^5.0.3"
           }
         },
         "serialize-error": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "set-getter": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "to-object-path": "^0.3.0"
           }
         },
         "set-value": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -8782,18 +8781,18 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "shell-source": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "concat-stream": "^1.4.7",
@@ -8802,16 +8801,16 @@
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false
         },
         "slash": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "slice-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-styles": "^3.2.0",
             "astral-regex": "^1.0.0",
@@ -8820,7 +8819,7 @@
         },
         "snapdragon": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "base": "^0.11.1",
@@ -8855,7 +8854,7 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-property": "^1.0.0",
@@ -8905,7 +8904,7 @@
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
@@ -8924,11 +8923,11 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true
+          "resolved": false
         },
         "source-map-resolve": {
           "version": "0.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "atob": "^2.1.1",
@@ -8940,7 +8939,7 @@
         },
         "source-map-support": {
           "version": "0.5.13",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -8955,12 +8954,12 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "spdx-correct": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -8968,11 +8967,11 @@
         },
         "spdx-exceptions": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -8980,11 +8979,11 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true
+          "resolved": false
         },
         "split-string": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -8992,15 +8991,15 @@
         },
         "sprintf-js": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false
         },
         "stack-utils": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "static-extend": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-property": "^0.2.5",
@@ -9020,7 +9019,7 @@
         },
         "string-width": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -9036,7 +9035,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safe-buffer": "~5.1.0"
           },
@@ -9050,46 +9049,46 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
         },
         "strip-bom": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "strip-bom-buf": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-utf8": "^0.2.1"
           }
         },
         "strip-color": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "strip-final-newline": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-indent": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false
         },
         "supertap": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "arrify": "^1.0.1",
             "indent-string": "^3.2.0",
@@ -9120,18 +9119,18 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "symbol-observable": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "sync-request": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "concat-stream": "^1.4.7",
             "http-response-object": "^1.0.1",
@@ -9140,14 +9139,14 @@
         },
         "sync-rpc": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "get-port": "^3.1.0"
           }
         },
         "tar-stream": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "bl": "^3.0.0",
@@ -9172,12 +9171,12 @@
         },
         "temp-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tempy": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "temp-dir": "^1.0.0",
@@ -9186,7 +9185,7 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "execa": "^0.7.0"
           },
@@ -9242,7 +9241,7 @@
         },
         "then-request": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "caseless": "~0.11.0",
             "concat-stream": "^1.4.7",
@@ -9254,7 +9253,7 @@
         },
         "through2": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -9262,7 +9261,7 @@
         },
         "through2-filter": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "through2": "~2.0.0",
@@ -9271,7 +9270,7 @@
         },
         "through2-map": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "through2": "~2.0.0",
@@ -9280,15 +9279,15 @@
         },
         "time-zone": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "to-function": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "component-props": "*"
@@ -9296,7 +9295,7 @@
         },
         "to-object-path": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -9313,11 +9312,11 @@
         },
         "to-readable-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "to-regex": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-property": "^2.0.2",
@@ -9328,7 +9327,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -9337,27 +9336,27 @@
         },
         "toml": {
           "version": "2.3.6",
-          "bundled": true
+          "resolved": false
         },
         "traverse": {
           "version": "0.6.6",
-          "bundled": true
+          "resolved": false
         },
         "trim-newlines": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "trim-off-newlines": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "type-check": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -9365,35 +9364,35 @@
         },
         "type-fest": {
           "version": "0.5.2",
-          "bundled": true
+          "resolved": false
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true
+          "resolved": false
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
         },
         "typescript": {
           "version": "3.5.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "uid2": {
           "version": "0.0.3",
-          "bundled": true
+          "resolved": false
         },
         "unicode-canonical-property-names-ecmascript": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "unicode-match-property-ecmascript": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "unicode-canonical-property-names-ecmascript": "^1.0.4",
             "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -9401,15 +9400,15 @@
         },
         "unicode-match-property-value-ecmascript": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "unicode-property-aliases-ecmascript": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false
         },
         "union-value": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -9420,19 +9419,19 @@
         },
         "uniq": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "crypto-random-string": "^1.0.0"
           }
         },
         "unique-temp-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mkdirp": "^0.5.1",
             "os-tmpdir": "^1.0.1",
@@ -9441,7 +9440,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has-value": "^0.3.1",
@@ -9480,7 +9479,7 @@
         },
         "update-notifier": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "boxen": "^3.0.0",
             "chalk": "^2.0.1",
@@ -9498,28 +9497,28 @@
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "url-parse-lax": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "prepend-http": "^2.0.0"
           }
         },
         "use": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "util.promisify": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -9528,7 +9527,7 @@
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -9536,25 +9535,25 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "defaults": "^1.0.3"
           }
         },
         "well-known-symbols": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "string-width": "^2.1.1"
           },
@@ -9585,16 +9584,16 @@
         },
         "wordwrap": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "write-file-atomic": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
@@ -9604,26 +9603,26 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "xtend": {
           "version": "4.0.2",
-          "bundled": true
+          "resolved": false
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "yargs-parser": {
           "version": "10.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "camelcase": "^4.1.0"
           }
         },
         "zip-stream": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "archiver-utils": "^2.1.0",
@@ -9646,351 +9645,6 @@
         }
       }
     },
-    "@netlify/plugin-404-no-more": {
-      "version": "file:../packages/netlify-plugin-404-no-more",
-      "dev": true,
-      "dependencies": {
-        "@types/q": {
-          "version": "1.5.2",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "boolbase": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "coa": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "@types/q": "^1.5.1",
-            "chalk": "^2.4.1",
-            "q": "^1.1.2"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "bundled": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "css-select": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^2.1.2",
-            "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
-          }
-        },
-        "css-select-base-adapter": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "css-tree": {
-          "version": "1.0.0-alpha.33",
-          "bundled": true,
-          "requires": {
-            "mdn-data": "2.0.4",
-            "source-map": "^0.5.3"
-          }
-        },
-        "css-what": {
-          "version": "2.1.3",
-          "bundled": true
-        },
-        "csso": {
-          "version": "3.5.1",
-          "bundled": true,
-          "requires": {
-            "css-tree": "1.0.0-alpha.29"
-          },
-          "dependencies": {
-            "css-tree": {
-              "version": "1.0.0-alpha.29",
-              "bundled": true,
-              "requires": {
-                "mdn-data": "~1.1.0",
-                "source-map": "^0.5.3"
-              }
-            },
-            "mdn-data": {
-              "version": "1.1.4",
-              "bundled": true
-            }
-          }
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "object-keys": "^1.0.12"
-          }
-        },
-        "dom-serializer": {
-          "version": "0.2.1",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "entities": "^2.0.0"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "bundled": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "es-abstract": {
-          "version": "1.14.2",
-          "bundled": true,
-          "requires": {
-            "es-to-primitive": "^1.2.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.0",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-inspect": "^1.6.0",
-            "object-keys": "^1.1.1",
-            "string.prototype.trimleft": "^2.0.0",
-            "string.prototype.trimright": "^2.0.0"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "has": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "has-symbols": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-callable": {
-          "version": "1.1.4",
-          "bundled": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-symbol": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "has-symbols": "^1.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "bundled": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "mdn-data": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "nth-check": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "boolbase": "~1.0.0"
-          }
-        },
-        "object-inspect": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "object.getownpropertydescriptors": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.5.1"
-          }
-        },
-        "object.values": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.12.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
-        "q": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "stable": {
-          "version": "0.1.8",
-          "bundled": true
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "svgo": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "coa": "^2.0.2",
-            "css-select": "^2.0.0",
-            "css-select-base-adapter": "^0.1.1",
-            "css-tree": "1.0.0-alpha.33",
-            "csso": "^3.5.1",
-            "js-yaml": "^3.13.1",
-            "mkdirp": "~0.5.1",
-            "object.values": "^1.1.0",
-            "sax": "~1.2.4",
-            "stable": "^0.1.8",
-            "unquote": "~1.1.1",
-            "util.promisify": "~1.0.0"
-          }
-        },
-        "unquote": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "util.promisify": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "object.getownpropertydescriptors": "^2.0.3"
-          }
-        }
-      }
-    },
     "@netlify/plugin-axe": {
       "version": "file:../packages/netlify-plugin-axe",
       "dev": true,
@@ -10002,12 +9656,12 @@
       "dependencies": {
         "@types/events": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/glob": {
           "version": "7.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/events": "*",
@@ -10017,17 +9671,17 @@
         },
         "@types/minimatch": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/node": {
           "version": "12.7.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ajv": {
           "version": "6.10.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -10038,7 +9692,7 @@
         },
         "array-union": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "array-uniq": "^1.0.1"
@@ -10046,12 +9700,12 @@
         },
         "array-uniq": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -10059,27 +9713,27 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "axe-cli": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "axe-core": "^3.2.2",
@@ -10092,12 +9746,12 @@
         },
         "axe-core": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "axe-webdriverjs": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "axe-core": "^3.3.1",
@@ -10107,7 +9761,7 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "core-js": "^2.4.0",
@@ -10116,12 +9770,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -10129,7 +9783,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -10138,17 +9792,17 @@
         },
         "buffer-from": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "chromedriver": {
           "version": "76.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "del": "^4.1.1",
@@ -10160,12 +9814,12 @@
         },
         "colors": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -10173,17 +9827,17 @@
         },
         "commander": {
           "version": "2.20.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -10194,17 +9848,17 @@
         },
         "core-js": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -10216,7 +9870,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -10224,7 +9878,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -10232,12 +9886,12 @@
         },
         "deep-is": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "del": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/glob": "^7.1.1",
@@ -10251,17 +9905,17 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "depd": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -10270,7 +9924,7 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -10278,7 +9932,7 @@
         },
         "execa": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -10294,12 +9948,12 @@
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "extract-zip": {
           "version": "1.6.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "concat-stream": "1.6.2",
@@ -10310,22 +9964,22 @@
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-deep-equal": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fd-slicer": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pend": "~1.2.0"
@@ -10333,12 +9987,12 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "form-data": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -10348,12 +10002,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "get-stream": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -10361,7 +10015,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -10369,7 +10023,7 @@
         },
         "glob": {
           "version": "7.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -10382,7 +10036,7 @@
         },
         "globby": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "array-union": "^1.0.1",
@@ -10402,12 +10056,12 @@
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ajv": "^6.5.5",
@@ -10416,7 +10070,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -10426,12 +10080,12 @@
         },
         "immediate": {
           "version": "3.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -10440,22 +10094,22 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-path-cwd": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-path-in-cwd": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-path-inside": "^2.1.0"
@@ -10463,7 +10117,7 @@
         },
         "is-path-inside": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.2"
@@ -10471,22 +10125,22 @@
         },
         "is-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-url": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is2": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "deep-is": "^0.1.3",
@@ -10496,42 +10150,42 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -10542,7 +10196,7 @@
         },
         "jszip": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lie": "~3.3.0",
@@ -10553,7 +10207,7 @@
         },
         "lie": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "immediate": "~3.0.5"
@@ -10561,17 +10215,17 @@
         },
         "merge-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-db": {
           "version": "1.40.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.24",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mime-db": "1.40.0"
@@ -10579,12 +10233,12 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -10592,12 +10246,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -10605,17 +10259,17 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-run-path": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -10631,17 +10285,17 @@
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -10649,7 +10303,7 @@
         },
         "onetime": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
@@ -10657,62 +10311,62 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-finally": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-map": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pako": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pend": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pify": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -10720,17 +10374,17 @@
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "psl": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -10739,17 +10393,17 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10763,12 +10417,12 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -10795,7 +10449,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -10803,22 +10457,22 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "selenium-webdriver": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jszip": "^3.1.3",
@@ -10829,17 +10483,17 @@
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "set-immediate-shim": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -10847,17 +10501,17 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "sshpk": {
           "version": "1.16.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -10873,7 +10527,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -10881,12 +10535,12 @@
         },
         "strip-final-newline": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tcp-port-used": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "4.1.0",
@@ -10912,7 +10566,7 @@
         },
         "tmp": {
           "version": "0.0.30",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "os-tmpdir": "~1.0.1"
@@ -10920,7 +10574,7 @@
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -10937,7 +10591,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -10945,17 +10599,17 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "uri-js": {
           "version": "4.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -10963,17 +10617,17 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -10983,7 +10637,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -10991,12 +10645,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "xml2js": {
           "version": "0.4.19",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "sax": ">=0.6.0",
@@ -11005,12 +10659,12 @@
         },
         "xmlbuilder": {
           "version": "9.0.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "yauzl": {
           "version": "2.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fd-slicer": "~1.0.1"
@@ -11036,12 +10690,12 @@
       "dependencies": {
         "@babel/parser": {
           "version": "7.5.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@netlify/zip-it-and-ship-it": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "archiver": "^3.0.0",
@@ -11060,7 +10714,7 @@
         },
         "@typescript-eslint/typescript-estree": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash.unescape": "4.0.1",
@@ -11069,7 +10723,7 @@
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -11077,7 +10731,7 @@
         },
         "archiver": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "archiver-utils": "^2.1.0",
@@ -11091,7 +10745,7 @@
         },
         "archiver-utils": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.4",
@@ -11125,12 +10779,12 @@
         },
         "ast-module-types": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "async": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -11138,17 +10792,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "base64-js": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "bl": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.1"
@@ -11156,7 +10810,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -11165,7 +10819,7 @@
         },
         "buffer": {
           "version": "5.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -11174,12 +10828,12 @@
         },
         "buffer-crc32": {
           "version": "0.2.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -11200,12 +10854,12 @@
         },
         "cliclopts": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -11213,17 +10867,17 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "commander": {
           "version": "2.20.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "compress-commons": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "buffer-crc32": "^0.2.13",
@@ -11251,17 +10905,17 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "crc": {
           "version": "3.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "buffer": "^5.1.0"
@@ -11269,7 +10923,7 @@
         },
         "crc32-stream": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "crc": "^3.4.4",
@@ -11278,7 +10932,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -11286,12 +10940,12 @@
         },
         "deep-is": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "detective-amd": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.3.1",
@@ -11302,7 +10956,7 @@
         },
         "detective-cjs": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.4.0",
@@ -11311,7 +10965,7 @@
         },
         "detective-es6": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "node-source-walk": "^4.0.0"
@@ -11319,7 +10973,7 @@
         },
         "detective-less": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.0.0",
@@ -11329,7 +10983,7 @@
         },
         "detective-postcss": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -11340,7 +10994,7 @@
         },
         "detective-sass": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -11350,7 +11004,7 @@
         },
         "detective-scss": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^4.1.1",
@@ -11360,12 +11014,12 @@
         },
         "detective-stylus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "detective-typescript": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/typescript-estree": "^1.9.0",
@@ -11375,12 +11029,12 @@
         },
         "elf-tools": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -11388,7 +11042,7 @@
         },
         "error-ex": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -11396,12 +11050,12 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "escodegen": {
           "version": "1.11.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "esprima": "^3.1.3",
@@ -11413,27 +11067,27 @@
         },
         "esprima": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "estraverse": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "esutils": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-levenshtein": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -11441,17 +11095,17 @@
         },
         "flatten": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fs-constants": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fs-extra": {
           "version": "8.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -11461,12 +11115,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "get-amd-module-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.3.2",
@@ -11475,7 +11129,7 @@
         },
         "glob": {
           "version": "7.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -11488,7 +11142,7 @@
         },
         "gonzales-pe": {
           "version": "4.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimist": "1.1.x"
@@ -11504,17 +11158,17 @@
         },
         "graceful-fs": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lru-cache": "^5.1.1"
@@ -11522,12 +11176,12 @@
         },
         "ieee754": {
           "version": "1.1.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -11535,12 +11189,12 @@
         },
         "indexes-of": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -11549,32 +11203,32 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-url": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsonfile": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -11582,7 +11236,7 @@
         },
         "lazystream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "readable-stream": "^2.0.5"
@@ -11607,7 +11261,7 @@
         },
         "levn": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -11616,7 +11270,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -11627,7 +11281,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -11636,42 +11290,42 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.defaults": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.difference": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.flatten": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isplainobject": {
           "version": "4.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.unescape": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
@@ -11679,7 +11333,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -11687,12 +11341,12 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "module-definition": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ast-module-types": "^2.4.0",
@@ -11701,12 +11355,12 @@
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "node-source-walk": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@babel/parser": "^7.0.0"
@@ -11714,7 +11368,7 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -11725,17 +11379,17 @@
         },
         "normalize-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-packlist": {
           "version": "1.4.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -11744,7 +11398,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -11752,7 +11406,7 @@
         },
         "optionator": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
@@ -11765,7 +11419,7 @@
         },
         "p-all": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-map": "^2.0.0"
@@ -11773,7 +11427,7 @@
         },
         "p-limit": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -11781,7 +11435,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -11789,17 +11443,17 @@
         },
         "p-map": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-try": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -11808,27 +11462,27 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "postcss": {
           "version": "7.0.17",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -11838,7 +11492,7 @@
         },
         "postcss-values-parser": {
           "version": "1.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "flatten": "^1.0.2",
@@ -11848,7 +11502,7 @@
         },
         "precinct": {
           "version": "6.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "commander": "^2.19.0",
@@ -11868,17 +11522,17 @@
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
@@ -11899,7 +11553,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "find-up": "^3.0.0",
@@ -11908,7 +11562,7 @@
         },
         "readable-stream": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -11918,12 +11572,12 @@
         },
         "require-package-name": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "resolve": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -11931,22 +11585,22 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "spdx-correct": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -11955,12 +11609,12 @@
         },
         "spdx-exceptions": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -11969,12 +11623,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11982,12 +11636,12 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -11995,7 +11649,7 @@
         },
         "tar-stream": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "bl": "^3.0.0",
@@ -12007,7 +11661,7 @@
         },
         "type-check": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -12015,27 +11669,27 @@
         },
         "typescript": {
           "version": "3.5.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "uniq": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "universalify": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -12044,22 +11698,22 @@
         },
         "wordwrap": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "zip-stream": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "archiver-utils": "^2.1.0",
@@ -12081,12 +11735,12 @@
       "dependencies": {
         "@sindresorhus/is": {
           "version": "0.14.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@szmarczak/http-timer": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "defer-to-connect": "^1.0.1"
@@ -12094,17 +11748,17 @@
         },
         "@types/node": {
           "version": "12.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "JSV": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ajv": {
           "version": "6.10.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -12115,7 +11769,7 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -12123,17 +11777,17 @@
         },
         "ansi-escapes": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -12141,17 +11795,17 @@
         },
         "array-find-index": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -12159,42 +11813,42 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "async-limiter": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "axe-core": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -12202,7 +11856,7 @@
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -12216,7 +11870,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -12225,7 +11879,7 @@
         },
         "cacheable-request": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "clone-response": "^1.0.2",
@@ -12256,12 +11910,12 @@
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "camelcase-keys": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0",
@@ -12271,17 +11925,17 @@
         },
         "capture-stack-trace": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -12291,17 +11945,17 @@
         },
         "chardet": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "charenc": {
           "version": "0.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "chrome-launcher": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -12313,17 +11967,17 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "restore-cursor": "^2.0.0"
@@ -12331,17 +11985,17 @@
         },
         "cli-spinners": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cli-width": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -12388,12 +12042,12 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "clone-response": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mimic-response": "^1.0.0"
@@ -12401,12 +12055,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -12414,12 +12068,12 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -12427,12 +12081,12 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "conf": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ajv": "^6.10.0",
@@ -12490,7 +12144,7 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
@@ -12503,17 +12157,17 @@
         },
         "cookie": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -12521,7 +12175,7 @@
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -12533,22 +12187,22 @@
         },
         "crypt": {
           "version": "0.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cssom": {
           "version": "0.3.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cssstyle": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cssom": "0.3.x"
@@ -12556,7 +12210,7 @@
         },
         "currently-unhandled": {
           "version": "0.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "array-find-index": "^1.0.1"
@@ -12564,7 +12218,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -12572,7 +12226,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -12580,12 +12234,12 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "decamelize-keys": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "decamelize": "^1.1.0",
@@ -12602,7 +12256,7 @@
         },
         "decompress-response": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mimic-response": "^1.0.0"
@@ -12610,12 +12264,12 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
@@ -12623,22 +12277,22 @@
         },
         "defer-to-connect": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "details-element-polyfill": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "dot-prop": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -12646,12 +12300,12 @@
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -12660,12 +12314,12 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -12673,12 +12327,12 @@
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "error-ex": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -12686,12 +12340,12 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "execa": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -12739,12 +12393,12 @@
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "external-editor": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chardet": "^0.4.0",
@@ -12754,22 +12408,22 @@
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-deep-equal": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "figures": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
@@ -12777,7 +12431,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -12785,12 +12439,12 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "form-data": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -12800,17 +12454,17 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -12818,7 +12472,7 @@
         },
         "glob": {
           "version": "7.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -12831,7 +12485,7 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -12839,7 +12493,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -12857,17 +12511,17 @@
         },
         "graceful-fs": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ajv": "^6.5.5",
@@ -12876,32 +12530,32 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "has-yarn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "http-cache-semantics": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "http-link-header": {
           "version": "0.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -12911,7 +12565,7 @@
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -12919,27 +12573,27 @@
         },
         "image-ssim": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "indent-string": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -12948,17 +12602,17 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inquirer": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -12979,12 +12633,12 @@
         },
         "intl": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "intl-messageformat": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "intl-messageformat-parser": "1.4.0"
@@ -13000,27 +12654,27 @@
         },
         "intl-messageformat-parser": {
           "version": "1.8.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
@@ -13028,12 +12682,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -13042,17 +12696,17 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -13060,102 +12714,102 @@
         },
         "is-plain-obj": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-promise": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-wsl": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-yarn-global": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jpeg-js": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "js-library-detector": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-buffer": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema-typed": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsonld": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "rdf-canonize": "^1.0.2",
@@ -13166,7 +12820,7 @@
         },
         "jsonlint-mod": {
           "version": "1.7.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "JSV": "^4.0.2",
@@ -13176,7 +12830,7 @@
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -13187,7 +12841,7 @@
         },
         "keyv": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "json-buffer": "3.0.0"
@@ -13195,7 +12849,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -13203,7 +12857,7 @@
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -13211,7 +12865,7 @@
         },
         "lighthouse": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "axe-core": "3.3.0",
@@ -13270,7 +12924,7 @@
         },
         "lighthouse-ci": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chrome-launcher": "^0.11.1",
@@ -13284,7 +12938,7 @@
         },
         "lighthouse-logger": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^2.6.8",
@@ -13293,7 +12947,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -13304,7 +12958,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -13313,22 +12967,22 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isequal": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.set": {
           "version": "4.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "log-symbols": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chalk": "^2.0.1"
@@ -13336,12 +12990,12 @@
         },
         "lookup-closest-locale": {
           "version": "6.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "loud-rejection": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "currently-unhandled": "^0.4.1",
@@ -13350,12 +13004,12 @@
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -13364,7 +13018,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -13372,17 +13026,17 @@
         },
         "map-obj": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "marky": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "md5": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "charenc": "~0.0.1",
@@ -13392,7 +13046,7 @@
         },
         "meow": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "camelcase-keys": "^4.0.0",
@@ -13419,22 +13073,22 @@
         },
         "merge-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "metaviewport-parser": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-db": {
           "version": "1.40.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.24",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mime-db": "1.40.0"
@@ -13442,17 +13096,17 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mimic-response": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -13460,12 +13114,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "minimist-options": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -13474,7 +13128,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -13482,27 +13136,27 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "node-forge": {
           "version": "0.8.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -13513,12 +13167,12 @@
         },
         "normalize-url": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-run-path": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -13534,17 +13188,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -13552,7 +13206,7 @@
         },
         "onetime": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -13560,7 +13214,7 @@
         },
         "open": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-wsl": "^1.1.0"
@@ -13576,7 +13230,7 @@
         },
         "ora": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
@@ -13606,7 +13260,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lcid": "^1.0.0"
@@ -13614,22 +13268,22 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-cancelable": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-finally": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -13637,7 +13291,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -13645,12 +13299,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -13661,12 +13315,12 @@
         },
         "parse-cache-control": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -13675,32 +13329,32 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -13708,17 +13362,17 @@
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pkg-up": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -13771,22 +13425,22 @@
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "psl": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -13795,22 +13449,22 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "quick-lru": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "raven": {
           "version": "2.6.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cookie": "0.3.1",
@@ -13822,7 +13476,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -13841,7 +13495,7 @@
         },
         "rdf-canonize": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "node-forge": "^0.8.1",
@@ -13850,7 +13504,7 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
@@ -13860,7 +13514,7 @@
         },
         "read-pkg-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "find-up": "^2.0.0",
@@ -13869,7 +13523,7 @@
         },
         "redent": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "indent-string": "^3.0.0",
@@ -13878,7 +13532,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -13887,7 +13541,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -13895,7 +13549,7 @@
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -13922,7 +13576,7 @@
         },
         "resolve": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -13930,7 +13584,7 @@
         },
         "responselike": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lowercase-keys": "^1.0.0"
@@ -13938,7 +13592,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "onetime": "^2.0.0",
@@ -13947,7 +13601,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -13955,12 +13609,12 @@
         },
         "robots-parser": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "run-async": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-promise": "^2.1.0"
@@ -13968,12 +13622,12 @@
         },
         "rx-lite": {
           "version": "4.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "rx-lite-aggregates": {
           "version": "4.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "rx-lite": "*"
@@ -13981,22 +13635,22 @@
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -14004,7 +13658,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -14012,17 +13666,17 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "spdx-correct": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -14031,12 +13685,12 @@
         },
         "spdx-exceptions": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -14045,12 +13699,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "speedline-core": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -14060,7 +13714,7 @@
         },
         "sshpk": {
           "version": "1.16.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -14076,12 +13730,12 @@
         },
         "stack-trace": {
           "version": "0.0.10",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -14090,7 +13744,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -14098,32 +13752,32 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-final-newline": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-indent": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -14131,7 +13785,7 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -14182,22 +13836,22 @@
         },
         "third-party-web": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tmp": {
           "version": "0.0.33",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "os-tmpdir": "~1.0.2"
@@ -14205,12 +13859,12 @@
         },
         "to-readable-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -14227,12 +13881,12 @@
         },
         "trim-newlines": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -14240,17 +13894,17 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "type-fest": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-typedarray": "^1.0.0"
@@ -14258,17 +13912,17 @@
         },
         "ultron": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "underscore": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -14276,12 +13930,12 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "update-notifier": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "boxen": "^3.0.0",
@@ -14489,7 +14143,7 @@
         },
         "uri-js": {
           "version": "4.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -14497,7 +14151,7 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -14505,12 +14159,12 @@
         },
         "uuid": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -14519,7 +14173,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -14529,7 +14183,7 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -14537,7 +14191,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -14545,7 +14199,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
@@ -14553,12 +14207,12 @@
         },
         "window-size": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -14604,12 +14258,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -14619,7 +14273,7 @@
         },
         "ws": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0",
@@ -14637,27 +14291,27 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "xmldom": {
           "version": "0.1.19",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "yargs": {
           "version": "3.32.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "camelcase": "^2.0.1",
@@ -14714,7 +14368,7 @@
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -14733,17 +14387,17 @@
       "dependencies": {
         "@types/braces": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/debug": {
           "version": "0.0.31",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/micromatch": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/braces": "*"
@@ -14751,17 +14405,17 @@
         },
         "@types/yargs": {
           "version": "12.0.12",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -14769,37 +14423,37 @@
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "atob": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
@@ -14853,7 +14507,7 @@
         },
         "braces": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -14881,7 +14535,7 @@
         },
         "cache-base": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
@@ -14897,12 +14551,12 @@
         },
         "camelcase": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -14912,7 +14566,7 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -14934,7 +14588,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^2.1.1",
@@ -14944,12 +14598,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
@@ -14958,7 +14612,7 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -14966,22 +14620,22 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "component-emitter": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -14993,7 +14647,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -15001,17 +14655,17 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "define-property": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -15051,7 +14705,7 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -15059,12 +14713,12 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "execa": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -15080,7 +14734,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -15129,7 +14783,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -15149,7 +14803,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -15213,7 +14867,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -15235,7 +14889,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -15243,12 +14897,12 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
@@ -15256,12 +14910,12 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "get-stream": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -15269,17 +14923,17 @@
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "has-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "get-value": "^2.0.6",
@@ -15289,7 +14943,7 @@
         },
         "has-values": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -15309,12 +14963,12 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -15333,12 +14987,12 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -15357,7 +15011,7 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -15375,17 +15029,17 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -15404,7 +15058,7 @@
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -15412,37 +15066,37 @@
         },
         "is-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
@@ -15450,7 +15104,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -15459,7 +15113,7 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
@@ -15467,12 +15121,12 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
@@ -15480,7 +15134,7 @@
         },
         "mem": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -15490,12 +15144,12 @@
         },
         "merge-stream": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -15515,12 +15169,12 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "for-in": "^1.0.2",
@@ -15540,12 +15194,12 @@
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.13",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -15563,12 +15217,12 @@
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "npm-run-path": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -15584,12 +15238,12 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -15619,7 +15273,7 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isobject": "^3.0.0"
@@ -15627,7 +15281,7 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -15635,7 +15289,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -15643,7 +15297,7 @@
         },
         "onetime": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
@@ -15651,7 +15305,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "execa": "^1.0.0",
@@ -15708,22 +15362,22 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-finally": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "p-limit": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -15731,7 +15385,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -15739,32 +15393,32 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -15773,7 +15427,7 @@
         },
         "regex-not": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -15782,37 +15436,37 @@
         },
         "repeat-element": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "run-if-diff": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/debug": "^0.0.31",
@@ -15825,7 +15479,7 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ret": "~0.1.10"
@@ -15833,17 +15487,17 @@
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "set-value": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -15865,7 +15519,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -15873,17 +15527,17 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "base": "^0.11.1",
@@ -15933,7 +15587,7 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-property": "^1.0.0",
@@ -15983,7 +15637,7 @@
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
@@ -16002,12 +15656,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "atob": "^2.1.1",
@@ -16019,12 +15673,12 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -16032,7 +15686,7 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-property": "^0.2.5",
@@ -16052,7 +15706,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -16061,7 +15715,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -16069,17 +15723,17 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "strip-final-newline": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -16087,7 +15741,7 @@
         },
         "to-object-path": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -16106,7 +15760,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "define-property": "^2.0.2",
@@ -16117,7 +15771,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -16126,7 +15780,7 @@
         },
         "union-value": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -16137,7 +15791,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "has-value": "^0.3.1",
@@ -16176,17 +15830,17 @@
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "use": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -16194,12 +15848,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -16245,17 +15899,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "yargs": {
           "version": "12.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -16274,11 +15928,326 @@
         },
         "yargs-parser": {
           "version": "11.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "@netlify/plugin-no-more-404": {
+      "version": "file:../packages/netlify-plugin-no-more-404",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "conf": "^6.1.0",
+        "netlify-redirect-parser": "^1.0.3",
+        "netlify-redirector": "^0.1.0"
+      },
+      "dependencies": {
+        "@iarna/toml": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
+          "integrity": "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "conf": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/conf/-/conf-6.1.0.tgz",
+          "integrity": "sha512-NjzT0zGZ7iy88ybk4ysz4YDMcGTEJzS2wFNKyQd1ChqcZfF6IKY1j+1+q5Dubu8si2skcMfA86t13vNz1mJckA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "debounce-fn": "^3.0.1",
+            "dot-prop": "^5.0.0",
+            "env-paths": "^2.2.0",
+            "json-schema-typed": "^7.0.1",
+            "make-dir": "^3.0.0",
+            "onetime": "^5.1.0",
+            "pkg-up": "^3.0.1",
+            "semver": "^6.2.0",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "debounce-fn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-3.0.1.tgz",
+          "integrity": "sha512-aBoJh5AhpqlRoHZjHmOzZlRx+wz2xVwGL9rjs+Kj0EWUrL4/h4K7OD176thl2Tdoqui/AaA4xhHrNArGLAaI3Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "dot-prop": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
+          "integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "env-paths": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "dev": true
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "json-schema-typed": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.1.tgz",
+          "integrity": "sha512-IqUK+Cqc8/MqHsCvv1TMccbKdBzoATOLHXZAF5UDu70/CCxo648cHUig24hc+XTK53TyeNk1UeVTlc2Haovtsw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "netlify-redirect-parser": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-1.0.3.tgz",
+          "integrity": "sha512-NDQKgrN5DgWIYvEyVRG8OgiM1KV140D+4f8rJkqbTCKj32uXokMuJ38woTyGnqBb565ygiFuU6uA0czHbvGxaw==",
+          "dev": true,
+          "requires": {
+            "@iarna/toml": "^2.2.3"
+          }
+        },
+        "netlify-redirector": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/netlify-redirector/-/netlify-redirector-0.1.0.tgz",
+          "integrity": "sha512-ATW6ZbFNiZdH1YmXrz5g6s6uD6W4TdwAMHsFZrpG2D+ZuIViL40YhnpVOG/LfbEA/gBDKZCWpmGwVAB4xDMCQw==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-up": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+          "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "dev": true,
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
+          "integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         }
       }
@@ -16292,7 +16261,7 @@
       "dependencies": {
         "@types/body-parser": {
           "version": "1.17.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/connect": "*",
@@ -16301,7 +16270,7 @@
         },
         "@types/connect": {
           "version": "3.4.32",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/node": "*"
@@ -16309,7 +16278,7 @@
         },
         "@types/express": {
           "version": "4.17.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/body-parser": "*",
@@ -16319,7 +16288,7 @@
         },
         "@types/express-serve-static-core": {
           "version": "4.16.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -16328,22 +16297,22 @@
         },
         "@types/mime": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/node": {
           "version": "12.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/range-parser": {
           "version": "1.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/serve-static": {
           "version": "1.13.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/express-serve-static-core": "*",
@@ -16352,7 +16321,7 @@
         },
         "ajv": {
           "version": "6.10.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -16363,12 +16332,12 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -16376,27 +16345,27 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -16404,17 +16373,17 @@
         },
         "buffer-equal-constant-time": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -16422,12 +16391,12 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -16435,17 +16404,17 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "deprecate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -16454,7 +16423,7 @@
         },
         "ecdsa-sig-formatter": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -16462,32 +16431,32 @@
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-deep-equal": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "form-data": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -16497,7 +16466,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -16505,12 +16474,12 @@
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ajv": "^6.5.5",
@@ -16519,7 +16488,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -16529,37 +16498,37 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "jsonwebtoken": {
           "version": "8.5.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jws": "^3.2.2",
@@ -16576,7 +16545,7 @@
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -16587,7 +16556,7 @@
         },
         "jwa": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "buffer-equal-constant-time": "1.0.1",
@@ -16597,7 +16566,7 @@
         },
         "jws": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "jwa": "^1.4.1",
@@ -16606,52 +16575,52 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.includes": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isboolean": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isinteger": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isnumber": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isplainobject": {
           "version": "4.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.isstring": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.once": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-db": {
           "version": "1.40.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.24",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "mime-db": "1.40.0"
@@ -16659,42 +16628,42 @@
         },
         "moment": {
           "version": "2.24.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "pop-iterate": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "psl": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "q": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -16704,12 +16673,12 @@
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -16736,32 +16705,32 @@
         },
         "rootpath": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "scmp": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "sshpk": {
           "version": "1.16.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -16777,7 +16746,7 @@
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -16794,7 +16763,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -16802,12 +16771,12 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "twilio": {
           "version": "3.33.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/express": "^4.16.1",
@@ -16824,7 +16793,7 @@
         },
         "uri-js": {
           "version": "4.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -16832,12 +16801,12 @@
         },
         "uuid": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -16847,12 +16816,12 @@
         },
         "weak-map": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "xmlbuilder": {
           "version": "9.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         }
       }
@@ -16867,7 +16836,7 @@
       "dependencies": {
         "@nodelib/fs.scandir": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "2.0.1",
@@ -16876,12 +16845,12 @@
         },
         "@nodelib/fs.stat": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@nodelib/fs.walk": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@nodelib/fs.scandir": "2.1.1",
@@ -16890,12 +16859,12 @@
         },
         "@types/events": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/glob": {
           "version": "7.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/events": "*",
@@ -16905,27 +16874,27 @@
         },
         "@types/minimatch": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@types/node": {
           "version": "12.6.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "array-union": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -16934,7 +16903,7 @@
         },
         "braces": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
@@ -16942,12 +16911,12 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "dir-glob": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-type": "^4.0.0"
@@ -16955,7 +16924,7 @@
         },
         "fast-glob": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.1",
@@ -16968,7 +16937,7 @@
         },
         "fastq": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "reusify": "^1.0.0"
@@ -16976,7 +16945,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
@@ -16984,12 +16953,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "glob": {
           "version": "7.1.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -17002,7 +16971,7 @@
         },
         "glob-parent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -17010,7 +16979,7 @@
         },
         "globby": {
           "version": "10.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/glob": "^7.1.1",
@@ -17025,12 +16994,12 @@
         },
         "ignore": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -17039,17 +17008,17 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -17057,32 +17026,32 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.chunk": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.padstart": {
           "version": "4.6.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "lodash.sortby": {
           "version": "4.7.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "merge2": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "micromatch": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "braces": "^3.0.1",
@@ -17091,7 +17060,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -17099,7 +17068,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -17107,37 +17076,37 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "path-type": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "picomatch": {
           "version": "2.0.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "reusify": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "run-parallel": {
           "version": "1.1.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "sitemap": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash.chunk": "^4.2.0",
@@ -17148,12 +17117,12 @@
         },
         "slash": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-number": "^7.0.0"
@@ -17161,7 +17130,7 @@
         },
         "tr46": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -17169,12 +17138,12 @@
         },
         "webidl-conversions": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "whatwg-url": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
@@ -17184,12 +17153,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "xmlbuilder": {
           "version": "13.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         }
       }


### PR DESCRIPTION
The `example` folder was showing the following error message during `npm install`:

```
npm WARN @netlify/build@0.0.18 had bundled packages that do not match the required version(s). They have been replaced with non-bundled versions.
npm WARN example-site@1.0.0 No repository field.

npm ERR! code ENOENT
npm ERR! syscall rename
npm ERR! path /home/ether/netlify/build/example/node_modules/.staging/@netlify/build-bbf94406/node_modules/@ava/babel-plugin-throws-helper
npm ERR! dest /home/ether/netlify/build/example/node_modules/.staging/@ava/babel-plugin-throws-helper-2f0ceca3
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, rename '/home/ether/netlify/build/example/node_modules/.staging/@netlify/build-bbf94406/node_modules/@ava/babel-plugin-throws-helper' -> '/home/ether/netlify/build/example/node_modules/.staging/@ava/babel-plugin-throws-helper-2f0ceca3'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ether/.npm/_logs/2019-10-11T08_44_27_094Z-debug.log
```

This was fixed by removing the `node_modules` directory and running `npm install` again.