### PR TITLE
Add `.yarn-error.log` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ research
 terraform
 .netlify
 lerna-debug.log
+.yarn-error.log
 .nyc_output
 coverage
 .eslintcache


### PR DESCRIPTION
This adds `.yarn-error.log` to `.gitignore` since it sometimes created for example when the network connection is down.