### PR TITLE
Normalize plugin event names

### DIFF
--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -3,6 +3,7 @@ const { validatePluginConfig } = require('../config/validate_props.js')
 
 const { getLogic } = require('./logic')
 const { validatePlugin } = require('./validate')
+const { normalizePlugin } = require('./normalize')
 const { getApiClient } = require('./api')
 const { getConstants } = require('./constants')
 
@@ -14,12 +15,15 @@ const { getConstants } = require('./constants')
 const loadPlugin = async function(payload) {
   const constants = await getConstants(payload)
   const logic = getLogic(payload, constants)
+
   validatePlugin(logic)
   validatePluginConfig(logic, payload)
 
-  const hooks = getPluginHooks(logic, payload)
+  const logicA = normalizePlugin(logic)
 
-  const context = getContext(logic, hooks, constants, payload)
+  const hooks = getPluginHooks(logicA, payload)
+
+  const context = getContext(logicA, hooks, constants, payload)
   return { context, hooks }
 }
 

--- a/packages/build/src/plugins/child/normalize.js
+++ b/packages/build/src/plugins/child/normalize.js
@@ -1,0 +1,19 @@
+const mapObj = require('map-obj')
+const { LEGACY_LIFECYCLE } = require('@netlify/config')
+
+// Normalize plugin shape
+const normalizePlugin = function(logic) {
+  return mapObj(logic, normalizeProperty)
+}
+
+const normalizeProperty = function(key, value) {
+  const newKey = LEGACY_LIFECYCLE[key]
+
+  if (newKey === undefined) {
+    return [key, value]
+  }
+
+  return [newKey, value]
+}
+
+module.exports = { normalizePlugin }


### PR DESCRIPTION
This normalizes plugin event names so that plugin authors that used the legacy `plugin.event` methods do not have compatibility issues.

Related to #531.