### PR TITLE
Do not make PR fail when test coverage decreases

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,9 @@ coverage:
   parsers:
     javascript:
       enable_partials: true
+  status:
+    project:
+      threshold: 5
+    patch:
+      threshold: 5
 comment: false


### PR DESCRIPTION
At the moment, PRs fail when test coverage decreases by any percentage. This changes it to only fail when test coverage drops by more than 5% (which should indicate an anomaly).