### PR TITLE
Pass `config` to plugin initialization function

### DIFF
--- a/docs/creating-a-plugin.md
+++ b/docs/creating-a-plugin.md
@@ -112,9 +112,9 @@ Plugin configuration is also supplied top level if you are returning a dynamic p
 Instead of a plugin being a simple object, instead the plugin is a `function` that returns a plain old javascript object.
 
 ```js
-function helloWorldPlugin(conf) {
-  console.log(conf.foo) // bar
-  console.log(conf.fizz) // pop
+function helloWorldPlugin({ pluginConfig, config }) {
+  console.log(pluginConfig.foo) // bar
+  console.log(pluginConfig.fizz) // pop
   return {
     preBuild: ({ pluginConfig, config }) => {
       console.log('Hello world from preBuild lifecycle step!')

--- a/docs/creating-a-plugin.md
+++ b/docs/creating-a-plugin.md
@@ -112,7 +112,7 @@ Plugin configuration is also supplied top level if you are returning a dynamic p
 Instead of a plugin being a simple object, instead the plugin is a `function` that returns a plain old javascript object.
 
 ```js
-function helloWorldPlugin({ pluginConfig, config }) {
+function helloWorldPlugin(pluginConfig, config) {
   console.log(pluginConfig.foo) // bar
   console.log(pluginConfig.fizz) // pop
   return {

--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -7,7 +7,7 @@ const { getConstants } = require('./constants')
 // Retrieve list of hook methods of a plugin.
 // This also validates the plugin.
 const load = async function({ pluginId, type, pluginPath, pluginConfig, configPath, config, core }) {
-  const logic = getLogic(pluginPath, pluginConfig)
+  const logic = getLogic({ pluginPath, config, pluginConfig })
   validatePlugin(logic)
 
   const constants = getConstants(configPath, config)

--- a/packages/build/src/plugins/child/logic.js
+++ b/packages/build/src/plugins/child/logic.js
@@ -1,8 +1,8 @@
 // Require the plugin file and fire its top-level function.
 // The returned object is the `logic` which includes all hook methods.
-const getLogic = function(pluginPath, pluginConfig) {
+const getLogic = function({ pluginPath, config, pluginConfig }) {
   const logic = requireLogic(pluginPath)
-  const logicA = loadLogic(logic, pluginConfig)
+  const logicA = loadLogic({ logic, config, pluginConfig })
   return logicA
 }
 
@@ -15,13 +15,13 @@ const requireLogic = function(pluginPath) {
   }
 }
 
-const loadLogic = function(logic, pluginConfig) {
+const loadLogic = function({ logic, config, pluginConfig }) {
   if (typeof logic !== 'function') {
     return logic
   }
 
   try {
-    return logic(pluginConfig)
+    return logic({ config, pluginConfig })
   } catch (error) {
     error.message = `Error loading plugin:\n${error.message}`
     throw error

--- a/packages/build/src/plugins/child/logic.js
+++ b/packages/build/src/plugins/child/logic.js
@@ -21,7 +21,7 @@ const loadLogic = function({ logic, config, pluginConfig }) {
   }
 
   try {
-    return logic({ config, pluginConfig })
+    return logic(pluginConfig, config)
   } catch (error) {
     error.message = `Error loading plugin:\n${error.message}`
     throw error

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -3,7 +3,7 @@ const { getApiClient } = require('./api')
 
 // Run a specific plugin hook
 const run = async function({ pluginPath, pluginConfig, hookName, config, token, error, constants }) {
-  const logic = getLogic(pluginPath, pluginConfig)
+  const logic = getLogic({ pluginPath, config, pluginConfig })
   const api = getApiClient({ logic, token })
   await logic[hookName]({ api, constants, pluginConfig, config, error })
   return {}

--- a/packages/netlify-plugin-no-more-404/index.js
+++ b/packages/netlify-plugin-no-more-404/index.js
@@ -9,7 +9,7 @@ const matchRules = require('./matchRules')
 // const test404plugin = true // toggle this off for production
 const test404plugin = false // toggle this off for production
 
-function netlify404nomore({ pluginConfig }) {
+function netlify404nomore(pluginConfig) {
   let on404 = pluginConfig.on404 || 'error' // either 'warn' or 'error'
   let cacheKey = pluginConfig.cacheKey || 'pluginNoMore404Cache' // string - helps to quickly switch to a new cache if a mistake was made
   return {

--- a/packages/netlify-plugin-no-more-404/index.js
+++ b/packages/netlify-plugin-no-more-404/index.js
@@ -9,9 +9,9 @@ const matchRules = require('./matchRules')
 // const test404plugin = true // toggle this off for production
 const test404plugin = false // toggle this off for production
 
-function netlify404nomore(conf) {
-  let on404 = conf.on404 || 'error' // either 'warn' or 'error'
-  let cacheKey = conf.cacheKey || 'pluginNoMore404Cache' // string - helps to quickly switch to a new cache if a mistake was made
+function netlify404nomore({ pluginConfig }) {
+  let on404 = pluginConfig.on404 || 'error' // either 'warn' or 'error'
+  let cacheKey = pluginConfig.cacheKey || 'pluginNoMore404Cache' // string - helps to quickly switch to a new cache if a mistake was made
   return {
     /* index html files preDeploy */
     preDeploy: async opts => {

--- a/packages/netlify-plugin-notifier/index.js
+++ b/packages/netlify-plugin-notifier/index.js
@@ -2,7 +2,7 @@ const TwilioSdk = require('twilio')
 
 const pkg = require('./package.json')
 
-module.exports = function netlifyNotifyPlugin({ pluginConfig }) {
+module.exports = function netlifyNotifyPlugin(pluginConfig) {
   const { notices, sms, email, webhook } = pluginConfig
 
   if (!notices) {

--- a/packages/netlify-plugin-notifier/index.js
+++ b/packages/netlify-plugin-notifier/index.js
@@ -2,7 +2,7 @@ const TwilioSdk = require('twilio')
 
 const pkg = require('./package.json')
 
-module.exports = function netlifyNotifyPlugin(pluginConfig) {
+module.exports = function netlifyNotifyPlugin({ pluginConfig }) {
   const { notices, sms, email, webhook } = pluginConfig
 
   if (!notices) {


### PR DESCRIPTION
We are passing the `pluginConfig` to plugins initialization functions, but we should also be passing the `config`. 

For example I needed this when working on the `functions` core plugin.