### PR TITLE
Refactor instructions count

### DIFF
--- a/packages/build/src/core/dry.js
+++ b/packages/build/src/core/dry.js
@@ -1,13 +1,13 @@
 const { logDryRunStart, logDryRunInstruction, logDryRunEnd } = require('../log/main')
 
 // If the `dry` option is specified, do a dry run
-const doDryRun = function({ buildInstructions, buildInstructions: { length }, configPath }) {
+const doDryRun = function({ buildInstructions, instructionsCount, configPath }) {
   const hookWidth = Math.max(...buildInstructions.map(getHookLength))
 
-  logDryRunStart(hookWidth, length)
+  logDryRunStart(hookWidth, instructionsCount)
 
   buildInstructions.forEach((instruction, index) => {
-    logDryRunInstruction({ instruction, index, configPath, hookWidth, length })
+    logDryRunInstruction({ instruction, index, configPath, hookWidth, instructionsCount })
   })
 
   logDryRunEnd()

--- a/packages/build/src/core/instructions.js
+++ b/packages/build/src/core/instructions.js
@@ -15,7 +15,8 @@ const getInstructions = function({ pluginsHooks, config }) {
   const buildInstructions = instructions.filter(instruction => !isErrorInstruction(instruction))
   const errorInstructions = instructions.filter(isErrorInstruction)
 
-  return { buildInstructions, errorInstructions }
+  const instructionsCount = buildInstructions.length
+  return { buildInstructions, errorInstructions, instructionsCount }
 }
 
 const isErrorInstruction = function({ hook }) {

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -62,8 +62,8 @@ const logLifeCycleStart = function(instructions) {
 ${SUBTEXT_PADDING}Found ${instructions.length} ${stepsWord}. Lets do this!`)
 }
 
-const logDryRunStart = function(hookWidth, length) {
-  const columnWidth = getDryColumnWidth(hookWidth, length)
+const logDryRunStart = function(hookWidth, instructionsCount) {
+  const columnWidth = getDryColumnWidth(hookWidth, instructionsCount)
   const line = '─'.repeat(columnWidth)
   const secondLine = '─'.repeat(columnWidth)
 
@@ -78,11 +78,17 @@ ${SUBTEXT_PADDING}│ ${DRY_HEADER_NAMES[0].padEnd(columnWidth)} │ ${DRY_HEADE
 ${SUBTEXT_PADDING}└─${line}─┴─${secondLine}─┘`)}`)
 }
 
-const logDryRunInstruction = function({ instruction: { id, hook, type, core }, index, configPath, hookWidth, length }) {
-  const columnWidth = getDryColumnWidth(hookWidth, length)
+const logDryRunInstruction = function({
+  instruction: { id, hook, type, core },
+  index,
+  configPath,
+  hookWidth,
+  instructionsCount,
+}) {
+  const columnWidth = getDryColumnWidth(hookWidth, instructionsCount)
   const line = '─'.repeat(columnWidth)
   const countText = `${index + 1}. `
-  const downArrow = length === index + 1 ? '  ' : ` ${arrowDown}`
+  const downArrow = instructionsCount === index + 1 ? '  ' : ` ${arrowDown}`
   const hookNameWidth = columnWidth - countText.length - downArrow.length
   const location = getPluginLocation({ id, type, core, configPath })
 
@@ -105,8 +111,8 @@ const getPluginLocation = function({ id, type, core, configPath }) {
   return `${white('Plugin')} ${id} ${yellowBright(type)}`
 }
 
-const getDryColumnWidth = function(hookWidth, length) {
-  const symbolsWidth = `${length}`.length + 4
+const getDryColumnWidth = function(hookWidth, instructionsCount) {
+  const symbolsWidth = `${instructionsCount}`.length + 4
   return Math.max(hookWidth + symbolsWidth, DRY_HEADER_NAMES[0].length)
 }
 

--- a/packages/build/src/telemetry/index.js
+++ b/packages/build/src/telemetry/index.js
@@ -15,11 +15,11 @@ const telemetry = Analytics({
 })
 
 // Send telemetry request when build completes
-const trackBuildComplete = async function({ buildInstructions, config, duration }) {
+const trackBuildComplete = async function({ instructionsCount, config, duration }) {
   const plugins = Object.values(config.plugins).map(getPluginType)
 
   await telemetry.track('buildComplete', {
-    steps: buildInstructions.length,
+    steps: instructionsCount,
     duration,
     pluginCount: plugins.length,
     plugins,


### PR DESCRIPTION
The number of instructions is used in several places: dry logging, normal logging, error handling, etc.

This PR does a small refactoring to add an `instructionsCount` variable to contain that information so it's consistent across the code base.