### PR TITLE
Normalize lifecycle event case

### DIFF
--- a/packages/config/src/lifecycle.js
+++ b/packages/config/src/lifecycle.js
@@ -86,4 +86,25 @@ const LEGACY_LIFECYCLE = {
   end: 'onEnd',
 }
 
-module.exports = { LIFECYCLE, LEGACY_LIFECYCLE }
+// `build.lifecycle.onEvent` can also be spelled `build.lifecycle.onevent`
+const normalizeLifecycleCase = function(event) {
+  const normalizedEvent = LIFECYCLE_CASES[event]
+  if (normalizedEvent === undefined) {
+    return event
+  }
+
+  return normalizedEvent
+}
+
+const getLifecycleCases = function() {
+  const events = [...LIFECYCLE, ...Object.keys(LEGACY_LIFECYCLE)].map(getLifecycleCase)
+  return Object.assign({}, ...events)
+}
+
+const getLifecycleCase = function(event) {
+  return { [event.toLowerCase()]: event }
+}
+
+const LIFECYCLE_CASES = getLifecycleCases()
+
+module.exports = { LIFECYCLE, LEGACY_LIFECYCLE, normalizeLifecycleCase }

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -1,7 +1,7 @@
 const mapObj = require('map-obj')
 const deepMerge = require('deepmerge')
 
-const { LEGACY_LIFECYCLE } = require('./lifecycle.js')
+const { LEGACY_LIFECYCLE, normalizeLifecycleCase } = require('./lifecycle.js')
 
 // Normalize configuration object
 const normalizeConfig = function(config) {
@@ -35,9 +35,10 @@ const normalizeCommand = function(lifecycle, command) {
 }
 
 const normalizeLifecycle = function(hook, value) {
-  const hookA = LEGACY_LIFECYCLE[hook] === undefined ? hook : LEGACY_LIFECYCLE[hook]
+  const hookA = normalizeLifecycleCase(hook)
+  const hookB = LEGACY_LIFECYCLE[hookA] === undefined ? hookA : LEGACY_LIFECYCLE[hookA]
   const valueA = typeof value === 'string' ? value.trim().split('\n') : value
-  return [hookA, valueA]
+  return [hookB, valueA]
 }
 
 module.exports = { normalizeConfig }


### PR DESCRIPTION
This allows users to write lifecycle events case-insensitively. For example `build.lifecycle.onbuild` would work like `build.lifecycle.onBuild`.

Connected to #531.