### PR TITLE
Fix test failing due to npm network connection

### DIFF
--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -101,6 +101,7 @@ const shouldIgnoreSnapshot = function(all) {
 const IGNORE_REGEXPS = [
   // Some tests run npm|yarn, which sometimes fail due to network errors
   /getaddrinfo EAI_AGAIN/,
+  /npm ERR!/,
 ]
 
 module.exports = { runFixture, FIXTURES_DIR }


### PR DESCRIPTION
This fixes a test that was randomly failing when there was a network connection with npm.

Reference: https://github.com/netlify/build/pull/602/checks?check_run_id=346368546