### PR TITLE
Make saving cache faster in CI

### DIFF
--- a/packages/build/tests/utils/cache/fixtures/hash/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash/plugin.js
@@ -15,7 +15,7 @@ module.exports = {
 
     await pWriteFile(id, id)
     console.log(await cache.save(id))
-    console.log(await cache.save(id, { move: true }))
+    console.log(await cache.save(id))
     console.log(await pathExists(id))
     await del(id)
   },

--- a/packages/build/tests/utils/cache/fixtures/hash_big/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash_big/plugin.js
@@ -19,7 +19,7 @@ module.exports = {
     const paths = await makeFiles(dir)
 
     console.log(await cache.save(dir))
-    console.log(await cache.save(dir, { move: true }))
+    console.log(await cache.save(dir))
     console.log((await Promise.all(paths.map(path => pathExists(path)))).every(Boolean))
     await del(dir)
   },

--- a/packages/build/tests/utils/cache/fixtures/hash_directory/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash_directory/plugin.js
@@ -19,7 +19,7 @@ module.exports = {
     const paths = await makeFiles(dir)
 
     console.log(await cache.save(dir))
-    console.log(await cache.save(dir, { move: true }))
+    console.log(await cache.save(dir))
     console.log((await Promise.all(paths.map(path => pathExists(path)))).every(Boolean))
     await del(dir)
   },

--- a/packages/cache-utils/src/hash.js
+++ b/packages/cache-utils/src/hash.js
@@ -15,7 +15,12 @@ const pReadFile = promisify(readFile)
 // Compute the hash of a file's contents.
 // Use SHA256 on the contents. Also hashes some file metadata: file path, file
 // type, permissions, uid/gid.
-const getHash = async function(srcPath, digests, base) {
+const getHash = async function({ srcPath, move, digests, base }) {
+  // Moving files is faster than computing hashes
+  if (move) {
+    return ''
+  }
+
   const { digestPath, fileStat } = await findDigest(srcPath, digests)
 
   if (fileStat.isDirectory()) {

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -12,7 +12,7 @@ const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, d
     return false
   }
 
-  const { manifestInfo, identical } = await getManifestInfo({ srcPath, cachePath, ttl, digests, base })
+  const { manifestInfo, identical } = await getManifestInfo({ srcPath, cachePath, move, ttl, digests, base })
   if (identical) {
     return false
   }


### PR DESCRIPTION
This makes saving cache faster in CI, since CI moves files, which is faster to do than computing hashes.