### PR TITLE
Allow legacy properties when validation property names

### DIFF
--- a/packages/config/src/validate/helpers.js
+++ b/packages/config/src/validate/helpers.js
@@ -6,9 +6,9 @@ const isBoolean = function(value) {
   return typeof value === 'boolean'
 }
 
-const validProperties = function(propNames) {
+const validProperties = function(propNames, legacyPropNames = propNames) {
   return {
-    check: value => Object.keys(value).every(propName => propNames.includes(propName)),
+    check: value => Object.keys(value).every(propName => [...propNames, ...legacyPropNames].includes(propName)),
     message: `has unknown properties. Valid properties are:
 ${propNames.map(propName => `  - ${propName}`).join('\n')}`,
   }


### PR DESCRIPTION
This enhances the helper that validates property names in the configuration, in order to support legacy/deprecated property names.

Connected to #531.