### PR TITLE
Fix test failing on Node `8.3.0`

### DIFF
--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -37,8 +37,8 @@ const NORMALIZE_REGEXPS = [
   // CI tests show some error messages differently
   [/\/file\/path bad option/g, 'node: bad option'],
   // Stack traces
-  [/Require stack:\n[^}]*}/g, ''],
   [/Require stack:\n(\s*- \/file\/path\n)+/g, ''],
+  [/Require stack:\n[^}]*}/g, ''],
   [/{ Error:/g, 'Error:'],
   [/^.*:\d+:\d+\)?$/gm, 'STACK TRACE'],
   [/^\s+at .*$/gm, 'STACK TRACE'],


### PR DESCRIPTION
This fixes a test that was failing on Node `8.3.0` due to Node 10 changing adding new properties to some types of errors.