### PR TITLE
Improve parent/child IPC for plugins parallelization

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -6106,6 +6106,11 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -56,6 +56,7 @@
     "string-width": "^4.1.0",
     "strip-ansi": "^5.2.0",
     "unixify": "^1.0.0",
+    "uuid": "^3.3.3",
     "yargs": "^14.2.0"
   },
   "devDependencies": {

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -47,10 +47,10 @@ const handleError = async function({ stack }) {
 
 // Wait for events from parent to perform plugin methods
 const handleEvents = async function(state) {
-  await getEventsFromParent((eventName, payload) => handleEvent(eventName, payload, state))
+  await getEventsFromParent((callId, eventName, payload) => handleEvent(callId, eventName, payload, state))
 }
 
-const handleEvent = async function(eventName, { callId, ...payload }, state) {
+const handleEvent = async function(callId, eventName, payload, state) {
   const response = await EVENTS[eventName](payload, state)
   await sendEventToParent(callId, response)
 }

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -41,8 +41,8 @@ const handleProcessError = async function(error, level) {
   await handleError(error)
 }
 
-const handleError = async function(error) {
-  await sendEventToParent('error', { stack: error.stack })
+const handleError = async function({ stack }) {
+  await sendEventToParent('error', { stack })
 }
 
 // Wait for events from parent to perform plugin methods

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -20,7 +20,7 @@ const bootPlugin = async function() {
     // We need to fire them in parallel because `process.send()` can be slow
     // to await, i.e. parent might send `load` event before child `ready` event
     // returns.
-    await Promise.all([handleEvents(state), sendEventToParent('ready', { callId: 'ready' })])
+    await Promise.all([handleEvents(state), sendEventToParent('ready')])
   } catch (error) {
     await handleError(error)
   }
@@ -52,7 +52,7 @@ const handleEvents = async function(state) {
 
 const handleEvent = async function(eventName, { callId, ...payload }, state) {
   const response = await EVENTS[eventName](payload, state)
-  await sendEventToParent(eventName, { ...response, callId })
+  await sendEventToParent(callId, response)
 }
 
 // Initial plugin load
@@ -66,7 +66,6 @@ const load = function(payload, state) {
 const run = async function({ hookName, error }, { context: { hooks, api, constants, pluginConfig, config } }) {
   const { method } = hooks.find(hookA => hookA.hookName === hookName)
   await method({ api, constants, pluginConfig, config, error })
-  return {}
 }
 
 const EVENTS = { load, run }

--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -16,7 +16,12 @@ const callChild = async function(childProcess, eventName, payload) {
 }
 
 // Receive event from child to parent process
-// Wait for `message` event. However stops if child process exits.
+// Wait for either:
+//  - `message` event with a specific `callId`
+//  - `message` event with an `error` `callId` indicating an exception in the
+//    child process
+//  - child process `exit`
+// In the later two cases, we propagate the error.
 // We need to make `p-event` listeners are properly cleaned up too.
 const getEventFromChild = async function(childProcess, callId) {
   if (!childProcess.connected) {

--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -10,7 +10,7 @@ const callChild = async function(childProcess, eventName, payload) {
   const callId = uuid()
   const [response] = await Promise.all([
     getEventFromChild(childProcess, callId),
-    sendEventToChild(childProcess, eventName, { ...payload, callId }),
+    sendEventToChild(childProcess, callId, eventName, payload),
   ])
   return response
 }
@@ -57,8 +57,8 @@ Instead of calling process.exit(), plugin methods should either return (on succe
 }
 
 // Send event from parent to child process
-const sendEventToChild = async function(childProcess, eventName, payload) {
-  await promisify(childProcess.send.bind(childProcess))([eventName, payload])
+const sendEventToChild = async function(childProcess, callId, eventName, payload) {
+  await promisify(childProcess.send.bind(childProcess))([callId, eventName, payload])
 }
 
 // Respond to events from parent to child process.
@@ -67,8 +67,8 @@ const getEventsFromParent = async function(callback) {
   return new Promise((resolve, reject) => {
     process.on('message', async message => {
       try {
-        const [eventName, payload] = message
-        await callback(eventName, payload)
+        const [callId, eventName, payload] = message
+        await callback(callId, eventName, payload)
       } catch (error) {
         reject(error)
       }

--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -34,14 +34,14 @@ const getEventFromChild = async function(childProcess, callId) {
   }
 }
 
-const isCorrectMessage = function(callId, [eventName, response]) {
-  return eventName === 'error' || callId === response.callId
+const isCorrectMessage = function(expectedCallId, [actualCallId]) {
+  return actualCallId === 'error' || actualCallId === expectedCallId
 }
 
 const getMessage = async function(messagePromise) {
-  const [eventName, response] = await messagePromise
+  const [callId, response] = await messagePromise
 
-  if (eventName === 'error') {
+  if (callId === 'error') {
     throw new Error(response.stack)
   }
 
@@ -75,8 +75,8 @@ const getEventsFromParent = async function(callback) {
 }
 
 // Send event from child to parent process
-const sendEventToParent = async function(eventName, payload) {
-  await promisify(process.send.bind(process))([eventName, payload])
+const sendEventToParent = async function(callId, payload) {
+  await promisify(process.send.bind(process))([callId, payload])
 }
 
 module.exports = {

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -34,7 +34,7 @@ const loadPlugin = async function(
   const { childProcess } = childProcesses[index]
 
   try {
-    const hooks = await callChild(childProcess, 'load', {
+    const { hooks } = await callChild(childProcess, 'load', {
       id,
       type,
       pluginPath,

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -3,7 +3,7 @@ const groupBy = require('group-by')
 const { logLoadPlugins, logLoadPlugin } = require('../log/main')
 
 const { isNotOverridden } = require('./override')
-const { sendEventToChild, getEventFromChild } = require('./ipc')
+const { callChild } = require('./ipc')
 
 // Retrieve plugin hooks for all plugins
 // Can use either a module name or a file path to the plugin.
@@ -34,23 +34,17 @@ const loadPlugin = async function(
   const { childProcess } = childProcesses[index]
 
   try {
-    // We need to fire them in parallel because `process.send()` can be slow
-    // to await, i.e. child might send `load` event before parent `load` event
-    // returns.
-    const [{ payload: hooks }] = await Promise.all([
-      getEventFromChild(childProcess, 'load'),
-      sendEventToChild(childProcess, 'load', {
-        id,
-        type,
-        pluginPath,
-        pluginConfig,
-        config,
-        configPath,
-        core,
-        baseDir,
-        token,
-      }),
-    ])
+    const hooks = await callChild(childProcess, 'load', {
+      id,
+      type,
+      pluginPath,
+      pluginConfig,
+      config,
+      configPath,
+      core,
+      baseDir,
+      token,
+    })
     const hooksA = hooks.map(hook => ({ ...hook, childProcess }))
     return hooksA
   } catch (error) {


### PR DESCRIPTION
The current plugins IPC relies on the assumption that a plugin's hooks are run serially. This won't be true anymore once we introduce plugins parallelization. This would lead to plugin hooks being resolved in random order, making the build crash.

This PR solves this problem by introducing multiplexing to plugins (similar to how HTTP/2 does it).