### PR TITLE
Load Netlify Site information in local builds

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -8,6 +8,8 @@ const filterObj = require('filter-obj')
 
 const { logFlags, logCurrentDirectory, logConfigPath } = require('../log/main')
 
+const { getSiteInfo } = require('./site_info')
+
 // Retrieve configuration object
 const loadConfig = async function(flags) {
   const flagsA = filterObj(flags, isDefined)
@@ -24,7 +26,9 @@ const loadConfig = async function(flags) {
   const baseDir = await getBaseDir(configPath)
 
   const netlifyConfig = await resolveFullConfig(configPath, flagsC)
-  return { netlifyConfig, configPath, baseDir, token, dry, siteId, context }
+
+  const siteInfo = await getSiteInfo(token, siteId)
+  return { netlifyConfig, configPath, baseDir, token, dry, siteInfo, context }
 }
 
 // Remove undefined and empty CLI flags

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -35,7 +35,7 @@ const build = async function(flags) {
   try {
     logBuildStart()
 
-    const { netlifyConfig, configPath, baseDir, token, dry, siteId, context } = await loadConfig(flags)
+    const { netlifyConfig, configPath, baseDir, token, dry, siteInfo, context } = await loadConfig(flags)
 
     const pluginsOptions = await getPluginsOptions(netlifyConfig, baseDir)
     await installPlugins(pluginsOptions, baseDir)
@@ -47,7 +47,7 @@ const build = async function(flags) {
       baseDir,
       token,
       dry,
-      siteId,
+      siteInfo,
       context,
     })
 
@@ -58,7 +58,7 @@ const build = async function(flags) {
     logBuildSuccess()
     const duration = endTimer(buildTimer, 'Netlify Build')
     logBuildEnd()
-    await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteId })
+    await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo })
     return true
   } catch (error) {
     logBuildError(error)
@@ -66,7 +66,7 @@ const build = async function(flags) {
   }
 }
 
-const buildRun = async function({ pluginsOptions, netlifyConfig, configPath, baseDir, token, dry, siteId, context }) {
+const buildRun = async function({ pluginsOptions, netlifyConfig, configPath, baseDir, token, dry, siteInfo, context }) {
   const utilsData = await startUtils(baseDir)
   const childEnv = await getChildEnv(baseDir, context)
   const childProcesses = await startPlugins(pluginsOptions, baseDir, childEnv)
@@ -82,7 +82,7 @@ const buildRun = async function({ pluginsOptions, netlifyConfig, configPath, bas
       childEnv,
       token,
       dry,
-      siteId,
+      siteInfo,
     })
   } finally {
     await stopPlugins(childProcesses)
@@ -99,7 +99,7 @@ const executeCommands = async function({
   childEnv,
   token,
   dry,
-  siteId,
+  siteInfo,
 }) {
   const pluginsCommands = await loadPlugins({
     pluginsOptions,
@@ -109,7 +109,7 @@ const executeCommands = async function({
     configPath,
     baseDir,
     token,
-    siteId,
+    siteInfo,
   })
 
   const { mainCommands, buildCommands, endCommands, errorCommands, commandsCount } = getCommands({

--- a/packages/build/src/core/site_info.js
+++ b/packages/build/src/core/site_info.js
@@ -1,0 +1,37 @@
+const {
+  env: { BUILD_SITE_INFO },
+} = require('process')
+
+const NetlifyAPI = require('netlify')
+
+const isNetlifyCI = require('../utils/is-netlify-ci')
+
+// Retrieve Netlify Site information, if availabled.
+// This is only used for local builds environment variables at the moment.
+const getSiteInfo = async function(token, id) {
+  if (token === undefined || id === undefined || isNetlifyCI()) {
+    return { id }
+  }
+
+  const api = new NetlifyAPI(token)
+  const siteInfo = await getSite(id, api)
+  return { ...siteInfo, id }
+}
+
+const getSite = async function(site_id, api) {
+  try {
+    // Used for testing.
+    // TODO: find a better method not to pollute source code with test mocking.
+    if (BUILD_SITE_INFO !== undefined) {
+      return JSON.parse(BUILD_SITE_INFO)
+    }
+
+    return await api.getSite({ site_id })
+    // Silently ignore errors. For example the network connection might be down,
+    // but local builds should still work regardless.
+  } catch (error) {
+    return {}
+  }
+}
+
+module.exports = { getSiteInfo }

--- a/packages/build/src/plugins/child/constants.js
+++ b/packages/build/src/plugins/child/constants.js
@@ -16,7 +16,7 @@ const getConstants = async function({
   netlifyConfig: {
     build: { publish, functions = DEFAULT_FUNCTIONS },
   },
-  siteId,
+  siteInfo: { id: siteId },
 }) {
   const isLocal = !isNetlifyCI()
   const functionsDist = getFunctionsDist(isLocal)

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -15,7 +15,7 @@ const loadPlugins = async function({
   configPath,
   baseDir,
   token,
-  siteId,
+  siteInfo,
 }) {
   logLoadPlugins()
 
@@ -29,7 +29,7 @@ const loadPlugins = async function({
         configPath,
         baseDir,
         token,
-        siteId,
+        siteInfo,
       }),
     ),
   )
@@ -46,7 +46,7 @@ const loadPlugins = async function({
 // Do it by executing the plugin `load` event handler.
 const loadPlugin = async function(
   { package, pluginPath, pluginConfig, id, core, local },
-  { childProcesses, index, netlifyConfig, utilsData, configPath, baseDir, token, siteId },
+  { childProcesses, index, netlifyConfig, utilsData, configPath, baseDir, token, siteInfo },
 ) {
   try {
     const { childProcess } = childProcesses[index]
@@ -62,7 +62,7 @@ const loadPlugin = async function(
       local,
       baseDir,
       token,
-      siteId,
+      siteInfo,
     })
     const pluginCommandsA = pluginCommands.map(pluginCommand => ({ ...pluginCommand, childProcess }))
     return pluginCommandsA

--- a/packages/build/src/telemetry/index.js
+++ b/packages/build/src/telemetry/index.js
@@ -15,12 +15,12 @@ const telemetry = Analytics({
 })
 
 // Send telemetry request when build completes
-const trackBuildComplete = async function({ commandsCount, netlifyConfig, duration, siteId }) {
-  const payload = getPayload({ commandsCount, netlifyConfig, duration, siteId })
+const trackBuildComplete = async function({ commandsCount, netlifyConfig, duration, siteInfo }) {
+  const payload = getPayload({ commandsCount, netlifyConfig, duration, siteInfo })
   await telemetry.track('buildComplete', payload)
 }
 
-const getPayload = function({ commandsCount, netlifyConfig, duration, siteId }) {
+const getPayload = function({ commandsCount, netlifyConfig, duration, siteInfo: { id: siteId } }) {
   const plugins = Object.values(netlifyConfig.plugins).map(getPluginPackage)
   return { steps: commandsCount, duration, pluginCount: plugins.length, plugins, siteId }
 }


### PR DESCRIPTION
This PR makes builds load the current Netlify Site information so it can be used in other parts of the build. 

Since this is currently only meant to be used for environment variables inside local builds, and calling the `getSite` API endpoint is slow, this is only performed in local builds that have the required information to perform the call. Otherwise, it is silently ignored.