### PR TITLE
Fix missing empty lines in logs

### DIFF
--- a/packages/build/src/log/empty.js
+++ b/packages/build/src/log/empty.js
@@ -1,0 +1,5 @@
+// We need to add a zero width space character in empty lines. Otherwise the
+// buildbot removes those due to a bug: https://github.com/netlify/buildbot/issues/595
+const EMPTY_LINE = '\u{200b}'
+
+module.exports = { EMPTY_LINE }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -9,7 +9,8 @@ const filterObj = require('filter-obj')
 const { version } = require('../../package.json')
 
 const { log } = require('./logger')
-const { cleanStacks } = require('./stack.js')
+const { cleanStacks } = require('./stack')
+const { EMPTY_LINE } = require('./empty')
 
 const HEADING_PREFIX = pointer
 const SUBTEXT_PADDING = '  '
@@ -17,7 +18,7 @@ const SUBTEXT_PADDING = '  '
 const logBuildStart = function() {
   log(`${greenBright.bold(`${HEADING_PREFIX} Starting Netlify Build v${version}`)}
 ${SUBTEXT_PADDING}https://github.com/netlify/build
-`)
+${EMPTY_LINE}`)
 }
 
 const logFlags = function(flags) {
@@ -34,7 +35,7 @@ const isDefined = function(key, value) {
 const logCurrentDirectory = function() {
   log(`${cyanBright.bold(`${HEADING_PREFIX} Current directory`)}
 ${SUBTEXT_PADDING}${cwd()}
-`)
+${EMPTY_LINE}`)
 }
 
 const logConfigPath = function(configPath) {
@@ -45,7 +46,7 @@ const logConfigPath = function(configPath) {
 
   log(`${cyanBright.bold(`${HEADING_PREFIX} Config file`)}
 ${SUBTEXT_PADDING}${configPath}
-`)
+${EMPTY_LINE}`)
 }
 
 const logResolveError = function(error, package) {
@@ -63,7 +64,10 @@ const logInstallPlugins = function() {
 }
 
 const logLoadPlugins = function() {
-  log(cyanBright.bold(`\n${HEADING_PREFIX} Loading plugins`))
+  log(
+    cyanBright.bold(`${EMPTY_LINE}
+${HEADING_PREFIX} Loading plugins`),
+  )
 }
 
 const logLoadedPlugins = function(pluginCommands) {
@@ -86,7 +90,8 @@ const getLoadedPlugin = function({ id, package, core, packageJson: { version } }
 }
 
 const logCommandsStart = function(commandsCount) {
-  log(`\n${greenBright.bold(`${HEADING_PREFIX} Running Netlify Build Lifecycle`)}
+  log(`${EMPTY_LINE}
+${greenBright.bold(`${HEADING_PREFIX} Running Netlify Build Lifecycle`)}
 ${SUBTEXT_PADDING}Found ${commandsCount} commands. Lets do this!`)
 }
 
@@ -147,16 +152,16 @@ const getDryColumnWidth = function(eventWidth, commandsCount) {
 const DRY_HEADER_NAMES = ['Event', 'Location']
 
 const logDryRunEnd = function() {
-  log(`
+  log(`${EMPTY_LINE}
 ${SUBTEXT_PADDING}If this looks good to you, run \`netlify build\` to execute the build
-`)
+${EMPTY_LINE}`)
 }
 
 const logCommand = function({ event, id, override }, { index, configPath, error }) {
   const overrideWarning =
     override.event === undefined
       ? ''
-      : redBright(`
+      : redBright(`${EMPTY_LINE}
 ${HEADING_PREFIX} OVERRIDE: "${override.event}" command in "${override.name}" has been overriden by "${id}"`)
   const configName = configPath === undefined ? '' : ` from ${basename(configPath)} config file`
   const description = id.startsWith('config.build')
@@ -164,7 +169,11 @@ ${HEADING_PREFIX} OVERRIDE: "${override.event}" command in "${override.name}" ha
     : `${bold(event)} command from ${bold(id)}`
   const logColor = error ? redBright.bold : cyanBright.bold
   const header = `${index}. Running ${description}`
-  log(logColor(`${overrideWarning}\n${getHeader(header)}\n`))
+  log(
+    logColor(`${overrideWarning}
+${getHeader(header)}
+${EMPTY_LINE}`),
+  )
 }
 
 const logShellCommandStart = function(shellCommand) {
@@ -172,7 +181,7 @@ const logShellCommandStart = function(shellCommand) {
 }
 
 const logCommandSuccess = function() {
-  log('')
+  log(EMPTY_LINE)
 }
 
 const logTimer = function(durationMs, event, id) {
@@ -193,20 +202,26 @@ const logCacheDir = function(path) {
 
 const logBuildError = function(error) {
   const errorStack = error.cleanStack ? cleanStacks(error.message) : `\n${error.stack}`
-  log(`
+  log(`${EMPTY_LINE}
 ${redBright.bold(getHeader('Netlify Build Error'))}
 ${errorStack}
-
+${EMPTY_LINE}
 ${redBright.bold(getHeader('END Netlify Build Error'))}
-`)
+${EMPTY_LINE}`)
 }
 
 const logBuildSuccess = function() {
-  log(greenBright.bold(`\n${getHeader('Netlify Build Complete')}\n`))
+  log(
+    greenBright.bold(`${EMPTY_LINE}
+${getHeader('Netlify Build Complete')}
+${EMPTY_LINE}`),
+  )
 }
 
 const logBuildEnd = function() {
-  log(`\n${cyanBright(SPARKLES)} Have a nice day!\n`)
+  log(`${EMPTY_LINE}
+${cyanBright(SPARKLES)} Have a nice day!
+${EMPTY_LINE}`)
 }
 
 const SPARKLES = platform === 'win32' ? '(/Ò_Ò)/' : '(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧'

--- a/packages/build/src/log/plugin_error.js
+++ b/packages/build/src/log/plugin_error.js
@@ -2,6 +2,8 @@ const { white, redBright } = require('chalk')
 
 const isNetlifyCI = require('../utils/is-netlify-ci')
 
+const { EMPTY_LINE } = require('./empty')
+
 // Retrieve error message when a plugin event handler fails
 const getPluginErrorMessage = function({ error, id, event, package, packageJson, local }) {
   const pluginDetails = getPluginDetails(packageJson, id)
@@ -20,14 +22,14 @@ ${error.message}`
 const getPluginDetails = function(packageJson, id) {
   // Local logs are less verbose to allow developers to focus on the stack trace
   if (!isNetlifyCI()) {
-    return ''
+    return EMPTY_LINE
   }
 
   const fields = serializeFields(packageJson, id)
-  return `
+  return `${EMPTY_LINE}
 ${redBright.bold('Plugin details')}
 ${fields}
-`
+${EMPTY_LINE}`
 }
 
 // Iterate over a series of package.json fields, serialize each then join them

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -12,6 +12,9 @@ const replaceOutput = function(output, [regExp, replacement]) {
 }
 
 const NORMALIZE_REGEXPS = [
+  // Zero width space characters due to a bug in buildbot:
+  // https://github.com/netlify/buildbot/issues/595
+  [/\u{200b}/gu, ''],
   // Windows specifics
   [/\r\n/gu, '\n'],
   [/\\/gu, '/'],


### PR DESCRIPTION
Some empty lines are missing in logs in production due to a bug in the buildbot (https://github.com/netlify/buildbot/issues/595).
This PR implements a workaround for this while this bug is being fixed.