### PR TITLE
Export legacy lifecycle names from `@netlify/config`

### DIFF
--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -6,7 +6,7 @@ const { addEnvVars } = require('./env')
 const { validateConfig } = require('./validate/main')
 const { normalizeConfig } = require('./normalize')
 const { handleFiles } = require('./files')
-const { LIFECYCLE } = require('./lifecycle')
+const { LIFECYCLE, LEGACY_LIFECYCLE } = require('./lifecycle')
 
 const resolveConfig = async function(configFile, { cwd, ...options } = {}) {
   const configPath = await getConfigPath(configFile, cwd)
@@ -47,3 +47,4 @@ module.exports = resolveConfig
 module.exports.getBaseDir = getBaseDir
 module.exports.getConfigPath = getConfigPath
 module.exports.LIFECYCLE = LIFECYCLE
+module.exports.LEGACY_LIFECYCLE = LEGACY_LIFECYCLE


### PR DESCRIPTION
This exports the legacy lifecycle names from `@netlify/config` so that `@netlify/build` can use them to normalize and validate plugin event handlers.