### PR TITLE
Remove backwards compat `config` from plugin lifecycle API

### DIFF
--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -77,8 +77,7 @@ const run = async function(
   { context: { pluginCommands, api, utils, constants, pluginConfig, netlifyConfig } },
 ) {
   const { method } = pluginCommands.find(pluginCommand => pluginCommand.originalEvent === originalEvent)
-  // TODO: remove `config` after releasing the Beta, since it's legacy
-  await method({ api, utils, constants, pluginConfig, config: netlifyConfig, netlifyConfig, error })
+  await method({ api, utils, constants, pluginConfig, netlifyConfig, error })
 }
 
 const EVENTS = { load, run }


### PR DESCRIPTION
Fixes #820.

This removes the `config` argument passed to plugin event handlers. This has been renamed to `netlifyConfig` and nobody is currently using it.