### PR TITLE
Remove dead code

### DIFF
--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -31,8 +31,7 @@ const handleCliError = function(error) {
   // Errors caused by users do not show stack traces and have exit code 1
   if (isUserError(error)) {
     console.error(error.message)
-    exit(1)
-    return
+    return exit(1)
   }
 
   // Internal errors / bugs have exit code 2


### PR DESCRIPTION
This removes some small dead code.
A `return` statement after `process.exit()` is never reached.
