### PR TITLE
Fix `onError` hook

### DIFF
--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -85,6 +85,8 @@ const sendEventToParent = async function(callId, payload) {
 
 // Errors are not serializable through `child_process` `ipc` so we need to
 // convert from/to plain objects.
+// TODO: use `child_process.spawn()` `serialization: 'advanced'` option after
+// dropping support for Node.js <=13.2.0
 const serializePayload = function({ error: { name, message, stack, ...error } = {}, ...payload }) {
   if (name === undefined) {
     return payload


### PR DESCRIPTION
`onError` hooks receive the `error` instance as argument:

```js
module.exports = {
  name: 'netlify-plugin-example',
  onError({ error }) {
    console.error(error)
  }
}
```

However plugins are spawned as child processes. The parent process communicates to them through [`child_process` `ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) which uses JSON as the message format. This leads to `error` instances being converted to plain objects, which makes them lose their `Error` prototype, `message`, `name` and `stack` properties.

This PR fixes this by serializing and parsing error instances ourselves.

Note that Node.js added support for `v8` serialization (based on the HTML structured clone algorithm) [**yesterday**](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V13.md#2019-11-21-version-1320-current-mylesborins)! :D This is available in Node `13.2.0`. Unfortunately the Node.js version of the parent process is the same as child processes, so we need to support Node down to `8.3.0` (see ongoing discussion #81).

Tagging @sdras since this is part of the ongoing "error handling" thread.