### PR TITLE
Fix CI detection

### DIFF
--- a/packages/build/src/utils/is-netlify-ci.js
+++ b/packages/build/src/utils/is-netlify-ci.js
@@ -1,4 +1,10 @@
-// Test if inside netlify build context
-module.exports = function isNetlifyCI() {
-  return Boolean(process.env.DEPLOY_PRIME_URL)
+const {
+  env: { NETLIFY },
+} = require('process')
+
+// Check if inside Netlify Build CI
+const isNetlifyCI = function() {
+  return Boolean(NETLIFY)
 }
+
+module.exports = isNetlifyCI

--- a/packages/build/tests/cache/main/tests.js
+++ b/packages/build/tests/cache/main/tests.js
@@ -12,6 +12,6 @@ test('Cache local', async t => {
 // TODO: figure out why
 if (platform !== 'win32') {
   test('Cache CI', async t => {
-    await runFixture(t, 'ci', { env: { TEST_CACHE_PATH: 'bower_components', DEPLOY_PRIME_URL: 'test' } })
+    await runFixture(t, 'ci', { env: { TEST_CACHE_PATH: 'bower_components', NETLIFY: 'true' } })
   })
 }

--- a/packages/build/tests/log/colors/tests.js
+++ b/packages/build/tests/log/colors/tests.js
@@ -24,7 +24,7 @@ test('Netlify CI', async t => {
     snapshot: false,
     normalize: false,
     flags: '--dry',
-    env: { DEPLOY_PRIME_URL: 'test' },
+    env: { NETLIFY: 'true' },
   })
   t.true(hasAnsi(all))
 })

--- a/packages/build/tests/plugins/constants/tests.js
+++ b/packages/build/tests/plugins/constants/tests.js
@@ -54,7 +54,7 @@ test('constants.CACHE_DIR local', async t => {
 })
 
 test('constants.CACHE_DIR CI', async t => {
-  await runFixture(t, 'cache', { env: { DEPLOY_PRIME_URL: 'test' } })
+  await runFixture(t, 'cache', { env: { NETLIFY: 'true' } })
 })
 
 test('constants.SITE_ID', async t => {

--- a/packages/build/tests/plugins/run/tests.js
+++ b/packages/build/tests/plugins/run/tests.js
@@ -17,5 +17,5 @@ test.serial('Big plugin output is not truncated', async t => {
 })
 
 test('Plugin output is buffered in CI', async t => {
-  await runFixture(t, 'ci', { env: { DEPLOY_PRIME_URL: 'test' } })
+  await runFixture(t, 'ci', { env: { NETLIFY: 'true' } })
 })

--- a/packages/build/tests/utils/cache/tests.js
+++ b/packages/build/tests/utils/cache/tests.js
@@ -89,7 +89,7 @@ test('cache-utils digests many', async t => {
 // TODO: figure out why
 if (!isCi || !version.startsWith('v8.')) {
   test('cache-utils ci', async t => {
-    await runFixture(t, 'save', { env: { DEPLOY_PRIME_URL: 'test' } })
+    await runFixture(t, 'save', { env: { NETLIFY: 'true' } })
   })
 }
 

--- a/packages/cache-utils/src/ci.js
+++ b/packages/cache-utils/src/ci.js
@@ -1,10 +1,10 @@
 const {
-  env: { DEPLOY_PRIME_URL },
+  env: { NETLIFY },
 } = require('process')
 
 // Check if inside Netlify Build CI
 const isNetlifyCI = function() {
-  return Boolean(DEPLOY_PRIME_URL)
+  return Boolean(NETLIFY)
 }
 
 module.exports = { isNetlifyCI }


### PR DESCRIPTION
The CI detection internal logic currently relies on `DEPLOY_PRIME_URL`. We should instead rely on the `NETLIFY=true` environment variable, which purpose is specifically to detect whether we are inside the Netlify CI.

Related to #734.