### PR TITLE
Fix example directory

### DIFF
--- a/examples/example-two/netlify.yml
+++ b/examples/example-two/netlify.yml
@@ -35,7 +35,7 @@ plugins:
       compareWithVersion: 0.0.3
   axe:
     type: '@netlify/plugin-axe'
-    enabled: true
+    enabled: false
     config:
        # https://github.com/dequelabs/axe-cli#running-specific-rules
       axeFlags: '--rules color-contrast,html-has-lang'

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "description": "Netlify build module",
   "main": "index.js",
   "scripts": {
-    "bootstrap": "lerna bootstrap && cd example && npm install",
+    "bootstrap": "lerna bootstrap && cd examples/example-two && npm install",
     "postinstall": "npm run bootstrap",
     "docs": "node ./scripts/docs.js",
     "test": "run-s test:*",
-    "test:lint": "eslint --ignore-path .gitignore --fix \"{packages,example}/**/*.js\"",
-    "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{packages,example}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
+    "test:lint": "eslint --ignore-path .gitignore --fix \"{packages,examples}/**/*.js\"",
+    "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{packages,examples}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
     "test:ava": "ava",
-    "example": "node ./packages/build/src/core/bin.js --config example/netlify.yml",
-    "debug": "node --inspect-brk ./packages/build/src/core/bin.js --config example/netlify.yml"
+    "example": "node ./packages/build/src/core/bin.js --config examples/example-two/netlify.yml",
+    "debug": "node --inspect-brk ./packages/build/src/core/bin.js --config examples/example-two/netlify.yml"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
The `example` directory was renamed to `examples`. Our npm scripts using that directory should be renamed as well.