### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ how the Netlify build operates.
 | :---------------------------------------------------------------------------------- | :------------------------------------------ |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleinit">init</a>** ‏‏‎ ‏‏‎ ‏‏‎                     | Runs before anything else                   |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecyclegetcache">getCache</a>** ‏‏‎ ‏‏‎ ‏‏‎             | Fetch previous build cache                  |
-| ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleinstall">install</a>** ‏‏‎ ‏‏‎ ‏‏‎               | Install project dependancies                |
+| ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleinstall">install</a>** ‏‏‎ ‏‏‎ ‏‏‎               | Install project dependencies                |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleprebuild">preBuild</a>** ‏‏‎ ‏‏‎ ‏‏‎             | Runs before functions & build commands run  |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecyclefunctionsbuild">functionsBuild</a>** ‏‏‎ ‏‏‎ ‏‏‎ | Build the serverless functions              |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecyclebuild">build</a>** ‏‏‎ ‏‏‎ ‏‏‎                   | Build commands are executed                 |
@@ -248,7 +248,7 @@ build:
 
 ### lifecycle.install
 
-`install` - Install project dependancies
+`install` - Install project dependencies
 
 <details>
   <summary>Using install</summary>
@@ -681,7 +681,7 @@ foo: ${env:MY_ENV_VAR}
 
 Netlify Plugins extend the functionality of the netlify build process.
 
-Plugins are POJOs (plain old javascript objects) that allow users to hook into the different lifecycle steps happening
+Plugins are POJOs (plain old JavaScript objects) that allow users to hook into the different lifecycle steps happening
 during their site builds.
 
 For example, hooking into the `preBuild` step to run something before your build command. Or the `postBuild` hook for

--- a/docs/creating-a-plugin.md
+++ b/docs/creating-a-plugin.md
@@ -2,7 +2,7 @@
 
 Netlify Plugins extend the functionality of the Netlify Build process.
 
-Plugins are plain javascript objects that allow users to hook into the different lifecycle steps happening during their
+Plugins are plain JavaScript objects that allow users to hook into the different lifecycle steps happening during their
 site builds.
 
 For example, hooking into the `preBuild` step to run something before your build command. Or the `postBuild` hook for
@@ -16,7 +16,7 @@ running things after your site build has completed.
 | :------------------------------------------- | :------------------------------------------ |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **init** ‏‏‎ ‏‏‎ ‏‏‎           | Runs before anything else                   |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **getCache** ‏‏‎ ‏‏‎ ‏‏‎       | Fetch previous build cache                  |
-| ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **install** ‏‏‎ ‏‏‎ ‏‏‎        | Install project dependancies                |
+| ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **install** ‏‏‎ ‏‏‎ ‏‏‎        | Install project dependencies                |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **preBuild** ‏‏‎ ‏‏‎ ‏‏‎       | Runs before functions & build commands run  |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **functionsBuild** ‏‏‎ ‏‏‎ ‏‏‎ | Build the serverless functions              |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **build** ‏‏‎ ‏‏‎ ‏‏‎          | Build commands are executed                 |
@@ -30,7 +30,7 @@ running things after your site build has completed.
 
 ## Anatomy of a plugin
 
-Plugins are javascript objects like so:
+Plugins are JavaScript objects like so:
 
 ```js
 const helloWorldPlugin = {
@@ -111,7 +111,7 @@ module.exports = helloWorldPlugin
 
 Plugin configuration is also supplied top level if you are returning a dynamic plugin.
 
-Instead of a plugin being a simple object, instead the plugin is a `function` that returns a plain old javascript
+Instead of a plugin being a simple object, instead the plugin is a `function` that returns a plain old JavaScript
 object.
 
 ```js

--- a/examples/example-two/README.md
+++ b/examples/example-two/README.md
@@ -4,7 +4,7 @@ This is a demo site showcasing the new Netlify Build features & lifecycle hooks.
 
 ## Setup
 
-Install dependancies
+Install dependencies
 
 ```
 npm install
@@ -39,7 +39,7 @@ how the Netlify build operates.
 | :---------------------------------------------------------------------------------- | :------------------------------------------ |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleinit">init</a>** ‏‏‎ ‏‏‎ ‏‏‎                     | Runs before anything else                   |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecyclegetcache">getCache</a>** ‏‏‎ ‏‏‎ ‏‏‎             | Fetch previous build cache                  |
-| ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleinstall">install</a>** ‏‏‎ ‏‏‎ ‏‏‎               | Install project dependancies                |
+| ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleinstall">install</a>** ‏‏‎ ‏‏‎ ‏‏‎               | Install project dependencies                |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecycleprebuild">preBuild</a>** ‏‏‎ ‏‏‎ ‏‏‎             | Runs before functions & build commands run  |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecyclefunctionsbuild">functionsBuild</a>** ‏‏‎ ‏‏‎ ‏‏‎ | Build the serverless functions              |
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **<a href="#lifecyclebuild">build</a>** ‏‏‎ ‏‏‎ ‏‏‎                   | Build commands are executed                 |
@@ -76,7 +76,7 @@ The Lifecycle flows through events and their `pre` and `post` counterparts.
 
 ## Plugins
 
-Plugins are POJOs (plain old javascript objects) with methods that match the various lifecycle events.
+Plugins are POJOs (plain old JavaScript objects) with methods that match the various lifecycle events.
 
 ```js
 function exampleNetlifyPlugin(config) {

--- a/packages/build/src/core/lifecycle.js
+++ b/packages/build/src/core/lifecycle.js
@@ -10,7 +10,7 @@ const LIFECYCLE = [
   'getCache',
   'postGetCache',
   /**
-   * `install` - Install project dependancies
+   * `install` - Install project dependencies
    */
   'preInstall',
   'install',

--- a/packages/build/src/scaffold/main.js
+++ b/packages/build/src/scaffold/main.js
@@ -1,5 +1,5 @@
 /**
- * (WIP) Scaffold docker image, update dependancies, set correct language libs
+ * (WIP) Scaffold docker image, update dependencies, set correct language libs
  * Node port of https://github.com/netlify/build-image/blob/xenial/run-build.sh
  */
 const execa = require('execa')


### PR DESCRIPTION
This fixes the following spelling typos:
  - `javascript` -> `JavaScript`
  - `dependancies` -> `dependencies`