### PR TITLE
Normalize `build.lifecycle.event` to `build.lifecycle.onEvent`

### DIFF
--- a/packages/config/src/lifecycle.js
+++ b/packages/config/src/lifecycle.js
@@ -59,4 +59,31 @@ const LIFECYCLE = [
   'onEnd',
 ]
 
-module.exports = { LIFECYCLE }
+// TODO: remove after going out of beta
+const LEGACY_LIFECYCLE = {
+  init: 'onInit',
+  preGetCache: 'onPreGetCache',
+  getCache: 'onGetCache',
+  postGetCache: 'onPostGetCache',
+  preInstall: 'onPreInstall',
+  install: 'onInstall',
+  postInstall: 'onPostInstall',
+  preBuild: 'onPreBuild',
+  build: 'onBuild',
+  postBuild: 'onPostBuild',
+  preFunctionsBuild: 'onPreFunctionsBuild',
+  functionsBuild: 'onFunctionsBuild',
+  postFunctionsBuild: 'onPostFunctionsBuild',
+  prePackage: 'onPrePackage',
+  package: 'onPackage',
+  postPackage: 'onPostPackage',
+  preDeploy: 'onPreDeploy',
+  preSaveCache: 'onPreSaveCache',
+  saveCache: 'onSaveCache',
+  postSaveCache: 'onPostSaveCache',
+  success: 'onSuccess',
+  error: 'onError',
+  end: 'onEnd',
+}
+
+module.exports = { LIFECYCLE, LEGACY_LIFECYCLE }

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -1,6 +1,8 @@
 const mapObj = require('map-obj')
 const deepMerge = require('deepmerge')
 
+const { LEGACY_LIFECYCLE } = require('./lifecycle.js')
+
 // Normalize configuration object
 const normalizeConfig = function(config) {
   const configA = deepMerge(DEFAULT_CONFIG, config)
@@ -33,8 +35,9 @@ const normalizeCommand = function(lifecycle, command) {
 }
 
 const normalizeLifecycle = function(hook, value) {
+  const hookA = LEGACY_LIFECYCLE[hook] === undefined ? hook : LEGACY_LIFECYCLE[hook]
   const valueA = typeof value === 'string' ? value.trim().split('\n') : value
-  return [hook, valueA]
+  return [hookA, valueA]
 }
 
 module.exports = { normalizeConfig }

--- a/packages/config/src/validate/validations.js
+++ b/packages/config/src/validate/validations.js
@@ -1,7 +1,7 @@
 const isPlainObj = require('is-plain-obj')
 const { cyan } = require('chalk')
 
-const { LIFECYCLE } = require('../lifecycle')
+const { LIFECYCLE, LEGACY_LIFECYCLE } = require('../lifecycle')
 
 const { isString, isBoolean, validProperties } = require('./helpers')
 
@@ -97,7 +97,7 @@ Please rename ${cyan.bold('build.command')} to ${cyan.bold('build.lifecycle.onBu
   },
   {
     property: 'build.lifecycle',
-    ...validProperties(LIFECYCLE),
+    ...validProperties(LIFECYCLE, Object.keys(LEGACY_LIFECYCLE)),
     example: { build: { lifecycle: { onBuild: 'npm run build' } } },
   },
   {


### PR DESCRIPTION
This allows users to use deprecated `build.lifecycle.event` which will be normalized to the new `build.lifecycle.onEvent` instead.

Connected to #531.