### PR TITLE
Allow dynamic examples in configuration validation

### DIFF
--- a/packages/config/src/validate/example.js
+++ b/packages/config/src/validate/example.js
@@ -3,7 +3,8 @@ const indentString = require('indent-string')
 const { red, green } = require('chalk')
 
 // Print invalid value and example netlify.yml
-const getExample = function({ value, prevPath, example }) {
+const getExample = function({ value, key, prevPath, example }) {
+  const exampleA = typeof example === 'function' ? example(value, key) : example
   return `
 ${red.bold('Invalid syntax')}
 
@@ -11,7 +12,7 @@ ${indentString(getInvalidValue(value, prevPath), 2)}
 
 ${green.bold('Valid syntax')}
 
-${indentString(serializeValue(example), 2)}`
+${indentString(serializeValue(exampleA), 2)}`
 }
 
 const getInvalidValue = function(value, prevPath) {


### PR DESCRIPTION
At the moment examples used on configuration validation are static. This PR allows them to be dynamic functions instead, taking the failed property as input.

Connected to #531.