### PR TITLE
Remove Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,4 @@ coverage:
   parsers:
     javascript:
       enable_partials: true
-comment:
-  layout: files,flags
-  require_changes: true
+comment: false


### PR DESCRIPTION
Codecov adds PR comments but this is a little spammy. Test coverage can already be seen from PR statuses.