### PR TITLE
Fix cache constant

### DIFF
--- a/packages/build/src/plugins/child/constants.js
+++ b/packages/build/src/plugins/child/constants.js
@@ -33,7 +33,7 @@ const getCacheDir = function(baseDir) {
   return resolve(baseDir, LOCAL_CACHE_DIR)
 }
 
-const CI_CACHE_DIR = '/opts/build/cache/'
+const CI_CACHE_DIR = '/opt/build/cache/'
 const LOCAL_CACHE_DIR = '.netlify/cache/'
 
 const getFunctionsDist = function(baseDir) {


### PR DESCRIPTION
The cache constant was initialized to `/opts/build/cache` instead of `/opt/build/cache`.

@jlengstorf 