### PR TITLE
Make lifecycle events case-insensitive

### DIFF
--- a/packages/build/tests/config/normalize/fixtures/case/netlify.yml
+++ b/packages/build/tests/config/normalize/fixtures/case/netlify.yml
@@ -1,3 +1,3 @@
 build:
   lifecycle:
-    onbuild: echo test
+    oNbUiLd: echo test

--- a/packages/config/src/lifecycle.js
+++ b/packages/config/src/lifecycle.js
@@ -88,7 +88,7 @@ const LEGACY_LIFECYCLE = {
 
 // `build.lifecycle.onEvent` can also be spelled `build.lifecycle.onevent`
 const normalizeLifecycleCase = function(event) {
-  const normalizedEvent = LIFECYCLE_CASES[event]
+  const normalizedEvent = LIFECYCLE_CASES[event.toLowerCase()]
   if (normalizedEvent === undefined) {
     return event
   }


### PR DESCRIPTION
This makes `config.build.lifecycle` events case-insensitive.