### PR TITLE
Rename `baseDir` to `buildDir`

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -20,7 +20,7 @@ const loadConfig = async function(flags) {
   const flagsB = { ...DEFAULT_FLAGS, ...flagsA }
   const { config, cwd, repositoryRoot, dry, nodePath, token, siteId, context } = removeFalsy(flagsB)
 
-  const { configPath, baseDir, config: netlifyConfig, context: contextA } = await resolveFullConfig(config, {
+  const { configPath, buildDir, config: netlifyConfig, context: contextA } = await resolveFullConfig(config, {
     cwd,
     repositoryRoot,
     context,
@@ -28,7 +28,7 @@ const loadConfig = async function(flags) {
   logConfigPath(configPath)
 
   const siteInfo = await getSiteInfo(token, siteId)
-  return { netlifyConfig, configPath, baseDir, nodePath, token, dry, siteInfo, context: contextA }
+  return { netlifyConfig, configPath, buildDir, nodePath, token, dry, siteInfo, context: contextA }
 }
 
 // Default values of CLI flags
@@ -37,8 +37,8 @@ const DEFAULT_FLAGS = {
   token: NETLIFY_AUTH_TOKEN,
 }
 
-// Retrieve configuration file path and base directory
-// Then load configuration file
+// Retrieve configuration file and related information
+// (path, build directory, etc.)
 const resolveFullConfig = async function(config, { cwd, repositoryRoot, context }) {
   try {
     return await resolveConfig(config, { cwd, repositoryRoot, context })

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -35,16 +35,16 @@ const build = async function(flags) {
   try {
     logBuildStart()
 
-    const { netlifyConfig, configPath, baseDir, nodePath, token, dry, siteInfo, context } = await loadConfig(flags)
+    const { netlifyConfig, configPath, buildDir, nodePath, token, dry, siteInfo, context } = await loadConfig(flags)
 
-    const pluginsOptions = await getPluginsOptions(netlifyConfig, baseDir)
-    await installPlugins(pluginsOptions, baseDir)
+    const pluginsOptions = await getPluginsOptions(netlifyConfig, buildDir)
+    await installPlugins(pluginsOptions, buildDir)
 
     const commandsCount = await buildRun({
       pluginsOptions,
       netlifyConfig,
       configPath,
-      baseDir,
+      buildDir,
       nodePath,
       token,
       dry,
@@ -71,16 +71,16 @@ const buildRun = async function({
   pluginsOptions,
   netlifyConfig,
   configPath,
-  baseDir,
+  buildDir,
   nodePath,
   token,
   dry,
   siteInfo,
   context,
 }) {
-  const utilsData = await startUtils(baseDir)
-  const childEnv = await getChildEnv({ baseDir, context, siteInfo })
-  const childProcesses = await startPlugins({ pluginsOptions, baseDir, nodePath, childEnv })
+  const utilsData = await startUtils(buildDir)
+  const childEnv = await getChildEnv({ buildDir, context, siteInfo })
+  const childProcesses = await startPlugins({ pluginsOptions, buildDir, nodePath, childEnv })
 
   try {
     return await executeCommands({
@@ -89,7 +89,7 @@ const buildRun = async function({
       netlifyConfig,
       utilsData,
       configPath,
-      baseDir,
+      buildDir,
       nodePath,
       childEnv,
       token,
@@ -107,7 +107,7 @@ const executeCommands = async function({
   netlifyConfig,
   utilsData,
   configPath,
-  baseDir,
+  buildDir,
   nodePath,
   childEnv,
   token,
@@ -120,7 +120,7 @@ const executeCommands = async function({
     netlifyConfig,
     utilsData,
     configPath,
-    baseDir,
+    buildDir,
     token,
     siteInfo,
   })
@@ -141,7 +141,7 @@ const executeCommands = async function({
     errorCommands,
     commandsCount,
     configPath,
-    baseDir,
+    buildDir,
     nodePath,
     childEnv,
   })

--- a/packages/build/src/plugins/child/constants.js
+++ b/packages/build/src/plugins/child/constants.js
@@ -12,9 +12,9 @@ const isNetlifyCI = require('../../utils/is-netlify-ci')
 // Retrieve constants passed to plugins
 const getConstants = async function({
   configPath,
-  baseDir,
+  buildDir,
   netlifyConfig: {
-    build: { publish = baseDir, functions },
+    build: { publish = buildDir, functions },
   },
   siteInfo: { id: siteId },
 }) {
@@ -52,7 +52,7 @@ const getConstants = async function({
      */
     SITE_ID: siteId,
   }
-  const constantsA = mapObj(constants, (key, path) => [key, normalizePath(path, baseDir, key)])
+  const constantsA = mapObj(constants, (key, path) => [key, normalizePath(path, buildDir, key)])
   return constantsA
 }
 
@@ -65,18 +65,18 @@ const getFunctionsDist = function(isLocal) {
   return `${tmpdir()}/zisi-${DEPLOY_ID}`
 }
 
-// The current directory is `baseDir`. Most constants are inside this `baseDir`.
-// Instead of passing absolute paths, we pass paths relative to `baseDir`, so
+// The current directory is `buildDir`. Most constants are inside this `buildDir`.
+// Instead of passing absolute paths, we pass paths relative to `buildDir`, so
 // that logs are less verbose.
-const normalizePath = function(path, baseDir, key) {
+const normalizePath = function(path, buildDir, key) {
   if (path === undefined || NOT_PATHS.includes(key)) {
     return path
   }
 
   const pathA = normalize(path)
 
-  if (pathA.startsWith(baseDir) && pathA !== baseDir) {
-    return relative(baseDir, pathA)
+  if (pathA.startsWith(buildDir) && pathA !== buildDir) {
+    return relative(buildDir, pathA)
   }
 
   return pathA

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -8,8 +8,8 @@ const { fail, cancel } = require('../error')
 // Some utilities need to perform some async initialization logic first.
 // We do it once for all plugins in the parent process then pass it to the child
 // processes.
-const startUtils = async function(baseDir) {
-  const git = await gitUtils({ cwd: baseDir })
+const startUtils = async function(buildDir) {
+  const git = await gitUtils({ cwd: buildDir })
   return { git }
 }
 

--- a/packages/build/src/plugins/env.js
+++ b/packages/build/src/plugins/env.js
@@ -5,14 +5,14 @@ const { getGitEnv } = require('./git')
 
 // Retrieve the environment variables passed to plugins and lifecycle commands.
 // When run locally, this tries to emulate the production environment.
-const getChildEnv = async function({ baseDir, context, siteInfo }) {
+const getChildEnv = async function({ buildDir, context, siteInfo }) {
   if (isNetlifyCI()) {
     return process.env
   }
 
   const defaultEnv = getDefaultEnv(siteInfo)
   const configurableEnv = getConfigurableEnv()
-  const forcedEnv = await getForcedEnv(baseDir, context)
+  const forcedEnv = await getForcedEnv(buildDir, context)
   return {
     ...removeFalsy(defaultEnv),
     ...process.env,
@@ -44,8 +44,8 @@ const getConfigurableEnv = function() {
 }
 
 // Environment variables that can be unset by neither local nor configuration
-const getForcedEnv = async function(baseDir, context) {
-  const gitEnv = await getGitEnv(baseDir)
+const getForcedEnv = async function(buildDir, context) {
+  const gitEnv = await getGitEnv(buildDir)
   return {
     // Configuration file context
     CONTEXT: context,

--- a/packages/build/src/plugins/git.js
+++ b/packages/build/src/plugins/git.js
@@ -5,11 +5,11 @@ const { removeFalsy } = require('../utils/remove_falsy')
 // Retrieve git-related information for use in environment variables.
 // git is optional and there might be not git repository.
 // We purposely keep this decoupled from the git utility.
-const getGitEnv = async function(baseDir) {
+const getGitEnv = async function(buildDir) {
   const [BRANCH, COMMIT_REF, CACHED_COMMIT_REF] = await Promise.all([
-    git(['rev-parse', '--abbrev-ref', 'HEAD'], baseDir),
-    git(['rev-parse', 'HEAD'], baseDir),
-    git(['rev-parse', 'HEAD^'], baseDir),
+    git(['rev-parse', '--abbrev-ref', 'HEAD'], buildDir),
+    git(['rev-parse', 'HEAD'], buildDir),
+    git(['rev-parse', 'HEAD^'], buildDir),
   ])
   const gitEnv = { BRANCH, HEAD: BRANCH, COMMIT_REF, CACHED_COMMIT_REF }
   const gitEnvA = removeFalsy(gitEnv)

--- a/packages/build/src/plugins/install.js
+++ b/packages/build/src/plugins/install.js
@@ -7,14 +7,14 @@ const { logInstallPlugins } = require('../log/main')
 
 // Install dependencies of local plugins.
 // Also resolve path of plugins' main files.
-const installPlugins = async function(pluginsOptions, baseDir) {
+const installPlugins = async function(pluginsOptions, buildDir) {
   const pluginsPaths = getPluginsPaths(pluginsOptions)
 
   if (pluginsPaths.length === 0) {
     return
   }
 
-  const packageRoots = await getPackageRoots(pluginsPaths, baseDir)
+  const packageRoots = await getPackageRoots(pluginsPaths, buildDir)
 
   if (packageRoots.length === 0) {
     return
@@ -40,9 +40,9 @@ const getPluginPath = function({ pluginPath }) {
 }
 
 // Retrieve `package.json` directories
-const getPackageRoots = async function(pluginsPaths, baseDir) {
-  const [baseRoot, ...packageRoots] = await Promise.all([baseDir, ...pluginsPaths].map(findPackageRoot))
-  const packageRootsA = packageRoots.filter(packageRoot => packageRoot !== baseRoot)
+const getPackageRoots = async function(pluginsPaths, buildDir) {
+  const [repositoryRoot, ...packageRoots] = await Promise.all([buildDir, ...pluginsPaths].map(findPackageRoot))
+  const packageRootsA = packageRoots.filter(packageRoot => packageRoot !== repositoryRoot)
   return [...new Set(packageRootsA)]
 }
 

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -15,7 +15,7 @@ const loadPlugins = async function({
   netlifyConfig,
   utilsData,
   configPath,
-  baseDir,
+  buildDir,
   token,
   siteInfo,
 }) {
@@ -29,7 +29,7 @@ const loadPlugins = async function({
         netlifyConfig,
         utilsData,
         configPath,
-        baseDir,
+        buildDir,
         token,
         siteInfo,
       }),
@@ -48,7 +48,7 @@ const loadPlugins = async function({
 // Do it by executing the plugin `load` event handler.
 const loadPlugin = async function(
   { package, pluginPath, pluginConfig, id, core, local },
-  { childProcesses, index, netlifyConfig, utilsData, configPath, baseDir, token, siteInfo },
+  { childProcesses, index, netlifyConfig, utilsData, configPath, buildDir, token, siteInfo },
 ) {
   const { childProcess } = childProcesses[index]
   const packageJson = await getPackageJson({ pluginPath, local })
@@ -64,7 +64,7 @@ const loadPlugin = async function(
       configPath,
       core,
       local,
-      baseDir,
+      buildDir,
       token,
       siteInfo,
       packageJson,

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -10,13 +10,13 @@ const CHILD_MAIN_FILE = `${__dirname}/child/main.js`
 //    (for both security and safety reasons)
 //  - logs can be buffered which allows manipulating them for log shipping,
 //    secrets redacting and parallel plugins
-const startPlugins = function({ pluginsOptions, baseDir, nodePath, childEnv }) {
-  return Promise.all(pluginsOptions.map(() => startPlugin({ baseDir, nodePath, childEnv })))
+const startPlugins = function({ pluginsOptions, buildDir, nodePath, childEnv }) {
+  return Promise.all(pluginsOptions.map(() => startPlugin({ buildDir, nodePath, childEnv })))
 }
 
-const startPlugin = async function({ baseDir, nodePath, childEnv }) {
+const startPlugin = async function({ buildDir, nodePath, childEnv }) {
   const childProcess = execa.node(CHILD_MAIN_FILE, {
-    cwd: baseDir,
+    cwd: buildDir,
     preferLocal: true,
     nodePath,
     execPath: nodePath,

--- a/packages/config/src/build_dir.js
+++ b/packages/config/src/build_dir.js
@@ -1,12 +1,12 @@
 const { resolve } = require('path')
 
-// Retrieve the base directory used to resolve most paths.
+// Retrieve the build directory used to resolve most paths.
 // This is (in priority order):
 //  - `build.base`
 //  - `--repositoryRoot`
 //  - the current directory
-const getBaseDir = function(repositoryRoot, { build: { base = repositoryRoot } }) {
+const getBuildDir = function(repositoryRoot, { build: { base = repositoryRoot } }) {
   return resolve(repositoryRoot, base)
 }
 
-module.exports = { getBaseDir }
+module.exports = { getBuildDir }

--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -1,21 +1,21 @@
 const { resolve } = require('path')
 
-// Make configuration paths relative to `baseDir`
-const handleFiles = function({ build, ...config }, baseDir) {
-  const buildA = PROP_NAMES.reduce((build, propName) => normalizePath(build, propName, baseDir), build)
+// Make configuration paths relative to `buildDir`
+const handleFiles = function({ build, ...config }, buildDir) {
+  const buildA = PROP_NAMES.reduce((build, propName) => normalizePath(build, propName, buildDir), build)
   return { ...config, build: buildA }
 }
 
 const PROP_NAMES = ['publish', 'functions']
 
-const normalizePath = function(build, propName, baseDir) {
+const normalizePath = function(build, propName, buildDir) {
   const path = build[propName]
 
   if (path === undefined) {
     return build
   }
 
-  const pathA = resolve(baseDir, path)
+  const pathA = resolve(buildDir, path)
   return { ...build, [propName]: pathA }
 }
 

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -1,5 +1,5 @@
 const { getConfigPath } = require('./path')
-const { getBaseDir } = require('./base_dir')
+const { getBuildDir } = require('./build_dir')
 const { addEnvVars } = require('./env')
 const { validateConfig } = require('./validate/main')
 const { normalizeConfig } = require('./normalize')
@@ -22,9 +22,9 @@ const resolveConfig = async function(configFile, options) {
 
     const configB = normalizeConfig(configA)
 
-    const baseDir = getBaseDir(repositoryRoot, configB)
-    const configC = handleFiles(configB, baseDir)
-    return { configPath, baseDir, config: configC, context }
+    const buildDir = getBuildDir(repositoryRoot, configB)
+    const configC = handleFiles(configB, buildDir)
+    return { configPath, buildDir, config: configC, context }
   } catch (error) {
     const configMessage = configPath === undefined ? '' : ` file ${configPath}`
     error.message = `When resolving config${configMessage}:\n${error.message}`


### PR DESCRIPTION
We use the internal variable name `baseDir` for what is actually the build directory (not the `base` directory). This is called `buildDir` in the buildbot as well.

This PR renames this variable to avoid confusion. This only renames internal variables that are not exposed to the users.