### PR TITLE
Fix default value of `build.publish`

### DIFF
--- a/packages/build/src/plugins/child/constants.js
+++ b/packages/build/src/plugins/child/constants.js
@@ -14,7 +14,7 @@ const getConstants = async function({
   configPath,
   baseDir,
   netlifyConfig: {
-    build: { publish, functions },
+    build: { publish = baseDir, functions },
   },
   siteInfo: { id: siteId },
 }) {

--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -6,31 +6,20 @@ const makeDir = require('make-dir')
 
 // Normalize and validate configuration properties that refer to directories
 const handleFiles = async function(config, baseDir) {
-  const files = await Promise.all(FILES.map(file => handleFile(config, baseDir, file)))
+  const files = await Promise.all(FILES.map(location => handleFile(config, baseDir, location)))
   return files.reduce(setProp, config)
 }
 
 // List of configuration properties that refer to directories
-const FILES = [{ location: 'build.publish' }, { location: 'build.functions' }]
+const FILES = ['build.publish', 'build.functions']
 
-const handleFile = async function(config, baseDir, { location, defaultPath }) {
+const handleFile = async function(config, baseDir, location) {
   const path = get(config, location)
 
-  const pathA = addDefault({ path, baseDir, defaultPath })
-  const pathB = normalizePath(pathA, baseDir)
-  await ensurePath(pathB)
+  const pathA = normalizePath(path, baseDir)
+  await ensurePath(pathA)
 
-  return { location, path: pathB }
-}
-
-// Add default value
-const addDefault = function({ path, baseDir, defaultPath }) {
-  if (path !== undefined || defaultPath === undefined) {
-    return path
-  }
-
-  const defaultPathA = resolve(baseDir, defaultPath)
-  return defaultPathA
+  return { location, path: pathA }
 }
 
 // Resolve paths relatively to the config file.

--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -11,7 +11,7 @@ const handleFiles = async function(config, baseDir) {
 }
 
 // List of configuration properties that refer to directories
-const FILES = [{ location: 'build.publish', defaultPath: baseDir => baseDir }, { location: 'build.functions' }]
+const FILES = [{ location: 'build.publish' }, { location: 'build.functions' }]
 
 const handleFile = async function(config, baseDir, { location, defaultPath }) {
   const path = get(config, location)
@@ -29,9 +29,8 @@ const addDefault = function({ path, baseDir, defaultPath }) {
     return path
   }
 
-  const defaultPathA = typeof defaultPath === 'function' ? defaultPath(baseDir) : defaultPath
-  const defaultPathB = resolve(baseDir, defaultPathA)
-  return defaultPathB
+  const defaultPathA = resolve(baseDir, defaultPath)
+  return defaultPathA
 }
 
 // Resolve paths relatively to the config file.


### PR DESCRIPTION
Fixes #665.
Related to #802.

`@netlify/config` is assigning a default value of `build.publish` to the base directory. 
This is what the buildbot does from a logic standpoint. However:
  - The CLI needs to know whether `build.publish` was defined or not by the user, because it errors then (unlike the `--prod` CLI flag is used), which is different from what the buildbot is doing (see #665)
  - The current buildbot does not assign that default value. Instead, it leaves the value empty. To be on the safe side once the buildbot starts using `@netlify/config`, this PR replicates that behavior.

Note that the `BASE_DIR` constant passed to plugin still has the default value, since it's more convenient for plugin authors.