### PR TITLE
Fix secrets redacting

### DIFF
--- a/packages/build/src/log/patch.js
+++ b/packages/build/src/log/patch.js
@@ -19,8 +19,8 @@ const serializeArg = function(arg, state) {
 }
 
 const redactProcess = function(childProcess) {
-  childProcess.stdout.pipe(replaceStream(secrets, '[secrets]')).pipe(process.stdout)
-  childProcess.stderr.pipe(replaceStream(secrets, '[secrets]')).pipe(process.stderr)
+  childProcess.stdout.pipe(replaceStream(secrets, '[secure]')).pipe(process.stdout)
+  childProcess.stderr.pipe(replaceStream(secrets, '[secure]')).pipe(process.stderr)
 }
 
 const SECRETS = ['SECRET_ENV_VAR', 'MY_API_KEY']


### PR DESCRIPTION
Secrets were being redacted as `[secure]` inside user commands but as `[secrets]` inside plugins. This PR makes it more consistent.