### PR TITLE
Simplify code

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -44,18 +44,15 @@ const build = async function(options) {
 
   const buildTimer = startTimer()
 
-  let instructions
-  let netlifyConfig
   try {
     logBuildStart()
 
     const { config, configPath, token, baseDir } = await loadConfig({ options: optionsA })
-    netlifyConfig = config
     const pluginsOptions = getPluginsOptions({ config })
 
     const pluginsHooks = await loadPlugins({ pluginsOptions, config, configPath, baseDir, token })
     const { buildInstructions, errorInstructions } = getInstructions({ pluginsHooks, config })
-    instructions = buildInstructions
+    const instructions = buildInstructions
     /* If the `dry` option is specified, do a dry run and exit */
     if (optionsA.dry) {
       doDryRun({ buildInstructions, configPath })
@@ -79,7 +76,7 @@ const build = async function(options) {
 
     logBuildSuccess()
     const duration = endTimer(buildTimer, 'Netlify Build')
-    logBuildEnd({ instructions, netlifyConfig, duration })
+    logBuildEnd({ instructions, config, duration })
   } catch (error) {
     logBuildError(error, optionsA)
   }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -214,10 +214,10 @@ const logBuildSuccess = function() {
   log()
 }
 
-const logBuildEnd = function({ instructions, netlifyConfig, duration }) {
+const logBuildEnd = function({ instructions, config, duration }) {
   const sparkles = cyanBright('(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧')
   log(`\n${sparkles} Have a nice day!\n`)
-  const plugins = getPluginsByType(netlifyConfig)
+  const plugins = getPluginsByType(config)
   // telemetry noOps if BUILD_TELEMETRY_DISBALED set
   telemetry.track('buildComplete', {
     steps: instructions.length,


### PR DESCRIPTION
Simplify code and make variable naming more consistent with the rest of the code (`config` vs `pluginConfig`).