### PR TITLE
Remove `npm run example`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{packages,examples,scripts}/**/*.js\"",
     "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{.github,packages,examples,scripts}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
     "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
-    "example": "node ./packages/build/src/core/bin.js --config examples/example-two/netlify.yml",
-    "debug": "node --inspect-brk ./packages/build/src/core/bin.js --config examples/example-two/netlify.yml"
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This removes `npm run example` due to `example-two` being removed by #550.