### PR TITLE
Update error logging

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -2,11 +2,13 @@ const execa = require('execa')
 const pMapSeries = require('p-map-series')
 const pReduce = require('p-reduce')
 const { EVENTS } = require('@netlify/config')
+const { white, redBright } = require('chalk')
 
 const { callChild } = require('../plugins/ipc')
 const { logCommandsStart, logCommand, logShellCommandStart, logCommandSuccess } = require('../log/main')
 const { startTimer, endTimer } = require('../log/timer')
 const { startOutput, stopOutput } = require('../log/stream')
+const { getPluginDetails } = require('../log/package')
 
 // Get commands for all events
 const getCommands = function({ pluginsCommands, netlifyConfig }) {
@@ -146,19 +148,34 @@ const fireShellCommand = async function({ event, shellCommand, baseDir }) {
 }
 
 // Fire a plugin command
-const firePluginCommand = async function({ id, childProcess, event, originalEvent }, { error }) {
+const firePluginCommand = async function(
+  { id, childProcess, event, originalEvent, package, packageData, local },
+  { error },
+) {
   const chunks = []
   startOutput(childProcess, chunks)
 
   try {
     await callChild(childProcess, 'run', { originalEvent, error })
   } catch (error) {
-    error.message = `In "${event}" command from "${id}":\n${error.message}`
+    error.message = getPluginErrorMessage({ error, id, event, package, packageData, local })
     error.cleanStack = true
     throw error
   } finally {
     await stopOutput(childProcess, chunks)
   }
+}
+
+const getPluginErrorMessage = function({ error, id, event, package, packageData, local }) {
+  const pluginDetails = getPluginDetails(packageData, id)
+  const location = local ? 'in local plugin' : 'in npm package'
+  return `${white.bold(`Plugin "${id}" failing with errors`)}
+${pluginDetails}
+${redBright.bold('Error location')}
+Thrown from "${white.bold(event)}" event ${location} ${white.bold(package)}
+
+${redBright.bold('Error message')}
+${error.message}`
 }
 
 module.exports = { getCommands, runCommands }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -196,6 +196,8 @@ const logBuildError = function(error) {
   log(`
 ${redBright.bold(getHeader('Netlify Build Error'))}
 ${errorStack}
+
+${redBright.bold(getHeader('END Netlify Build Error'))}
 `)
 }
 

--- a/packages/build/src/log/package.js
+++ b/packages/build/src/log/package.js
@@ -1,0 +1,69 @@
+const { redBright } = require('chalk')
+
+const isNetlifyCI = require('../utils/is-netlify-ci')
+
+// Retrieve plugin's package.json details to include in error messages.
+// Please note `packageJson` has been normalized by `normalize-package-data`.
+const getPluginDetails = function(packageJson, id) {
+  // Local logs are less verbose to allow developers to focus on the stack trace
+  if (!isNetlifyCI()) {
+    return ''
+  }
+
+  const fields = serializeFields(packageJson, id)
+  return `
+${redBright.bold('Plugin details')}
+${fields}`
+}
+
+// Iterate over a series of package.json fields, serialize each then join them
+const serializeFields = function(packageJson, id) {
+  return Object.entries(FIELDS)
+    .map(([name, getField]) => serializeField({ name, getField, packageJson, id }))
+    .filter(Boolean)
+    .join('\n')
+}
+
+// Serialize a single package.json field
+const serializeField = function({ name, getField, packageJson, id }) {
+  const field = getField(packageJson, id)
+  if (field === undefined) {
+    return
+  }
+
+  const nameA = `${name}:`.padEnd(NAME_PADDING)
+  return `${nameA}${field}`
+}
+
+const NAME_PADDING = 16
+
+const getId = function(packageJson, id) {
+  return id
+}
+
+const getVersion = function({ version }) {
+  return version
+}
+
+const getRepository = function({ repository: { url } = {} }) {
+  return url
+}
+
+const getNpmLink = function({ name }) {
+  return `https://www.npmjs.com/package/${name}`
+}
+
+const getIssuesLink = function({ bugs: { url } = {} }) {
+  return url
+}
+
+// List of package.json to serialize
+const FIELDS = {
+  ID: getId,
+  Version: getVersion,
+  Repository: getRepository,
+  'NPM link': getNpmLink,
+  'Report issues': getIssuesLink,
+}
+
+module.exports = { getPluginDetails }


### PR DESCRIPTION
Update error logging to include package.json information including git url, npm url, issues url, & version of plugin info.

Fixes https://github.com/netlify/build/issues/764

Remote CI will see the following, with a big block to determine where the error logs end as well. This is due to additional logs spit out afterwards by buildbot

![image](https://user-images.githubusercontent.com/532272/74577979-dd75a080-4f46-11ea-9b8f-1e905fbc443a.png)

Local view is less verbose, to allow devs to focus on the error & stack trace

![image](https://user-images.githubusercontent.com/532272/74578010-085ff480-4f47-11ea-8edd-fbd47ae202a4.png)

