### PR TITLE
Add Codecov

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,6 +28,5 @@ jobs:
         run: npm run test-ci
       - name: Codecov test coverage
         run:
-          os="${{ matrix.os }}" && os="${os/-latest/}" && node="${{ matrix.node }}}" && node="node_${node//./_}" && curl
-          -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
-          secrets.CODECOV_TOKEN }} -F "$os" -F "$node"
+          curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
+          secrets.CODECOV_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,22 +26,9 @@ jobs:
         run: npm install
       - name: Tests
         run: npm run test-ci
-      - name: Coveralls test coverage
-        uses: coverallsapp/github-action@master
+      - name: Codecov test coverage
+        uses: codecov/codecov-action@1.0.3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: 'true'
-      ## Parallel test coverages do not currently work with Coveralls
-      ## See https://github.com/coverallsapp/github-action/issues/13
-      ## and https://github.com/coverallsapp/github-action/issues/18
-      ## Which means only the fastest build (usually either Linux or Mac) is used.
-      ## When this is fixed, the following lines should be commented out.
-      # coverage:
-      #   needs: build
-      #   runs-on: ubuntu-latest
-      #   steps:
-      - name: Coveralls finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: 'true'
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage/coverage-final.json
+          flags: ${{ matrix.os }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Tests
         run: npm run test-ci
       - name: Codecov test coverage
-        run: bash scripts/coverage.sh
+        run: bash scripts/coverage.sh "${{ secrets.CODECOV_TOKEN }}" "${{ matrix.os }}" "${{ matrix.node }}"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm run test-ci
       - name: Codecov test coverage
         run:
-          os="${{ matrix.os }}" && os="${os/-latest/}" && curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml
-          -f coverage/coverage-final.json -t ${{ secrets.CODECOV_TOKEN }} -F "$os"
-          # -F node_${{ matrix.node }}
+          os="${{ matrix.os }}" && os="${os/-latest/}" && node="${{ matrix.node }}}" && node="node_${node//./_}" && curl
+          -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
+          secrets.CODECOV_TOKEN }} -F "$os" -F "$node"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,4 @@ jobs:
       - name: Tests
         run: npm run test-ci
       - name: Codecov test coverage
-        run:
-          curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
-          secrets.CODECOV_TOKEN }}
+        run: bash scripts/coverage.sh

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,4 +31,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage/coverage-final.json
-          flags: ${{ matrix.os }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Codecov test coverage
         run:
           curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
-          secrets.CODECOV_TOKEN }}
-          # -F ${{ matrix.os }} -F node_${{ matrix.node }}
+          secrets.CODECOV_TOKEN }} -F ${{ matrix.os }}
+          # -F node_${{ matrix.node }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Tests
         run: npm run test-ci
       - name: Codecov test coverage
-        uses: codecov/codecov-action@1.0.3
+        uses: codecov/codecov-action@v1.0.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage/coverage-final.json

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm run test-ci
       - name: Codecov test coverage
         run:
-          curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
-          secrets.CODECOV_TOKEN }} -F ${{ matrix.os }}
+          os="${{ matrix.os }}" && os="${os/-latest/}" && curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml
+          -f coverage/coverage-final.json -t ${{ secrets.CODECOV_TOKEN }} -F "$os"
           # -F node_${{ matrix.node }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Tests
         run: npm run test-ci
       - name: Codecov test coverage
-        uses: codecov/codecov-action@v1.0.3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage/coverage-final.json
+        run:
+          curl -s https://codecov.io/bash | bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t ${{
+          secrets.CODECOV_TOKEN }}
+          # -F ${{ matrix.os }} -F node_${{ matrix.node }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="static/logo.png" width="400"/><br>
 
-[![Coverage Status](https://coveralls.io/repos/github/netlify/build/badge.svg)](https://coveralls.io/github/netlify/build)
+[![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
 Netlify build is the next generation of CI/CD tooling for modern web applications.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  strict_yaml_branch: master
+coverage:
+  range: [80, 100]
+  parsers:
+    javascript:
+      enable_partials: true
+comment:
+  layout: files,flags
+  require_changes: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{packages,examples,scripts}/**/*.js\"",
     "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{.github,packages,examples,scripts}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
     "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text ava",
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
     "example": "node ./packages/build/src/core/bin.js --config examples/example-two/netlify.yml",
     "debug": "node --inspect-brk ./packages/build/src/core/bin.js --config examples/example-two/netlify.yml"
   },

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Upload test coverage to Codecov
+
+token="$1"
+
+os="$2"
+os="${os/-latest/}"
+
+node="$3"
+node="node_${node//./_}"
+
+curl -s https://codecov.io/bash | \
+  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t "$token" -F "$os" -F "$node"


### PR DESCRIPTION
This replaces Coveralls with Codecov. 
Coveralls has some bugs that break parallel test coverage:
  - https://github.com/coverallsapp/github-action/issues/18
  - https://github.com/coverallsapp/github-action/issues/13

This means we are only getting test coverage from the fastest build, usually Linux, and not from Windows and Mac.
Using Codecov fixes that.