### PR TITLE
Fix missing newline after CLI flags logging

### DIFF
--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -22,7 +22,7 @@ ${EMPTY_LINE}`)
 
 const logFlags = function(flags) {
   const flagsA = omit(flags, HIDDEN_FLAGS)
-  log(cyanBright.bold(`${HEADING_PREFIX} Flags`), indent(serialize(flagsA)))
+  log(cyanBright.bold(`${HEADING_PREFIX} Flags`), indent(serialize(flagsA)).trimRight(), EMPTY_LINE)
 }
 
 const CI_HIDDEN_FLAGS = isNetlifyCI() ? ['nodePath', 'cachedConfig'] : []


### PR DESCRIPTION
An empty line (for cosmetics) is missing between the CLI flags logging and the current directory logging. This PR fixes that.