### PR TITLE
Allow warning messages during configuration validation

### DIFF
--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -57,10 +57,10 @@ const validateProperty = function(
     return
   }
 
-  reportError({ prevPath, propPath, message, example, value, key, parent })
+  reportError({ prevPath, propPath, message, example, warn, value, key, parent })
 }
 
-const reportError = function({ prevPath, propPath, message, example, value, key, parent }) {
+const reportError = function({ prevPath, propPath, message, example, warn, value, key, parent }) {
   const messageA = typeof message === 'function' ? message(value, key, parent) : message
   const error = `Configuration property ${cyan.bold(propPath)} ${messageA}
 ${getExample({ value, key, prevPath, example })}`

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -28,6 +28,7 @@ const validateProperty = function(
     check,
     message,
     example,
+    warn,
   },
 ) {
   const value = parent[propName]
@@ -44,6 +45,7 @@ const validateProperty = function(
       check,
       message,
       example,
+      warn,
     })
   }
 
@@ -62,7 +64,12 @@ const reportError = function({ prevPath, propPath, message, example, value, key,
   const messageA = typeof message === 'function' ? message(value, key, parent) : message
   const error = `Configuration property ${cyan.bold(propPath)} ${messageA}
 ${getExample({ value, key, prevPath, example })}`
-  throw new Error(error)
+
+  if (!warn) {
+    throw new Error(error)
+  }
+
+  console.warn(error)
 }
 
 // Recurse over children (each part of the `property` array).

--- a/packages/config/src/validate/validations.js
+++ b/packages/config/src/validate/validations.js
@@ -15,6 +15,7 @@ const { isString, isBoolean, validProperties } = require('./helpers')
 //   - `check` {(value) => boolean}: validation check function
 //   - `message` {string}: error message
 //   - `example` {string}: example of correct code
+//   - `warn` {boolean}: whether to print a console message or throw an error
 // We use this instead of JSON schema (or others) to get nicer error messages.
 const VALIDATIONS = [
   {


### PR DESCRIPTION
At the moment configuration validation failures always result in a build error. This enhances this by allows warning messages instead, for example for deprecated properties, that do not make builds fail.

Connected to #531.