### PR TITLE
Speed up linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ terraform
 lerna-debug.log
 .nyc_output
 coverage
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs": "node ./scripts/docs.js",
     "test": "run-s test:* test:dev:*",
     "test-ci": "run-s test:* test:ci:*",
-    "test:lint": "eslint --ignore-path .gitignore --fix \"{packages,examples}/**/*.js\"",
+    "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{packages,examples}/**/*.js\"",
     "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{packages,examples}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
     "test:dev:ava": "ava",
     "test:ci:ava": "nyc -r lcovonly -r text ava",


### PR DESCRIPTION
This speeds up ESLint by using caching.

This also print errors with the source code lines that failed.