### PR TITLE
Improve `--config` option resolution

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -4,9 +4,6 @@ require('../utils/polyfills')
 const { setColorLevel } = require('../log/colors')
 setColorLevel()
 
-const resolveConfig = require('@netlify/config')
-const { getConfigPath } = require('@netlify/config')
-
 const { getPluginsOptions } = require('../plugins/options')
 const { installPlugins } = require('../plugins/install')
 const { loadPlugins } = require('../plugins/load')
@@ -85,5 +82,3 @@ const build = async function(options) {
 }
 
 module.exports = build
-module.exports.resolveConfig = resolveConfig
-module.exports.getConfigPath = getConfigPath

--- a/packages/config/package-lock.json
+++ b/packages/config/package-lock.json
@@ -2154,6 +2154,14 @@
         "path-exists": "^3.0.0"
       },
       "dependencies": {
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2554,11 +2562,11 @@
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^2.2.0"
       }
     },
     "p-map": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,6 +21,7 @@
     "find-up": "^4.1.0",
     "map-obj": "^4.1.0",
     "minimist": "^1.2.0",
+    "p-locate": "^4.1.0",
     "path-exists": "^4.0.0",
     "resolve": "^1.12.0"
   },

--- a/packages/config/path.js
+++ b/packages/config/path.js
@@ -1,9 +1,12 @@
 const findUp = require('find-up')
+const pLocate = require('p-locate')
 
 // Retrieve path to the configuration file.
 // Lookup from `cwd` (default: current directory) to find any file named
 // `netlify.toml`, `netlify.yml`, etc.
-const getConfigPath = async function(cwd) {
+const getConfigPath = async function(cwds) {
+  const cwdsA = Array.isArray(cwds) ? cwds : [cwds]
+  const cwd = await pLocate(cwdsA, async cwd => Boolean(await findUp(FILENAMES, { cwd })))
   const configPath = await findUp(FILENAMES, { cwd })
 
   if (configPath === undefined) {


### PR DESCRIPTION
This allows using several base directories to search for the configuration file when using `getConfigPath()`. For example the CLI searches first for `process.cwd()` then for `site.root`.