### PR TITLE
Improve test snapshots normalization

### DIFF
--- a/packages/build/tests/README.md
+++ b/packages/build/tests/README.md
@@ -55,7 +55,7 @@ An additional object can be passed to `runFixture()` with the following options:
 - `flags` `{string[]}`: other CLI flags
 - `cwd` `{string}`: current directory
 - `env` `{object}`: environment variables
-- `debug` `{boolean}`: see [below](#output-normalization)
+- `normalize` `{boolean}`: see [below](#output-normalization)
 
 You usually do not need to specify any of those options except `flags` when testing specific CLI flags.
 
@@ -113,8 +113,10 @@ Sometimes the `netlify-build` output contains non-deterministic information such
 Those would make the test snapshot non-reproducible. To fix this, the output is normalized by `./helpers/normalize.js`.
 This basically performs a series of regular expressions replacements.
 
-If you want to remove the normalization during debugging, use the `debug` option:
+If you want to remove the normalization during debugging, use the `normalize` option:
 
 ```js
-await runFixture(t, 'fixture_name', { debug: true })
+await runFixture(t, 'fixture_name', { normalize: false })
 ```
+
+`normalize` is `false` when `PRINT=1` is used, `true` otherwise.

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -23,8 +23,9 @@ const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
 //  - `config` {string}: `--config` CLI flag
 //  - `cwd` {string}: current directory when calling `netlify-build`
 //  - `env` {object}: environment variable
+//  - `normalize` {boolean}: whether to normalize output
 //  - `snapshot` {boolean}: whether to create a snapshot
-const runFixture = async function(t, fixtureName, { flags = '', config, cwd, env, debug, snapshot = true } = {}) {
+const runFixture = async function(t, fixtureName, { flags = '', config, cwd, env, normalize, snapshot = true } = {}) {
   const envA = { CACHE_BASE: '.', NETLIFY_BUILD_SAVE_CACHE: '1', ...env }
   const configFlag = getConfigFlag(config, fixtureName)
   const binaryPath = await BINARY_PATH
@@ -37,7 +38,7 @@ const runFixture = async function(t, fixtureName, { flags = '', config, cwd, env
   })
 
   const isPrint = PRINT === '1'
-  doTestAction({ t, all, isPrint, debug, snapshot })
+  doTestAction({ t, all, isPrint, normalize, snapshot })
 
   return { all, exitCode }
 }
@@ -62,8 +63,8 @@ const getConfigFlag = function(config, fixtureName) {
 // The `PRINT` environment variable can be set to `1` to run the test in print
 // mode. Print mode is a debugging mode which shows the test output but does
 // not create nor compare its snapshot.
-const doTestAction = function({ t, all, isPrint, debug = isPrint, snapshot }) {
-  const allA = debug ? all : normalizeOutput(all)
+const doTestAction = function({ t, all, isPrint, normalize = !isPrint, snapshot }) {
+  const allA = normalize ? normalizeOutput(all) : all
 
   if (isPrint) {
     return printOutput(t, allA)


### PR DESCRIPTION
This PR improves test snapshots helpers by adding a `normalize` option to turn it off.