### PR TITLE
Fix test failing on Windows

### DIFF
--- a/packages/build/tests/config/load/tests.js
+++ b/packages/build/tests/config/load/tests.js
@@ -4,9 +4,8 @@ const { tmpdir } = require('os')
 
 const test = require('ava')
 const makeDir = require('make-dir')
-const del = require('del')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
+const { runFixture, FIXTURES_DIR, removeDir } = require('../../helpers/main')
 
 test('Empty configuration', async t => {
   await runFixture(t, 'empty')
@@ -39,7 +38,7 @@ test('No --config but none found', async t => {
   try {
     await runFixture(t, '', { config: false, cwd })
   } finally {
-    del(cwd, { force: true })
+    removeDir(cwd)
   }
 })
 
@@ -54,7 +53,7 @@ test('No --config but none found and with environment variables', async t => {
       env: { NETLIFY_CONFIG_BUILD_LIFECYCLE_ONBUILD: 'echo onBuild' },
     })
   } finally {
-    del(cwd, { force: true })
+    removeDir(cwd)
   }
 })
 

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -11,6 +11,7 @@ const {
 const execa = require('execa')
 const { getBinPath } = require('get-bin-path')
 const { magentaBright } = require('chalk')
+const del = require('del')
 
 const { normalizeOutput } = require('./normalize')
 
@@ -108,4 +109,14 @@ const IGNORE_REGEXPS = [
   /npm ERR!/,
 ]
 
-module.exports = { runFixture, FIXTURES_DIR }
+// Removing a directory sometimes fails on Windows in CI due to Windows
+// directory locking.
+// This results in `EBUSY: resource busy or locked, rmdir /path/to/dir`
+const removeDir = async function(dir) {
+  try {
+    await del(dir, { force: true })
+    // eslint-disable-next-line no-empty
+  } catch (error) {}
+}
+
+module.exports = { runFixture, FIXTURES_DIR, removeDir }

--- a/packages/build/tests/plugins/constants/tests.js
+++ b/packages/build/tests/plugins/constants/tests.js
@@ -1,7 +1,6 @@
 const test = require('ava')
-const del = require('del')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
+const { runFixture, FIXTURES_DIR, removeDir } = require('../../helpers/main')
 
 test('constants.CONFIG_PATH', async t => {
   await runFixture(t, 'config')
@@ -20,12 +19,12 @@ test('constants.BUILD_DIR relative path', async t => {
 })
 
 test('constants.BUILD_DIR automatic value', async t => {
-  await del(`${FIXTURES_DIR}/build_auto/.netlify/build`)
+  await removeDir(`${FIXTURES_DIR}/build_auto/.netlify/build`)
   await runFixture(t, 'build_auto')
 })
 
 test('constants.BUILD_DIR missing path', async t => {
-  await del(`${FIXTURES_DIR}/build_missing/publish`)
+  await removeDir(`${FIXTURES_DIR}/build_missing/publish`)
   await runFixture(t, 'build_missing')
 })
 
@@ -42,7 +41,7 @@ test('constants.FUNCTIONS_SRC automatic value', async t => {
 })
 
 test('constants.FUNCTIONS_SRC missing path', async t => {
-  await del(`${FIXTURES_DIR}/functions_src_missing/missing`)
+  await removeDir(`${FIXTURES_DIR}/functions_src_missing/missing`)
   await runFixture(t, 'functions_src_missing')
 })
 

--- a/packages/build/tests/plugins/functions/tests.js
+++ b/packages/build/tests/plugins/functions/tests.js
@@ -1,39 +1,38 @@
 const test = require('ava')
-const del = require('del')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
+const { runFixture, FIXTURES_DIR, removeDir } = require('../../helpers/main')
 
 test('Functions: simple setup', async t => {
-  await del(`${FIXTURES_DIR}/simple/.netlify/functions/`)
+  await removeDir(`${FIXTURES_DIR}/simple/.netlify/functions/`)
   await runFixture(t, 'simple')
 })
 
 test('Functions: missing source directory', async t => {
-  await del(`${FIXTURES_DIR}/missing/missing/`)
+  await removeDir(`${FIXTURES_DIR}/missing/missing/`)
   await runFixture(t, 'missing')
 })
 
 test('Functions: default directory', async t => {
-  await del(`${FIXTURES_DIR}/default/.netlify/functions/`)
+  await removeDir(`${FIXTURES_DIR}/default/.netlify/functions/`)
   await runFixture(t, 'default')
 })
 
 test('Functions: install dependencies top-level', async t => {
-  await del([`${FIXTURES_DIR}/deps/.netlify/functions/`, `${FIXTURES_DIR}/deps/functions/node_modules/`])
+  await removeDir([`${FIXTURES_DIR}/deps/.netlify/functions/`, `${FIXTURES_DIR}/deps/functions/node_modules/`])
   await runFixture(t, 'deps')
-  await del(`${FIXTURES_DIR}/deps/functions/node_modules/`)
+  await removeDir(`${FIXTURES_DIR}/deps/functions/node_modules/`)
 })
 
 test('Functions: install dependencies nested', async t => {
-  await del([
+  await removeDir([
     `${FIXTURES_DIR}/deps_dir/.netlify/functions/`,
     `${FIXTURES_DIR}/deps_dir/functions/function/node_modules/`,
   ])
   await runFixture(t, 'deps_dir')
-  await del(`${FIXTURES_DIR}/deps_dir/functions/function/node_modules/`)
+  await removeDir(`${FIXTURES_DIR}/deps_dir/functions/function/node_modules/`)
 })
 
 test('Functions: ignore package.json inside node_modules', async t => {
-  await del(`${FIXTURES_DIR}/deps_node_modules/.netlify/functions/`)
+  await removeDir(`${FIXTURES_DIR}/deps_node_modules/.netlify/functions/`)
   await runFixture(t, 'deps_node_modules')
 })

--- a/packages/build/tests/plugins/install/tests.js
+++ b/packages/build/tests/plugins/install/tests.js
@@ -2,14 +2,13 @@ const { platform } = require('process')
 const { tmpdir } = require('os')
 
 const test = require('ava')
-const del = require('del')
 const cpy = require('cpy')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
+const { runFixture, FIXTURES_DIR, removeDir } = require('../../helpers/main')
 
 test('Install local plugin dependencies: with npm', async t => {
   await runFixture(t, 'npm')
-  await del(`${FIXTURES_DIR}/npm/plugin/node_modules`)
+  await removeDir(`${FIXTURES_DIR}/npm/plugin/node_modules`)
 })
 
 // This test does not work on Windows when run inside Ava
@@ -17,7 +16,7 @@ test('Install local plugin dependencies: with npm', async t => {
 if (platform !== 'win32') {
   test.skip('Install local plugin dependencies: with yarn', async t => {
     await runFixture(t, 'yarn')
-    await del(`${FIXTURES_DIR}/yarn/plugin/node_modules`)
+    await removeDir(`${FIXTURES_DIR}/yarn/plugin/node_modules`)
   })
 }
 
@@ -38,11 +37,5 @@ test('Install local plugin dependencies: no root package.json', async t => {
   await cpy('**', tmpDir, { cwd: `${FIXTURES_DIR}/no_root_package`, parents: true })
 
   await runFixture(t, 'no_root_package', { config: `${tmpDir}/netlify.yml` })
-
-  try {
-    await del(tmpDir, { force: true })
-    // This sometimes fails on Windows in CI due to Windows directory looking.
-    // This results in `EBUSY: resource busy or locked, rmdir /path/to/dir`
-    // eslint-disable-next-line no-empty
-  } catch (error) {}
+  await removeDir(tmpDir, { force: true })
 })


### PR DESCRIPTION
Tests sometimes fail on Windows due to directory locking (`EBUSY`). A previous PR fixed it for one specific test, but this is a more generic problem. This PR introduces a helper function to solve this for all tests.