### PR TITLE
Fix invalid test

### DIFF
--- a/packages/build/tests/core/telemetry/tests.js
+++ b/packages/build/tests/core/telemetry/tests.js
@@ -64,7 +64,7 @@ test('Telemetry error', async t => {
   const { stopServer } = await startServer()
   await runFixture(t, 'success', {
     flags: '--site-id=test',
-    env: { BUILD_TELEMETRY_DISABLED: '', BUILD_TELEMETRY_URL: 'invalid' },
+    env: { BUILD_TELEMETRY_DISABLED: '', BUILD_TELEMETRY_URL: '...' },
   })
   await stopServer()
 })


### PR DESCRIPTION
An integration test is currently hanging when run locally (but not in CI) due to an incorrect parameter. This PR fixes that.

The test is meant to perform an invalid HTTP request but the current parameter was actually valid, making the test hang.