### PR TITLE
Use object spreads instead of `Object.assign()`

### DIFF
--- a/packages/build/src/core/instructions.js
+++ b/packages/build/src/core/instructions.js
@@ -71,7 +71,7 @@ const runInstruction = async function(instruction, { currentData, index, config,
 
     endTimer(methodTimer, name, hook)
 
-    return Object.assign({}, currentData, pluginReturnValue)
+    return { ...currentData, ...pluginReturnValue }
   } catch (error) {
     error.message = `Error in '${name}' plugin:\n${error.message}`
     throw error

--- a/packages/build/src/core/options.js
+++ b/packages/build/src/core/options.js
@@ -7,7 +7,7 @@ const camelcaseKeys = require('camelcase-keys')
 // Retrieve build options
 const getOptions = function(options = {}) {
   const envOptions = getEnvOptions()
-  return Object.assign({}, envOptions, options)
+  return { ...envOptions, ...options }
 }
 
 // Find all environment variables starting with `NETLIFY_BUILD_*` and converts

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -2,7 +2,7 @@ const DEFAULT_PLUGINS_DIR = __dirname
 
 // Load plugin options (specified by user in `config.plugins`)
 const getPluginsOptions = function({ config: { plugins: pluginsOptions } }) {
-  const pluginsOptionsA = Object.assign({}, DEFAULT_PLUGINS, pluginsOptions)
+  const pluginsOptionsA = { ...DEFAULT_PLUGINS, ...pluginsOptions }
   return Object.entries(pluginsOptionsA)
     .map(normalizePluginOptions)
     .filter(isPluginEnabled)
@@ -13,7 +13,7 @@ const DEFAULT_PLUGINS = {
 }
 
 const normalizePluginOptions = function([pluginId, pluginOptions]) {
-  const { type, core, enabled, config: pluginConfig } = Object.assign({}, DEFAULT_PLUGIN_OPTIONS, pluginOptions)
+  const { type, core, enabled, config: pluginConfig } = { ...DEFAULT_PLUGIN_OPTIONS, ...pluginOptions }
   return { pluginId, type, core, enabled, pluginConfig }
 }
 

--- a/packages/config/normalize.js
+++ b/packages/config/normalize.js
@@ -1,26 +1,25 @@
 const mapObj = require('map-obj')
-const omit = require('omit.js')
 
 // Normalize configuration object
 const normalizeConfig = function(config) {
-  const configA = Object.assign({ build: {}, plugins: {} }, config)
-  const configB = normalizeLifecycles(configA)
+  const configA = { ...DEFAULT_CONFIG, ...config }
+  const configB = normalizeLifecycles({ config: configA })
   return configB
 }
 
-const normalizeLifecycles = function(config) {
-  const {
-    build,
-    build: { command, lifecycle = {} }
-  } = config
-  const buildA = omit(build, ['command'])
+const DEFAULT_CONFIG = { build: {}, plugins: {} }
+
+const normalizeLifecycles = function({
+  config,
+  config: {
+    build: { command, lifecycle = {}, ...build }
+  }
+}) {
   const lifecycleA = normalizeCommand(lifecycle, command)
 
   const lifecycleB = mapObj(lifecycleA, normalizeLifecycle)
 
-  return Object.assign({}, config, {
-    build: Object.assign({}, buildA, { lifecycle: lifecycleB })
-  })
+  return { ...config, build: { ...build, lifecycle: lifecycleB } }
 }
 
 // `build.lifecycle.build` was previously called `build.command`

--- a/packages/config/package-lock.json
+++ b/packages/config/package-lock.json
@@ -672,15 +672,6 @@
         "estraverse": "^4.1.1"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1156,7 +1147,8 @@
     "core-js": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -2467,14 +2459,6 @@
         "symbol-observable": "^1.0.4"
       }
     },
-    "omit.js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.2.tgz",
-      "integrity": "sha512-/QPc6G2NS+8d4L/cQhbk6Yit1WTB6Us2g84A7A/1+w9d/eRGHyEqC5kkQtHVoHZ5NFWGG7tUGgrhVZwgZanKrQ==",
-      "requires": {
-        "babel-runtime": "^6.23.0"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2970,11 +2954,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regexp.prototype.flags": {
       "version": "1.2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,7 +21,6 @@
     "find-up": "^4.1.0",
     "map-obj": "^4.1.0",
     "minimist": "^1.2.0",
-    "omit.js": "^1.0.2",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/netlify-plugin-no-more-404/matchRules.js
+++ b/packages/netlify-plugin-no-more-404/matchRules.js
@@ -10,14 +10,11 @@ async function matchRules(relativeUrl, projectDir) {
   return getMatcher(projectDir).then(matcher => {
     const reqUrl = new url.URL(relativeUrl, 'http://temp/')
     // const cookieValues = cookie.parse(req.headers.cookie || '')
-    // const headers = Object.assign(
-    //   {},
-    //   {
-    //     'x-language': cookieValues.nf_lang || getLanguage(req),
-    //     'x-country': cookieValues.nf_country || getCountry(req)
-    //   },
-    //   req.headers
-    // )
+    // const headers = {
+    //   'x-language': cookieValues.nf_lang || getLanguage(req),
+    //   'x-country': cookieValues.nf_country || getCountry(req),
+    //   ...req.headers
+    // }
 
     // Definition: https://github.com/netlify/libredirect/blob/e81bbeeff9f7c260a5fb74cad296ccc67a92325b/node/src/redirects.cpp#L28-L60
     const matchReq = {


### PR DESCRIPTION
Several of our dependencies are using object spreads, which limit our Node support to `8.3.0`. We could bundle and transpile our dependencies with Rollup to get `8.0.0` support. If we do so, our main core would be transpiled as well.

So we can safely use object spreads in our code instead of `Object.assign()`.