### PR TITLE
Fix tests on Windows

### DIFF
--- a/packages/build/tests/plugins/load/fixtures/early_exit/plugin.js
+++ b/packages/build/tests/plugins/load/fixtures/early_exit/plugin.js
@@ -7,4 +7,8 @@ module.exports = {
   },
 }
 
-setTimeout(exit)
+setTimeout(() => {
+  setTimeout(() => {
+    exit()
+  }, 0)
+}, 0)


### PR DESCRIPTION
A test was failing on Windows due to child process termination being different on Windows and on Unix.