### PR TITLE
Add `debug` option to test helpers

### DIFF
--- a/packages/build/tests/README.md
+++ b/packages/build/tests/README.md
@@ -55,6 +55,7 @@ An additional object can be passed to `runFixture()` with the following options:
 - `flags` `{string[]}`: other CLI flags
 - `cwd` `{string}`: current directory
 - `env` `{object}`: environment variables
+- `debug` `{boolean}`: see [below](#output-normalization)
 
 You usually do not need to specify any of those options except `flags` when testing specific CLI flags.
 
@@ -111,3 +112,9 @@ Sometimes the `netlify-build` output contains non-deterministic information such
 
 Those would make the test snapshot non-reproducible. To fix this, the output is normalized by `./helpers/normalize.js`.
 This basically performs a series of regular expressions replacements.
+
+If you want to remove the normalization during debugging, use the `debug` option:
+
+```js
+await runFixture(t, 'fixture_name', { debug: true })
+```


### PR DESCRIPTION
This adds a `debug` option to test helpers to print the non-normalized output of `netlify-build`.

The option is documented in the tests `README.md`.