### PR TITLE
Make `--config` CLI flag optional

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -31,13 +31,15 @@ const loadConfig = async function(flags) {
     branch,
   } = removeFalsy(flagsB)
 
-  const {
-    configPath,
-    buildDir,
-    config: netlifyConfig,
-    context: contextA,
-    branch: branchA,
-  } = await resolveFullConfig(config, { defaultConfig, cachedConfig, cwd, repositoryRoot, context, branch })
+  const { configPath, buildDir, config: netlifyConfig, context: contextA, branch: branchA } = await resolveFullConfig({
+    config,
+    defaultConfig,
+    cachedConfig,
+    cwd,
+    repositoryRoot,
+    context,
+    branch,
+  })
   logBuildDir(buildDir)
   logConfigPath(configPath)
 
@@ -53,12 +55,17 @@ const DEFAULT_FLAGS = {
 
 // Retrieve configuration file and related information
 // (path, build directory, etc.)
-const resolveFullConfig = async function(
+const resolveFullConfig = async function({
   config,
-  { defaultConfig, cachedConfig, cwd, repositoryRoot, context, branch },
-) {
+  defaultConfig,
+  cachedConfig,
+  cwd,
+  repositoryRoot,
+  context,
+  branch,
+}) {
   try {
-    return await resolveConfig(config, { defaultConfig, cachedConfig, cwd, repositoryRoot, context, branch })
+    return await resolveConfig({ config, defaultConfig, cachedConfig, cwd, repositoryRoot, context, branch })
   } catch (error) {
     if (error.type === 'userError') {
       delete error.type

--- a/packages/build/tests/config/load/tests.js
+++ b/packages/build/tests/config/load/tests.js
@@ -60,7 +60,7 @@ test('--defaultConfig with an invalid relative path', async t => {
 
 test('--cachedConfig', async t => {
   const repositoryRoot = `${FIXTURES_DIR}/cached_config`
-  const cachedConfig = await resolveConfig(undefined, { repositoryRoot })
+  const cachedConfig = await resolveConfig({ repositoryRoot })
   const cachedConfigPath = `${repositoryRoot}/cached.yml`
   await pWriteFile(cachedConfigPath, JSON.stringify(cachedConfig, null, 2))
   try {

--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -10,10 +10,10 @@ const { parseFlags } = require('./flags')
 
 // CLI entry point
 const runCli = async function() {
-  const { config, ...flags } = parseFlags()
+  const flags = parseFlags()
 
   try {
-    const result = await resolveConfig(config, flags)
+    const result = await resolveConfig(flags)
     handleCliSuccess(result)
   } catch (error) {
     handleCliError(error)

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -15,7 +15,7 @@ const { deepMerge } = require('./utils/merge')
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function(configFile, { cachedConfig, ...opts } = {}) {
+const resolveConfig = async function({ cachedConfig, ...opts } = {}) {
   // Performance optimization when @netlify/config caller has already previously
   // called it and cached the result.
   // This is used by the buildbot which:
@@ -25,12 +25,19 @@ const resolveConfig = async function(configFile, { cachedConfig, ...opts } = {})
     return await getConfig(cachedConfig, 'cachedConfig')
   }
 
-  const { defaultConfig: defaultConfigPath, cwd, context, repositoryRoot, branch } = await normalizeOpts(opts)
+  const {
+    config: configOpt,
+    defaultConfig: defaultConfigPath,
+    cwd,
+    context,
+    repositoryRoot,
+    branch,
+  } = await normalizeOpts(opts)
 
   const defaultConfig = await getConfig(defaultConfigPath, 'defaultConfig')
 
   const { configPath, config } = await loadConfig({
-    configFile,
+    configOpt,
     cwd,
     context,
     repositoryRoot,
@@ -58,7 +65,7 @@ const getConfig = async function(configPath, name) {
 // The first pass uses the `defaultConfig`'s `build.base` (if defined).
 // The second pass uses the `build.base` from the first pass (if defined).
 const loadConfig = async function({
-  configFile,
+  configOpt,
   cwd,
   context,
   repositoryRoot,
@@ -72,7 +79,7 @@ const loadConfig = async function({
     config: {
       build: { base },
     },
-  } = await getFullConfig({ configFile, cwd, context, repositoryRoot, branch, defaultConfig, base: defaultBase })
+  } = await getFullConfig({ configOpt, cwd, context, repositoryRoot, branch, defaultConfig, base: defaultBase })
 
   // No second pass needed since there is no `build.base`
   if (base === undefined || base === defaultBase) {
@@ -95,8 +102,8 @@ const loadConfig = async function({
 }
 
 // Load configuration file and normalize it, merge contexts, etc.
-const getFullConfig = async function({ configFile, cwd, context, repositoryRoot, branch, defaultConfig, base }) {
-  const configPath = await getConfigPath({ configFile, cwd, repositoryRoot, base })
+const getFullConfig = async function({ configOpt, cwd, context, repositoryRoot, branch, defaultConfig, base }) {
+  const configPath = await getConfigPath({ configOpt, cwd, repositoryRoot, base })
 
   try {
     const config = await parseConfig(configPath)

--- a/packages/config/src/path.js
+++ b/packages/config/src/path.js
@@ -8,9 +8,9 @@ const locatePath = require('locate-path')
 //  - a `netlify.*` file in the `repositoryRoot/{base}`
 //  - a `netlify.*` file in the `repositoryRoot`
 //  - a `netlify.*` file in the current directory or any parent
-const getConfigPath = async function({ configFile, cwd, repositoryRoot, base }) {
-  if (configFile !== undefined) {
-    return resolve(cwd, configFile)
+const getConfigPath = async function({ configOpt, cwd, repositoryRoot, base }) {
+  if (configOpt !== undefined) {
+    return resolve(cwd, configOpt)
   }
 
   if (base !== undefined) {


### PR DESCRIPTION
Part of #802.

When using `@netlify/config`, the `--config` CLI flag should be optional. Most users don't need to specify that flag since we automatically find the configuration file inside the repository root directory or base directory. This means this option should be a named parameter instead of a positional one.