### PR TITLE
Allow Node.js down to `8.3.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {},
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=8.3.0"
   }
 }


### PR DESCRIPTION
According to current integration tests, it seems like we are supporting Node.js down to `8.3.0`. 

Many of our dependencies are using object spreads, which are supported only since `8.3.0`.