### PR TITLE
Allow `yarn` to be locally installed

### DIFF
--- a/packages/build/src/utils/install.js
+++ b/packages/build/src/utils/install.js
@@ -10,7 +10,7 @@ const installDependencies = async function(packageRoot) {
   const command = await getCommand(packageRoot)
 
   try {
-    await execa.command(command, { cwd: packageRoot, stdio: 'inherit' })
+    await execa.command(command, { cwd: packageRoot, stdio: 'inherit', preferLocal: true })
   } catch (error) {
     error.message = `Error while installing dependencies in ${packageRoot}\n${error.message}`
     throw error


### PR DESCRIPTION
This allows `yarn` to be locally installed (instead of globally) when automatically installing local plugins dependencies.