### PR TITLE
Improve error message in `@netlify/config`

### DIFF
--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -25,7 +25,8 @@ const resolveConfig = async function(configFile, { cwd = getCwd() } = {}) {
     const configC = await handleFiles(configB, baseDir)
     return configC
   } catch (error) {
-    error.message = `When resolving config file ${configPath}:\n${error.message}`
+    const configMessage = configPath === undefined ? '' : ` file ${configPath}`
+    error.message = `When resolving config${configMessage}:\n${error.message}`
     throw error
   }
 }


### PR DESCRIPTION
This PR improves an error message shown when an error is thrown inside `@netlify/config` but the user is using no configuration file.