### PR TITLE
Add `snapshot` test parameter

### DIFF
--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -23,7 +23,8 @@ const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
 //  - `config` {string}: `--config` CLI flag
 //  - `cwd` {string}: current directory when calling `netlify-build`
 //  - `env` {object}: environment variable
-const runFixture = async function(t, fixtureName, { flags = '', config, cwd, env, debug } = {}) {
+//  - `snapshot` {boolean}: whether to create a snapshot
+const runFixture = async function(t, fixtureName, { flags = '', config, cwd, env, debug, snapshot = true } = {}) {
   const configFlag = getConfigFlag(config, fixtureName)
   const binaryPath = await BINARY_PATH
   const { all, exitCode } = await execa.command(`${binaryPath} ${configFlag} ${flags}`, {
@@ -35,7 +36,7 @@ const runFixture = async function(t, fixtureName, { flags = '', config, cwd, env
   })
 
   const isPrint = PRINT === '1'
-  doTestAction({ t, all, isPrint, debug })
+  doTestAction({ t, all, isPrint, debug, snapshot })
 
   return { all, exitCode }
 }
@@ -60,14 +61,16 @@ const getConfigFlag = function(config, fixtureName) {
 // The `PRINT` environment variable can be set to `1` to run the test in print
 // mode. Print mode is a debugging mode which shows the test output but does
 // not create nor compare its snapshot.
-const doTestAction = function({ t, all, isPrint, debug = isPrint }) {
+const doTestAction = function({ t, all, isPrint, debug = isPrint, snapshot }) {
   const allA = debug ? all : normalizeOutput(all)
 
   if (isPrint) {
     return printOutput(t, allA)
   }
 
-  t.snapshot(allA)
+  if (snapshot) {
+    t.snapshot(allA)
+  }
 }
 
 const printOutput = function(t, all) {


### PR DESCRIPTION
This adds a `snapshot` parameter to the test utility to configuring snapshots.