### PR TITLE
Fix utilities `README`

### DIFF
--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -142,12 +142,6 @@ module.exports = {
 }
 ```
 
-# Install
-
-```
-npm install @netlify/cache-utils
-```
-
 # API
 
 ## save(path, options?)

--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -19,12 +19,6 @@ module.exports = {
 }
 ```
 
-# Install
-
-```
-npm install @netlify/functions-utils
-```
-
 # API
 
 ## add(path)

--- a/packages/git-utils/README.md
+++ b/packages/git-utils/README.md
@@ -7,12 +7,6 @@
 
 Utility for dealing with modified, created, deleted files since a git commit.
 
-## Install
-
-```bash
-npm install @netlify/git-utils
-```
-
 ## Usage
 
 ```js

--- a/packages/run-utils/README.md
+++ b/packages/run-utils/README.md
@@ -75,12 +75,6 @@ const exampleNetlifyPlugin = {
 }
 ```
 
-# Install
-
-```
-npm install @netlify/run-utils
-```
-
 # API
 
 ## run(file, arguments, options?)


### PR DESCRIPTION
It is not required to run `npm install` anymore to use utilities.
This PR fixes documentation to reflect this.