### PR TITLE
Move some lines of code

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -35,11 +35,11 @@ const build = async function(flags = {}) {
 
     const { config, configPath, token, baseDir } = await loadConfig({ flags })
 
-    const pluginsOptions = getPluginsOptions({ config })
-    const pluginsOptionsA = await installPlugins(pluginsOptions, baseDir)
+    const pluginsOptions = await getPluginsOptions(config, baseDir)
+    await installPlugins(pluginsOptions, baseDir)
 
     const commandsCount = await buildRun({
-      pluginsOptions: pluginsOptionsA,
+      pluginsOptions,
       config,
       configPath,
       baseDir,

--- a/packages/build/src/plugins/install.js
+++ b/packages/build/src/plugins/install.js
@@ -1,37 +1,13 @@
 const { dirname } = require('path')
-const { promisify } = require('util')
 
-const resolve = require('resolve')
 const findUp = require('find-up')
 
 const { installDependencies } = require('../utils/install')
 const { logInstallPlugins } = require('../log/main')
 
-const pResolve = promisify(resolve)
-
 // Install dependencies of local plugins.
 // Also resolve path of plugins' main files.
 const installPlugins = async function(pluginsOptions, baseDir) {
-  const pluginsOptionsA = await Promise.all(pluginsOptions.map(pluginOptions => resolvePlugin(pluginOptions, baseDir)))
-
-  await installPluginDependencies(pluginsOptionsA, baseDir)
-
-  return pluginsOptionsA
-}
-
-// We use `resolve` because `require()` should be relative to `baseDir` not to
-// this `__filename`
-const resolvePlugin = async function({ type, ...pluginOptions }, baseDir) {
-  try {
-    const pluginPath = await pResolve(type, { basedir: baseDir })
-    return { ...pluginOptions, type, pluginPath }
-  } catch (error) {
-    error.message = `'${type}' plugin not installed or found\n${error.message}`
-    throw error
-  }
-}
-
-const installPluginDependencies = async function(pluginsOptions, baseDir) {
   const pluginsPaths = getPluginsPaths(pluginsOptions)
 
   if (pluginsPaths.length === 0) {

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -1,13 +1,20 @@
 const {
   env: { NETLIFY_BUILD_SAVE_CACHE },
 } = require('process')
+const { promisify } = require('util')
+
+const resolve = require('resolve')
+
+const pResolve = promisify(resolve)
 
 const FUNCTIONS_PLUGIN = `${__dirname}/functions/index.js`
 const CACHE_PLUGIN = `${__dirname}/../cache/plugin.js`
 
 // Load plugin options (specified by user in `config.plugins`)
-const getPluginsOptions = function({ config: { plugins: pluginsOptions } }) {
-  return [...DEFAULT_PLUGINS, ...pluginsOptions].map(normalizePluginOptions).filter(isPluginEnabled)
+const getPluginsOptions = async function({ plugins: pluginsOptions }, baseDir) {
+  const pluginsOptionsA = [...DEFAULT_PLUGINS, ...pluginsOptions].map(normalizePluginOptions).filter(isPluginEnabled)
+  const pluginsOptionsB = await Promise.all(pluginsOptionsA.map(pluginOptions => resolvePlugin(pluginOptions, baseDir)))
+  return pluginsOptionsB
 }
 
 const DEFAULT_PLUGINS = [
@@ -27,6 +34,18 @@ const DEFAULT_PLUGIN_OPTIONS = { enabled: true, core: false, config: {} }
 
 const isPluginEnabled = function({ enabled }) {
   return String(enabled) !== 'false'
+}
+
+// We use `resolve` because `require()` should be relative to `baseDir` not to
+// this `__filename`
+const resolvePlugin = async function({ type, ...pluginOptions }, baseDir) {
+  try {
+    const pluginPath = await pResolve(type, { basedir: baseDir })
+    return { ...pluginOptions, type, pluginPath }
+  } catch (error) {
+    error.message = `'${type}' plugin not installed or found\n${error.message}`
+    throw error
+  }
 }
 
 module.exports = { getPluginsOptions }


### PR DESCRIPTION
This moves the logic related to plugin resolution closer to plugin loading instead of making it part of the plugin dependencies installation logic.