### PR TITLE
Fix output streaming in the BuildBot

### DIFF
--- a/packages/build/src/log/patch.js
+++ b/packages/build/src/log/patch.js
@@ -14,16 +14,22 @@ const log = function(...args) {
 
 const serializeArg = function(arg, state) {
   const argA = typeof arg === 'string' ? arg : inspect(arg, { depth: Infinity })
-  const argB = redactEnv.redact(argA, secrets)
+  const argB = redactString(argA)
   return argB
 }
 
-const redactProcess = function(childProcess) {
-  childProcess.stdout.pipe(replaceStream(secrets, '[secure]')).pipe(process.stdout)
-  childProcess.stderr.pipe(replaceStream(secrets, '[secure]')).pipe(process.stderr)
+const redactString = function(string) {
+  return redactEnv.redact(string, secrets)
+}
+
+const redactProcess = function({ stdout, stderr, all }) {
+  const stdoutA = stdout.pipe(replaceStream(secrets, '[secure]'))
+  const stderrA = stderr.pipe(replaceStream(secrets, '[secure]'))
+  const allA = all.pipe(replaceStream(secrets, '[secure]'))
+  return { stdout: stdoutA, stderr: stderrA, all: allA }
 }
 
 const SECRETS = ['SECRET_ENV_VAR', 'MY_API_KEY']
 const secrets = redactEnv.build(SECRETS)
 
-module.exports = { log, redactProcess }
+module.exports = { log, redactString, redactProcess }

--- a/packages/build/src/log/stream.js
+++ b/packages/build/src/log/stream.js
@@ -1,0 +1,37 @@
+const isNetlifyCI = require('../utils/is-netlify-ci.js')
+
+const { redactProcess, redactString } = require('./patch')
+
+// In CI, we need to buffer child processes output at the moment due to the
+// current BuildBot not handling it correctly.
+// But locally we want to stream output instead for a better developer
+// experience.
+// See https://github.com/netlify/build/issues/343
+const streamProcessOutput = function(childProcess) {
+  const { stdout, stderr, all } = redactProcess(childProcess)
+
+  if (!shouldBuffer()) {
+    stdout.pipe(process.stdout)
+    stderr.pipe(process.stderr)
+  }
+
+  return all
+}
+
+const writeProcessOutput = function(output) {
+  if (shouldBuffer()) {
+    process.stdout.write(output)
+  }
+}
+
+const writeProcessError = function({ all }) {
+  if (shouldBuffer()) {
+    process.stdout.write(`${redactString(all)}\n`)
+  }
+}
+
+const shouldBuffer = function() {
+  return isNetlifyCI()
+}
+
+module.exports = { streamProcessOutput, writeProcessOutput, writeProcessError }


### PR DESCRIPTION
Fixes #343.

The current BuildBot is not handling child processes streaming properly. This fixes it:
  - when run in the BuildBot, plugins output is printed all at once (each time some plugin lifecycle has eneded)
  - when run locally, plugins output is streamed