### PR TITLE
Update toml to use correct syntax

### DIFF
--- a/examples/backwards-compat/README.md
+++ b/examples/backwards-compat/README.md
@@ -109,10 +109,10 @@ For this example we will add the `@netlify/sitemap` plugin
 
    ```toml
    # Build Plugins
-   [plugins]
-     [plugins.sitemap]
-     type = "@netlify/plugin-sitemap"
-     config = { baseUrl = "https://my-site.com" }
+   [[plugins]]
+   type = "@netlify/plugin-sitemap"
+     [plugins.config]
+     baseUrl = "https://my-site.com"
    ```
 
    Your full `toml` should look like this:
@@ -131,10 +131,10 @@ For this example we will add the `@netlify/sitemap` plugin
      onBuild = "npm run makeSite"
 
    # Build Plugins
-   [plugins]
-     [plugins.siteMapPlugin]
-     type = "@netlify/plugin-sitemap"
-     config = { baseUrl = "https://my-site.com" }
+   [[plugins]]
+   type = "@netlify/plugin-sitemap"
+     [plugins.config]
+     baseUrl = "https://my-site.com"
    ```
 
 3. **Preview and run the build**


### PR DESCRIPTION
**Which problem is this pull request solving?**
The toml for backwards compatibility is currently an older version and causes errors in the current version of netlify build cli, specifically the error mentions incorrect syntax.

**List other issues or pull requests related to this problem**
This addresses the comments in [this issue](https://github.com/netlify/build/issues/337#issuecomment-545211855) and updates the docs accordingly

**Describe the solution you've chosen**
I've updated the docs to reflect the changes to the toml

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
