### PR TITLE
Add recommendations on keywords to add to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ plugins:
       - jim@netlify.com
 ```
 
+Netlify plugins can be found on npm by
+[searching for `keywords:netlify-build-plugin`](https://www.npmjs.com/search?q=keywords%3Anetlify-build-plugin).
+
 ## Lifecycle
 
 The build process runs through a series of lifecycle `events`. These events are the places we can hook into and extend how the Netlify build operates.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ plugins:
 ```
 
 Netlify plugins can be found on npm by
-[searching for `keywords:netlify-build-plugin`](https://www.npmjs.com/search?q=keywords%3Anetlify-build-plugin).
+[searching for `keywords:netlify-plugin`](https://www.npmjs.com/search?q=keywords%3Anetlify-plugin).
 
 ## Lifecycle
 

--- a/docs/creating-a-plugin.md
+++ b/docs/creating-a-plugin.md
@@ -131,3 +131,15 @@ Plugins as functions returning the object is a powerful way to provide advanced 
 - Returning only specific lifecycles to execute based on config
 - Giving plugin users the ability to customize order of execution of functionality
 - Preforming input validation on configuration to fail fast if invalid values are passed in
+
+## Publishing a plugin
+
+The
+[`name` property in `package.json`](https://docs.npmjs.com/files/package.json#name)
+should start with `netlify-plugin-` (such as `netlify-plugin-example`).
+
+It is recommended for the GitHub repository to be named like this as well.
+
+The
+[`keywords` property in `package.json`](https://docs.npmjs.com/files/package.json#keywords) and the [GitHub topics](https://github.com/topics)
+should contain the `netlify` and `netlify-build-plugin` keywords.

--- a/docs/creating-a-plugin.md
+++ b/docs/creating-a-plugin.md
@@ -136,10 +136,11 @@ Plugins as functions returning the object is a powerful way to provide advanced 
 
 The
 [`name` property in `package.json`](https://docs.npmjs.com/files/package.json#name)
-should start with `netlify-plugin-` (such as `netlify-plugin-example`).
+should start with `netlify-plugin-` (such as `netlify-plugin-example` or
+`@scope/netlify-plugin-example`).
 
 It is recommended for the GitHub repository to be named like this as well.
 
 The
 [`keywords` property in `package.json`](https://docs.npmjs.com/files/package.json#keywords) and the [GitHub topics](https://github.com/topics)
-should contain the `netlify` and `netlify-build-plugin` keywords.
+should contain the `netlify` and `netlify-plugin` keywords.

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "keywords": [
     "netlify",
-    "netlify-build",
-    "netlify-build-plugin"
+    "netlify-plugin"
   ],
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
       "pre-push": "npm test"
     }
   },
+  "keywords": [
+    "netlify",
+    "netlify-build",
+    "netlify-build-plugin"
+  ],
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Follow-up on #107.

This documents some npm keywords and GitHub topics that plugin authors should add to their plugins, so that users can easily find/search them.