### PR TITLE
Fix paths resolution inside the configuration file

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -37,7 +37,7 @@ const build = async function(flags) {
 
     const { netlifyConfig, configPath, buildDir, nodePath, token, dry, siteInfo, context } = await loadConfig(flags)
 
-    const pluginsOptions = await getPluginsOptions(netlifyConfig, buildDir)
+    const pluginsOptions = await getPluginsOptions(netlifyConfig, buildDir, configPath)
     await installPlugins(pluginsOptions, buildDir)
 
     const commandsCount = await buildRun({

--- a/packages/build/tests/config/cwd/fixtures/build_base_cwd/netlify.yml
+++ b/packages/build/tests/config/cwd/fixtures/build_base_cwd/netlify.yml
@@ -3,4 +3,4 @@ build:
   lifecycle:
     onBuild: node -p "process.cwd()"
 plugins:
-  - package: ./plugin.js
+  - package: ./base/plugin.js


### PR DESCRIPTION
Part of #802.

Most paths inside Netlify Build are relative to the build directory (which is either `build.base` or the repository root directory).

However inside the configuration file, paths should be relative to that configuration file since this is what users are most likely to expect. At the moment, this is only for local plugins paths.

This PR fixes this issue.