### PR TITLE
Add tests covering stack traces normalization

### DIFF
--- a/packages/build/tests/log/stack/fixtures/config_validation/netlify.yml
+++ b/packages/build/tests/log/stack/fixtures/config_validation/netlify.yml
@@ -1,0 +1,3 @@
+build:
+  lifecycle:
+    invalid: echo

--- a/packages/build/tests/log/stack/fixtures/lifecycle/file.js
+++ b/packages/build/tests/log/stack/fixtures/lifecycle/file.js
@@ -1,0 +1,3 @@
+const { exit } = require('process')
+
+exit(1)

--- a/packages/build/tests/log/stack/fixtures/lifecycle/netlify.yml
+++ b/packages/build/tests/log/stack/fixtures/lifecycle/netlify.yml
@@ -1,0 +1,3 @@
+build:
+  lifecycle:
+    onInit: node file.js

--- a/packages/build/tests/log/stack/fixtures/load/netlify.yml
+++ b/packages/build/tests/log/stack/fixtures/load/netlify.yml
@@ -1,0 +1,2 @@
+plugins:
+  - type: ./plugin.js

--- a/packages/build/tests/log/stack/fixtures/load/plugin.js
+++ b/packages/build/tests/log/stack/fixtures/load/plugin.js
@@ -1,0 +1,5 @@
+const test = function() {
+  throw new Error('test')
+}
+
+test()

--- a/packages/build/tests/log/stack/fixtures/plugin/netlify.yml
+++ b/packages/build/tests/log/stack/fixtures/plugin/netlify.yml
@@ -1,0 +1,2 @@
+plugins:
+  - type: ./plugin.js

--- a/packages/build/tests/log/stack/fixtures/plugin/plugin.js
+++ b/packages/build/tests/log/stack/fixtures/plugin/plugin.js
@@ -1,0 +1,6 @@
+module.exports = {
+  name: 'netlify-plugin-example',
+  onInit() {
+    throw new Error('test')
+  },
+}

--- a/packages/build/tests/log/stack/tests.js
+++ b/packages/build/tests/log/stack/tests.js
@@ -1,0 +1,47 @@
+const { cwd } = require('process')
+
+const test = require('ava')
+
+const { runFixture } = require('../../helpers/main')
+
+test('Clean stack traces of lifecycle commands', async t => {
+  const { all } = await runFixture(t, 'lifecycle', { snapshot: false, normalize: false })
+  const count = getStackLinesCount(all)
+  t.is(count, 0)
+})
+
+test('Clean stack traces of plugin event handlers', async t => {
+  const { all } = await runFixture(t, 'plugin', { snapshot: false, normalize: false })
+  const count = getStackLinesCount(all)
+  t.is(count, 1)
+})
+
+test('Clean stack traces of plugin loads', async t => {
+  const { all } = await runFixture(t, 'load', { snapshot: false, normalize: false })
+  const count = getStackLinesCount(all)
+  t.is(count, 1)
+})
+
+test('Clean stack traces of config validation', async t => {
+  const { all } = await runFixture(t, 'config_validation', { snapshot: false, normalize: false })
+  const count = getStackLinesCount(all)
+  t.is(count, 0)
+})
+
+const getStackLinesCount = function(all) {
+  return all.split('\n').filter(isStackLine).length
+}
+
+const isStackLine = function(line) {
+  return line.trim().startsWith('at ')
+}
+
+test('Clean stack traces from cwd', async t => {
+  const { all } = await runFixture(t, 'plugin', { snapshot: false, normalize: false })
+  t.false(all.includes(`onInit (${cwd()}`))
+})
+
+test('Clean stack traces but keep error message', async t => {
+  const { all } = await runFixture(t, 'plugin', { snapshot: false, normalize: false })
+  t.true(all.includes('Error: test'))
+})


### PR DESCRIPTION
This adds some tests covering the normalization/cleaning we do on error stack traces to keep logs as user-friendly as possible.