### PR TITLE
Fix bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,7 +41,7 @@ Command line options and/or configuration file, if any.
 Enter the following command in a terminal and copy/paste its output:
 
 ```bash
-npx envinfo --system --binaries --npmPackages @netlify/build @netlify/config netlify-cli
+npx envinfo --system --binaries --npmPackages @netlify/build,@netlify/config,netlify-cli
 ```
 
 **Screenshots**


### PR DESCRIPTION
This fixes the bug report template. The `envinfo` command line has a syntax error.