### PR TITLE
Improve CI speed more

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -6,5 +6,4 @@ export default {
   environmentVariables: {
     BUILD_TELEMETRY_DISABLED: 'true',
   },
-  serial: Boolean(process.env.GITHUB_ACTION),
 }


### PR DESCRIPTION
This improves the CI speed by increasing parallelism. Ava defaults to 2 test files in parallel at once when run in CI.