### PR TITLE
Move some code around

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -11,6 +11,7 @@ const { loadPlugins } = require('../plugins/load')
 const { logBuildStart, logBuildError, logBuildSuccess, logBuildEnd } = require('../log/main')
 const { startTimer, endTimer } = require('../log/timer')
 const isNetlifyCI = require('../utils/is-netlify-ci')
+const { trackBuildComplete } = require('../utils/telemetry')
 
 const { getOptions } = require('./options')
 const { loadConfig } = require('./config')
@@ -61,6 +62,7 @@ const build = async function(options) {
     logBuildSuccess()
     const duration = endTimer(buildTimer, 'Netlify Build')
     logBuildEnd({ buildInstructions, config, duration })
+    trackBuildComplete({ buildInstructions, config, duration })
     return true
   } catch (error) {
     logBuildError(error)

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -3,7 +3,6 @@ const { basename } = require('path')
 const { tick, pointer, arrowDown } = require('figures')
 const omit = require('omit.js')
 
-const telemetry = require('../utils/telemetry')
 const { version } = require('../../package.json')
 
 const { log } = require('./logger')
@@ -194,14 +193,6 @@ const logBuildSuccess = function() {
 const logBuildEnd = function({ buildInstructions, config, duration }) {
   const sparkles = cyanBright('(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧')
   log(`\n${sparkles} Have a nice day!\n`)
-  const plugins = Object.values(config.plugins).map(({ type }) => type)
-  // telemetry noOps if BUILD_TELEMETRY_DISBALED set
-  telemetry.track('buildComplete', {
-    steps: buildInstructions.length,
-    duration,
-    pluginCount: plugins.length,
-    plugins,
-  })
 }
 
 module.exports = {

--- a/packages/build/src/utils/telemetry/index.js
+++ b/packages/build/src/utils/telemetry/index.js
@@ -14,4 +14,20 @@ const telemetry = Analytics({
   plugins: plugins,
 })
 
-module.exports = telemetry
+// Send telemetry request when build completes
+const trackBuildComplete = function({ buildInstructions, config, duration }) {
+  const plugins = Object.values(config.plugins).map(getPluginType)
+
+  telemetry.track('buildComplete', {
+    steps: buildInstructions.length,
+    duration,
+    pluginCount: plugins.length,
+    plugins,
+  })
+}
+
+const getPluginType = function({ type }) {
+  return type
+}
+
+module.exports = { trackBuildComplete }


### PR DESCRIPTION
This moves lines of code around to keep the logging file only related to console logging.