### PR TITLE
Simplify code related to configuration file paths

### DIFF
--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -1,41 +1,22 @@
 const { resolve } = require('path')
 
-const { get, set, delete: deleteProp } = require('dot-prop')
-
-// Normalize and validate configuration properties that refer to directories
-const handleFiles = function(config, baseDir) {
-  const files = FILES.map(location => handleFile(config, baseDir, location))
-  return files.reduce(setProp, config)
+// Make configuration paths relative to `baseDir`
+const handleFiles = function({ build, ...config }, baseDir) {
+  const buildA = PROP_NAMES.reduce((build, propName) => normalizePath(build, propName, baseDir), build)
+  return { ...config, build: buildA }
 }
 
-// List of configuration properties that refer to directories
-const FILES = ['build.publish', 'build.functions']
+const PROP_NAMES = ['publish', 'functions']
 
-const handleFile = function(config, baseDir, location) {
-  const path = get(config, location)
-  const pathA = normalizePath(path, baseDir)
-  return { location, path: pathA }
-}
+const normalizePath = function(build, propName, baseDir) {
+  const path = build[propName]
 
-// Resolve paths relatively to the config file.
-// Also normalize paths to OS-specific path delimiters.
-const normalizePath = function(path, baseDir) {
   if (path === undefined) {
-    return path
+    return build
   }
 
-  return resolve(baseDir, path)
-}
-
-// Set new value back to the configuration object
-const setProp = function(config, { location, path }) {
-  if (path === undefined) {
-    deleteProp(config, location)
-  } else {
-    set(config, location, path)
-  }
-
-  return config
+  const pathA = resolve(baseDir, path)
+  return { ...build, [propName]: pathA }
 }
 
 module.exports = { handleFiles }


### PR DESCRIPTION
Related to #802.

When `build.base` is defined, `build.functions` and `build.publish` are relative to it. Otherwise they are relative to the repository root directory. This logic is present [in the buildbot](https://github.com/netlify/buildbot/blob/77379b6d05a07355f28f6b725fb3c96cb742a426/bot/configuration.go#L57).

`@netlify/config` replicates this logic, but the current code can be simplified. This PR refactors the code to simplify it, without changing behavior.