### PR TITLE
Fix plugin output sometimes missing

### DIFF
--- a/packages/build/src/core/instructions.js
+++ b/packages/build/src/core/instructions.js
@@ -115,7 +115,7 @@ const execCommand = async function({ hook, command, baseDir }) {
     error.cleanStack = true
     throw error
   } finally {
-    stopOutput(childProcess, chunks)
+    await stopOutput(childProcess, chunks)
   }
 }
 
@@ -137,7 +137,7 @@ const firePluginHook = async function({ id, childProcess, hook, hookName }, { er
     error.cleanStack = true
     throw error
   } finally {
-    stopOutput(childProcess, chunks)
+    await stopOutput(childProcess, chunks)
   }
 }
 


### PR DESCRIPTION
The output from plugins was sometimes missing due to child process's output not being flushed out. This PR fixes this.