### PR TITLE
Fix `context` default value

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -1,5 +1,5 @@
 const {
-  env: { NETLIFY_AUTH_TOKEN, CONTEXT },
+  env: { NETLIFY_AUTH_TOKEN },
   execPath,
 } = require('process')
 
@@ -20,18 +20,20 @@ const loadConfig = async function(flags) {
   const flagsB = { ...DEFAULT_FLAGS, ...flagsA }
   const { config, cwd, dry, nodePath, token, siteId, context } = removeFalsy(flagsB)
 
-  const { configPath, baseDir, config: netlifyConfig } = await resolveFullConfig(config, { cwd, context })
+  const { configPath, baseDir, config: netlifyConfig, context: contextA } = await resolveFullConfig(config, {
+    cwd,
+    context,
+  })
   logConfigPath(configPath)
 
   const siteInfo = await getSiteInfo(token, siteId)
-  return { netlifyConfig, configPath, baseDir, nodePath, token, dry, siteInfo, context }
+  return { netlifyConfig, configPath, baseDir, nodePath, token, dry, siteInfo, context: contextA }
 }
 
 // Default values of CLI flags
 const DEFAULT_FLAGS = {
   nodePath: execPath,
   token: NETLIFY_AUTH_TOKEN,
-  context: CONTEXT || 'production',
 }
 
 // Retrieve configuration file path and base directory

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -1,4 +1,7 @@
-const { cwd: getCwd } = require('process')
+const {
+  cwd: getCwd,
+  env: { CONTEXT },
+} = require('process')
 
 const { getConfigPath } = require('./path')
 const { getBaseDir } = require('./base_dir')
@@ -9,7 +12,7 @@ const { handleFiles } = require('./files')
 const { EVENTS, LEGACY_EVENTS } = require('./events')
 const { parseConfig } = require('./parse/main')
 
-const resolveConfig = async function(configFile, { cwd = getCwd() } = {}) {
+const resolveConfig = async function(configFile, { cwd = getCwd(), context = CONTEXT || 'production' } = {}) {
   const configPath = await getConfigPath(configFile, cwd)
 
   try {
@@ -23,7 +26,7 @@ const resolveConfig = async function(configFile, { cwd = getCwd() } = {}) {
 
     const configB = normalizeConfig(configA)
     const configC = await handleFiles(configB, baseDir)
-    return { configPath, baseDir, config: configC }
+    return { configPath, baseDir, config: configC, context }
   } catch (error) {
     const configMessage = configPath === undefined ? '' : ` file ${configPath}`
     error.message = `When resolving config${configMessage}:\n${error.message}`


### PR DESCRIPTION
Related to #802.

The `context` option defaults to the `CONTEXT` environment variable or to `'production'`.

This default value is assigned inside `@netlify/build`. However this should be assigned by `@netlify/config` instead so that users of both libraries get the correct default value.