### PR TITLE
Fix typo in environment variable `DISBALED` -> `DISABLED`

### DIFF
--- a/packages/build/src/utils/telemetry/index.js
+++ b/packages/build/src/utils/telemetry/index.js
@@ -4,8 +4,8 @@ const pkg = require('../../../package.json')
 
 const plugins = require('./plugins')
 
-/* If BUILD_TELEMETRY_DISBALED, disable api calls */
-const activePlugins = process.env.BUILD_TELEMETRY_DISBALED ? [] : plugins
+/* If BUILD_TELEMETRY_DISABLED, disable api calls */
+const activePlugins = process.env.BUILD_TELEMETRY_DISABLED ? [] : plugins
 
 /* If DEBUG true, disable telemetry api calls */
 const DEBUG_ENABLED = false


### PR DESCRIPTION
`NETLIFY_BUILD_DISABLED` environment variable had a typo.