### PR TITLE
Simplify some error message in `@netlify/config`

### DIFF
--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -126,8 +126,7 @@ const getFullConfig = async function({ configOpt, cwd, context, repositoryRoot, 
     const configD = normalizeConfig(configC)
     return { configPath, config: configD }
   } catch (error) {
-    const configMessage = configPath === undefined ? '' : ` file ${configPath}`
-    error.message = `When resolving config${configMessage}:\n${error.message}`
+    error.message = `When resolving config file ${configPath}:\n${error.message}`
     throw error
   }
 }


### PR DESCRIPTION
Part of #802.

This simplifies the main error message in `@netlify/config` when an error happens during configuration resolution (e.g. parsing error). When the code reaches that point, `configPath` cannot be `undefined` since, if there is no configuration file, no error can be thrown from parsing it. So the code can be simplified a little.