### PR TITLE
Remove permissions checks on build directory

### DIFF
--- a/packages/build/tests/config/load/tests.js
+++ b/packages/build/tests/config/load/tests.js
@@ -1,4 +1,4 @@
-const { cwd, platform } = require('process')
+const { cwd } = require('process')
 const { relative } = require('path')
 
 const test = require('ava')
@@ -50,13 +50,6 @@ test('--config and environment variables', async t => {
     env: { NETLIFY_CONFIG_BUILD_LIFECYCLE_ONBUILD: 'echo onBuild' },
   })
 })
-
-// Windows permissions system is different
-if (platform !== 'win32') {
-  test('--config with a directory without permissions', async t => {
-    await runFixture(t, 'empty', { config: false, cwd: '/' })
-  })
-}
 
 test('--config with an absolute path', async t => {
   await runFixture(t, 'empty')

--- a/packages/config/src/base_dir.js
+++ b/packages/config/src/base_dir.js
@@ -3,7 +3,7 @@ const { cwd } = require('process')
 
 // Retrieve the base directory used to resolve most paths.
 // This is the configuration file's directory.
-const getBaseDir = async function(configPath) {
+const getBaseDir = function(configPath) {
   if (configPath === undefined) {
     return cwd()
   }

--- a/packages/config/src/base_dir.js
+++ b/packages/config/src/base_dir.js
@@ -1,37 +1,14 @@
 const { dirname } = require('path')
 const { cwd } = require('process')
-const {
-  access,
-  constants: { R_OK, W_OK },
-} = require('fs')
-const { promisify } = require('util')
-
-const { throwError } = require('./error')
-
-const pAccess = promisify(access)
 
 // Retrieve the base directory used to resolve most paths.
 // This is the configuration file's directory.
 const getBaseDir = async function(configPath) {
-  const baseDir = getBaseDirValue(configPath)
-  await validatePermissions(baseDir)
-  return baseDir
-}
-
-const getBaseDirValue = function(configPath) {
   if (configPath === undefined) {
     return cwd()
   }
 
   return dirname(configPath)
-}
-
-const validatePermissions = async function(baseDir) {
-  try {
-    await pAccess(baseDir, R_OK | W_OK)
-  } catch (error) {
-    throwError(`Wrong permissions on the base directory ${baseDir}`)
-  }
 }
 
 module.exports = { getBaseDir }

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -14,7 +14,7 @@ const resolveConfig = async function(configFile, options) {
   const configPath = await getConfigPath(configFile, cwd)
 
   try {
-    const baseDir = await getBaseDir(configPath)
+    const baseDir = getBaseDir(configPath)
 
     const config = await parseConfig(configPath)
 


### PR DESCRIPTION
Part of #802.

Netlify Build currently ensures that the build directory has read and write permissions.

This behavior is not backward compatible with the buildbot which does not do those permission checks.

A user could technically have no build command and publish a specific directory of the repository source files, hence not require any write permissions for it. Those permissions checks would be breaking to that user.

Therefore this PR is removing those checks.