### PR TITLE
Improve error handling

### DIFF
--- a/packages/build/src/error/handle.js
+++ b/packages/build/src/error/handle.js
@@ -1,5 +1,5 @@
 // Handle top-level build errors.
-// Logging is done separtely.
+// Logging is done separately.
 const handleBuildError = async function() {}
 
 module.exports = { handleBuildError }

--- a/packages/build/src/error/handle.js
+++ b/packages/build/src/error/handle.js
@@ -1,0 +1,5 @@
+// Handle top-level build errors.
+// Logging is done separtely.
+const handleBuildError = async function() {}
+
+module.exports = { handleBuildError }


### PR DESCRIPTION
Our top-level error handler is currently only logging the error.

We will soon need to add more logic to this top-level error handler (in order to cancel builds on `cancel` errors). This PR does some refactoring to allow this type of additional error handling logic at the top-level.