### PR TITLE
Fix git user name

### DIFF
--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -136,6 +136,8 @@ const createRepoDir = async function() {
   await execa.command('git config user.name test', { cwd })
   await execa.command('git commit --allow-empty -m one', { cwd })
   await execa.command('git commit --allow-empty -m two', { cwd })
+  await execa.command('git config --unset user.email', { cwd })
+  await execa.command('git config --unset user.name', { cwd })
 
   return cwd
 }


### PR DESCRIPTION
This fixes the git user name being `test` during tests, which shows up in GitHub actions and Codecov UI.