### PR TITLE
Allow test fixtures to contain `node_modules` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
+!packages/build/tests/fixtures/*/node_modules
+!packages/build/tests/fixtures/*/*/node_modules
 research
 .DS_Store
 terraform


### PR DESCRIPTION
This allows test fixtures to contain `node_modules` folder committed to the Git repository. This is useful for some tests.