### PR TITLE
Improve error handling at the start of the build

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -31,9 +31,9 @@ const { doDryRun } = require('./dry')
  * @param  {boolean} [flags.dry] - printing commands without executing them
  */
 const build = async function(flags) {
-  const buildTimer = startTimer()
-
   try {
+    const buildTimer = startTimer()
+
     logBuildStart()
 
     const { netlifyConfig, configPath, buildDir, nodePath, token, dry, siteInfo, context, branch } = await loadConfig(


### PR DESCRIPTION
Some statements are currently not covered by the top-level error handler.
This PR fixes this.