### PR TITLE
Simplify error handling in `@netlify/config`

### DIFF
--- a/packages/config/src/base_dir.js
+++ b/packages/config/src/base_dir.js
@@ -6,6 +6,8 @@ const {
 } = require('fs')
 const { promisify } = require('util')
 
+const { throwError } = require('./error')
+
 const pAccess = promisify(access)
 
 // Retrieve the base directory used to resolve most paths.
@@ -28,9 +30,7 @@ const validatePermissions = async function(baseDir) {
   try {
     await pAccess(baseDir, R_OK | W_OK)
   } catch (error) {
-    const errorA = new Error(`Wrong permissions on the base directory ${baseDir}`)
-    errorA.type = 'userError'
-    throw errorA
+    throwError(`Wrong permissions on the base directory ${baseDir}`)
   }
 }
 

--- a/packages/config/src/error.js
+++ b/packages/config/src/error.js
@@ -1,0 +1,23 @@
+// We distinguish between errors thrown intentionally and uncaught exceptions
+// (such as bugs) with a `type` property.
+const throwError = function(messageOrError, error) {
+  const errorA = getError(messageOrError, error)
+  errorA.type = 'userError'
+  throw errorA
+}
+
+// Can pass either `message`, `error` or `message, error`
+const getError = function(messageOrError, error) {
+  if (messageOrError instanceof Error) {
+    return messageOrError
+  }
+
+  if (error === undefined) {
+    return new Error(messageOrError)
+  }
+
+  error.message = `${messageOrError}\n${error.message}`
+  return error
+}
+
+module.exports = { throwError }

--- a/packages/config/src/path.js
+++ b/packages/config/src/path.js
@@ -5,6 +5,8 @@ const findUp = require('find-up')
 const resolvePath = require('resolve')
 const pathExists = require('path-exists')
 
+const { throwError } = require('./error')
+
 const pResolve = promisify(resolvePath)
 
 // Configuration location can be:
@@ -40,9 +42,7 @@ const getModuleConfig = async function(configFile, cwd) {
   try {
     return await pResolve(configFile, { basedir: cwd })
   } catch (error) {
-    error.message = `Configuration file does not exist: ${configFile}\n${error.message}`
-    error.type = 'userError'
-    throw error
+    throwError(`Configuration file does not exist: ${configFile}`, error)
   }
 }
 
@@ -50,9 +50,7 @@ const getLocalConfig = async function(configFile, cwd = process.cwd()) {
   const configPath = resolve(cwd, configFile)
 
   if (!(await pathExists(configPath))) {
-    const error = new Error(`Configuration file does not exist: ${configPath}`)
-    error.type = 'userError'
-    throw error
+    throwError(`Configuration file does not exist: ${configPath}`)
   }
 
   return configPath

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -1,5 +1,7 @@
 const { cyan } = require('chalk')
 
+const { throwError } = require('../error')
+
 const { VALIDATIONS } = require('./validations')
 const { getExample } = require('./example')
 
@@ -11,8 +13,7 @@ const validateConfig = function(config) {
       validateProperty(config, { ...validation, nextPath: property.split('.') })
     })
   } catch (error) {
-    error.type = 'userError'
-    throw error
+    throwError(error)
   }
 }
 
@@ -62,14 +63,14 @@ const validateProperty = function(
 
 const reportError = function({ prevPath, propPath, message, example, warn, value, key, parent }) {
   const messageA = typeof message === 'function' ? message(value, key, parent) : message
-  const error = `Configuration property ${cyan.bold(propPath)} ${messageA}
+  const errorMessage = `Configuration property ${cyan.bold(propPath)} ${messageA}
 ${getExample({ value, parent, key, prevPath, example })}`
 
   if (!warn) {
-    throw new Error(error)
+    throwError(errorMessage)
   }
 
-  console.warn(`${error}\n`)
+  console.warn(`${errorMessage}\n`)
 }
 
 // Recurse over children (each part of the `property` array).
@@ -125,7 +126,7 @@ const checkRequired = function({ value, required, propPath, prevPath, example })
 
   // Not used yet
   // istanbul ignore next
-  throw new Error(`Configuration property ${cyan.bold(propPath)} is required.
+  throwError(`Configuration property ${cyan.bold(propPath)} is required.
 ${getExample({ value, prevPath, example })}`)
 }
 


### PR DESCRIPTION
Related to #802.

In `@netlify/config`, we currently distinguish between errors that are:
  - caused by user, such as configuration file syntax errors
  - caused by our code or plugins code, which are most likely bugs

We do this in order to report this differently.

We do it by adding a `type: 'userError'` property to user errors. 
Note: we do this instead of defining a custom `Error` class since it's easier to keep the original error (and its stack trace) this way.

This PR simply refactors the code to provide with a common utility for throwing errors that follow that pattern, instead of adding that `type` property all the times. This is refactoring only, no behavior changes.