### PR TITLE
Fix process errors logging

### DIFF
--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -26,7 +26,7 @@ const bootPlugin = async function() {
 // On uncaught exceptions and unhandled rejections, print the stack trace.
 // Also, prevent child processes from crashing on uncaught exceptions.
 const handleProcessErrors = function() {
-  logProcessErrors({ log: handleProcessError, colors: hasColors(), exitOn: [] })
+  logProcessErrors({ log: handleProcessError, colors: hasColors(), exitOn: [], level: { multipleResolves: 'silent' } })
 }
 
 const handleProcessError = async function(error, level) {


### PR DESCRIPTION
When a promise is resolved twice, an error is currently printed. This PR fixes this.