### PR TITLE
Small refactoring of empty values

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -15,14 +15,15 @@ const loadConfig = async function(flags) {
   logCurrentDirectory()
 
   const flagsB = { ...DEFAULT_FLAGS, ...flagsA }
-  const { config, cwd, dry, token, siteId, context } = flagsB
+  const flagsC = filterObj(flagsB, isDefined)
+  const { config, cwd, dry, token, siteId, context } = flagsC
 
   // Retrieve configuration file path and base directory
   const configPath = await getConfigPath(config, cwd)
   logConfigPath(configPath)
   const baseDir = await getBaseDir(configPath)
 
-  const netlifyConfig = await resolveFullConfig(configPath, flagsB)
+  const netlifyConfig = await resolveFullConfig(configPath, flagsC)
   return { netlifyConfig, configPath, baseDir, token, dry, siteId, context }
 }
 


### PR DESCRIPTION
Some CLI flags can be either an empty string or `undefined`. This PR normalizes them to `undefined` only for consistency purpose.