### PR TITLE
Dynamic configuration validation error messages

### DIFF
--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -55,10 +55,10 @@ const validateProperty = function(
     return
   }
 
-  reportError({ prevPath, propPath, message, example, warn, value, key, parent })
+  reportError({ prevPath, propPath, message, example, value, key, parent })
 }
 
-const reportError = function({ prevPath, propPath, message, example, warn, value, key, parent }) {
+const reportError = function({ prevPath, propPath, message, example, value, key, parent }) {
   const messageA = typeof message === 'function' ? message(value, key, parent) : message
   const error = `Configuration property ${cyan.bold(propPath)} ${messageA}
 ${getExample({ value, key, prevPath, example })}`

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -55,8 +55,14 @@ const validateProperty = function(
     return
   }
 
-  throw new Error(`Configuration property ${cyan.bold(propPath)} ${message}
-${getExample({ value, key, prevPath, example })}`)
+  reportError({ prevPath, propPath, message, example, warn, value, key, parent })
+}
+
+const reportError = function({ prevPath, propPath, message, example, warn, value, key, parent }) {
+  const messageA = typeof message === 'function' ? message(value, key, parent) : message
+  const error = `Configuration property ${cyan.bold(propPath)} ${messageA}
+${getExample({ value, key, prevPath, example })}`
+  throw new Error(error)
 }
 
 // Recurse over children (each part of the `property` array).


### PR DESCRIPTION
At the moment error messages thrown during configuration validation are static. This PR enhances them to allow dynamic error messages, taking the failed property as input.

Connected to #531.