### PR TITLE
Add configuration merging logic

### DIFF
--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -1,24 +1,17 @@
 const isPlainObj = require('is-plain-obj')
-const deepmerge = require('deepmerge')
+
+const { deepMerge } = require('./utils/merge')
 
 // Merge `config.context.{CONTEXT|BRANCH}.*` to `config.build.*`
 // CONTEXT is the `--context` CLI flag.
 // BRANCH is the `--branch` CLI flag.
-const mergeContext = function({ context: contextProps, build = {}, ...config }, context, branch) {
+const mergeContext = function({ context: contextProps, ...config }, context, branch) {
   if (!isPlainObj(contextProps)) {
-    return { ...config, build }
+    return config
   }
 
-  const contextBuild = contextProps[context]
-  const branchBuild = contextProps[branch]
-  const buildA = deepmerge.all([build, { ...contextBuild }, { ...branchBuild }], { arrayMerge })
-  return { ...config, build: buildA }
-}
-
-// By default `deepmerge` concatenates arrays. We use the `arrayMerge` option
-// to remove this behavior.
-const arrayMerge = function(arrayA, arrayB) {
-  return arrayB
+  const build = deepMerge(config.build, contextProps[context], contextProps[branch])
+  return { ...config, build }
 }
 
 module.exports = { mergeContext }

--- a/packages/config/src/utils/merge.js
+++ b/packages/config/src/utils/merge.js
@@ -1,0 +1,16 @@
+const deepmerge = require('deepmerge')
+const isPlainObj = require('is-plain-obj')
+
+// Deep merge utility for configuration objects
+const deepMerge = function(...values) {
+  const objects = values.filter(isPlainObj)
+  return deepmerge.all(objects, { arrayMerge })
+}
+
+// By default `deepmerge` concatenates arrays. We use the `arrayMerge` option
+// to remove this behavior.
+const arrayMerge = function(arrayA, arrayB) {
+  return arrayB
+}
+
+module.exports = { deepMerge }


### PR DESCRIPTION
Part of #802.

This separates the logic we use to merge configuration objects together into its own utility function.

Merging configuration objects is used in several places:
  - when merging `context` configuration
  - when merging UI settings