### PR TITLE
Improve error handling

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -15,7 +15,7 @@ const isNetlifyCI = require('../utils/is-netlify-ci')
 const { trackBuildComplete } = require('../telemetry')
 
 const { loadConfig } = require('./config')
-const { getInstructions, runBuildInstructions, runErrorInstructions } = require('./instructions')
+const { getInstructions, runInstructions } = require('./instructions')
 const { tomlWrite } = require('./toml')
 const { doDryRun } = require('./dry')
 
@@ -114,13 +114,14 @@ const executeInstructions = async function({
     return
   }
 
-  try {
-    await runBuildInstructions(buildInstructions, { configPath, baseDir })
-    return instructionsCount
-  } catch (error) {
-    await runErrorInstructions(errorInstructions, { configPath, baseDir, error })
-    throw error
-  }
+  await runInstructions({
+    buildInstructions,
+    errorInstructions,
+    instructionsCount,
+    configPath,
+    baseDir,
+  })
+  return instructionsCount
 }
 
 module.exports = build

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -56,10 +56,10 @@ const logLoadPlugin = function(id, type, core) {
   log(yellowBright(`${SUBTEXT_PADDING}Loading plugin ${idA}from ${location}`))
 }
 
-const logLifeCycleStart = function(instructions) {
-  const stepsWord = instructions.length === 1 ? 'step' : `steps`
+const logLifeCycleStart = function(instructionsCount) {
+  const stepsWord = instructionsCount === 1 ? 'step' : `steps`
   log(`\n${greenBright.bold(`${HEADING_PREFIX} Running Netlify Build Lifecycle`)}
-${SUBTEXT_PADDING}Found ${instructions.length} ${stepsWord}. Lets do this!`)
+${SUBTEXT_PADDING}Found ${instructionsCount} ${stepsWord}. Lets do this!`)
 }
 
 const logDryRunStart = function(hookWidth, instructionsCount) {


### PR DESCRIPTION
Currently, if two plugins have an `onError` hook, and one of them throws an error, the other `onError` is not guaranteed to complete.

This PR fixes this by ensuring that if `onError` hooks fail, they first wait for other `onError` to complete before propagating their error. The error thrown inside the `onError` hook is eventually propagated and printed on logs, for users to see what's wrong with their error handling.

Tagging @sdras since we discussed this issue.