### PR TITLE
Fix store-related bug with 404 plugin

### DIFF
--- a/packages/netlify-plugin-no-more-404/index.js
+++ b/packages/netlify-plugin-no-more-404/index.js
@@ -12,27 +12,25 @@ const test404plugin = false // toggle this off for production
 function netlify404nomore(conf) {
   let on404 = conf.on404 || 'error' // either 'warn' or 'error'
   let cacheKey = conf.cacheKey || 'pluginNoMore404Cache' // string - helps to quickly switch to a new cache if a mistake was made
-  let store
   return {
-    // kvstore in `${NETLIFY_CACHE_DIR}/${name}.json`
-    // we choose to let the user createStore instead of doing it for them
-    // bc they may want to set `defaults` and `schema` and `de/serialize`
-    init({ constants: { CACHE_DIR } }) {
-      store = new Conf({
-        cwd: CACHE_DIR,
-        configName: 'netlify-plugin-no-more-404'
-      })
-    },
-
     /* index html files preDeploy */
     preDeploy: async opts => {
       // console.log({ opts })
-      const { BUILD_DIR } = opts.constants // where we start from
+      const { CACHE_DIR, BUILD_DIR } = opts.constants // where we start from
 
       // let BUILD_DIR = opts.config.build.publish // build folder from netlify config.. there ought to be a nicer way to get this if set elsewhere
       if (typeof BUILD_DIR === 'undefined') {
         throw new Error('must specify publish dir in netlify config [build] section')
       }
+
+      // kvstore in `${NETLIFY_CACHE_DIR}/${name}.json`
+      // we choose to let the user createStore instead of doing it for them
+      // bc they may want to set `defaults` and `schema` and `de/serialize`
+      const store = new Conf({
+        cwd: CACHE_DIR,
+        configName: 'netlify-plugin-no-more-404'
+      })
+
       const buildFolderPath = path.resolve(BUILD_DIR)
       const prevManifest = store.get(cacheKey) || []
       if (test404plugin) {


### PR DESCRIPTION
Each plugin hook is run it a separate process. This is not optimal, unfortunately trying to run all plugin hooks in the same process was tricky (attempt at #221) and made it hard to retrieve the logs of specific hooks.

Because of this, when combined with a top-level function, modification on closure variables by plugin hooks are not propagated to other plugin hooks, since each plugin hook triggers its own top-level function. Solution to this problem could be:
  - attempt again to spawn a single process per plugin
  - using a `plugin.hooks()` method instead of top-level function (rejected at #255).

In the meantime, this created a bug with the 404 plugin which was doing this. This PR fixes it.