### PR TITLE
Fix dry run

### DIFF
--- a/packages/build/src/core/dry.js
+++ b/packages/build/src/core/dry.js
@@ -1,12 +1,13 @@
 const { logDryRunStart, logDryRunInstruction, logDryRunEnd } = require('../log/main')
 
 // If the `dry` option is specified, do a dry run
-const doDryRun = function({ buildInstructions, configPath }) {
-  logDryRunStart()
+const doDryRun = function({ buildInstructions, buildInstructions: { length }, configPath }) {
+  const hookWidth = Math.max(...buildInstructions.map(getHookLength))
 
-  const width = Math.max(...buildInstructions.map(getHookLength))
+  logDryRunStart(hookWidth, length)
+
   buildInstructions.forEach((instruction, index) => {
-    logDryRunInstruction({ instruction, index, configPath, width, buildInstructions })
+    logDryRunInstruction({ instruction, index, configPath, hookWidth, length })
   })
 
   logDryRunEnd()


### PR DESCRIPTION
This fixes the following issues with dry run:
  - it did not work when 0 hooks were run (e.g. empty configuration file)
  - the header was misaligned when all hook names were very short