### PR TITLE
Fix `BRANCH` environment variable

### DIFF
--- a/packages/config/src/options/branch.js
+++ b/packages/config/src/options/branch.js
@@ -14,7 +14,7 @@ const getBranch = async function({ branch, repositoryRoot }) {
     return branch
   }
 
-  if (BRANCH !== undefined) {
+  if (BRANCH) {
     return BRANCH
   }
 


### PR DESCRIPTION
`@netlify/config` uses the `BRANCH` environment variable to figure out branch-specific contexts. If undefined, it is not used. However when set to an empty string, it should behave as if it was `undefined`, which is not the case at the moment. This PR fixes that.