### PR TITLE
Add a test for config warning messages colorization

### DIFF
--- a/packages/build/tests/config/validate/tests.js
+++ b/packages/build/tests/config/validate/tests.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+const hasAnsi = require('has-ansi')
 
 const { runFixtureConfig } = require('../../helpers/main')
 
@@ -114,4 +115,9 @@ test('build.context: object', async t => {
 
 test('build.context.CONTEXT: object', async t => {
   await runFixtureConfig(t, 'build_context_nested_object')
+})
+
+test('Colors', async t => {
+  const { stderr } = await runFixtureConfig(t, 'build_object', { snapshot: false, normalize: false })
+  t.true(hasAnsi(stderr))
 })


### PR DESCRIPTION
When the configuration file has errors or warnings, those are shown in colors. 
This PR adds a test to ensure the colors are correctly shown.