### PR TITLE
Fix netlify-functions-core on Windows

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -5209,6 +5209,11 @@
         "autolinker": "~0.28.0"
       }
     },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -5966,6 +5971,24 @@
         "mkdirp": "^0.5.1",
         "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
+      }
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "requires": {
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "update-notifier": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -54,6 +54,7 @@
     "replacestream": "^4.0.3",
     "resolve": "^1.12.0",
     "strip-ansi": "^5.2.0",
+    "unixify": "^1.0.0",
     "yargs": "^14.2.0"
   },
   "devDependencies": {

--- a/packages/build/src/plugins/functions/index.js
+++ b/packages/build/src/plugins/functions/index.js
@@ -4,6 +4,7 @@ const pathExists = require('path-exists')
 const fastGlob = require('fast-glob')
 const readdirp = require('readdirp')
 const { zipFunctions } = require('@netlify/zip-it-and-ship-it')
+const unixify = require('unixify')
 
 const { installDependencies } = require('../../utils/install')
 
@@ -27,7 +28,8 @@ const init = async function({ constants: { FUNCTIONS_SRC } }) {
 
 // Install Netlify functions dependencies
 const install = async function({ constants: { FUNCTIONS_SRC } }) {
-  const packagePaths = await fastGlob([`${FUNCTIONS_SRC}/**/package.json`, `!${FUNCTIONS_SRC}/**/node_modules`], {
+  const base = unixify(FUNCTIONS_SRC)
+  const packagePaths = await fastGlob([`${base}/**/package.json`, `!${base}/**/node_modules`], {
     onlyFiles: true,
     unique: true,
   })


### PR DESCRIPTION
Since the introduction of the `FUNCTIONS_SRC` constant, `netlify-functions-core` stopped working on Windows due to the introduction of OS-specific path delimiters. This PR fixes that.