### PR TITLE
Remove some dead code

### DIFF
--- a/packages/build/tests/config/load/tests.js
+++ b/packages/build/tests/config/load/tests.js
@@ -59,5 +59,5 @@ test('--config with an invalid relative path', async t => {
 })
 
 test('--repository-root', async t => {
-  await runFixture(t, '', { config: false, flags: `--repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: `--repository-root=${FIXTURES_DIR}/empty` })
 })


### PR DESCRIPTION
This removes some dead code in a single test.
This test is using an option (`config`) which has been removed in a previous PR and is not needed anymore for that test.