### PR TITLE
Fix correct usage of `execa()` vs `execa.command()`

### DIFF
--- a/packages/build/src/install/python/index.js
+++ b/packages/build/src/install/python/index.js
@@ -31,7 +31,7 @@ module.exports = async function installPython(cwd, cacheDir) {
     const env = await source(`${HOME}/python${PYTHON_VERSION}/bin/activate`)
     console.log('new env', env)
     // Default
-    // await execa.command(`${HOME}/python${PYTHON_VERSION}/bin/activate`)
+    // await execa(`${HOME}/python${PYTHON_VERSION}/bin/activate`)
   }
   return PYTHON_VERSION
 }

--- a/packages/netlify-plugin-lighthouse/index.js
+++ b/packages/netlify-plugin-lighthouse/index.js
@@ -26,7 +26,7 @@ module.exports = {
     })
 
     // TODO: fetch previous scores from cache
-    await execa.command(`lighthouse-ci ${site}`, { stdio: 'inherit' })
+    await execa('lighthouse-ci', site, { stdio: 'inherit' })
 
     // serialize response
     const curLightHouse = {}


### PR DESCRIPTION
`execa.command(command)` is like `execa(command[0], command.slice(1).split(' '))`. Which means siginificant spaces inside `command` must be backslash escaped.