### PR TITLE
Fix `console.log()` debugging statement left

### DIFF
--- a/packages/netlify-plugin-axe/index.js
+++ b/packages/netlify-plugin-axe/index.js
@@ -5,7 +5,6 @@ const mkdirp = require('mkdirp')
 
 module.exports = {
   init: async ({ constants }) => {
-    console.log('constants', constants)
     const resultsDir = join(constants.CACHE_DIR, `axe-results`)
     mkdirp.sync(resultsDir)
     await execa('chmod', ['-R', '+rw', resultsDir])


### PR DESCRIPTION
This fixes a debugging statement that was left in `netlify-plugin-axe`.