### PR TITLE
Make API client available to the whole codebase

### DIFF
--- a/packages/build/src/core/api.js
+++ b/packages/build/src/core/api.js
@@ -1,0 +1,14 @@
+const NetlifyAPI = require('netlify')
+
+// Retrieve Netlify API client, if an access token was passed
+const getApiClient = function(token) {
+  if (token === undefined) {
+    return
+  }
+
+  // TODO: find less intrusive way to mock HTTP requests
+  const api = new NetlifyAPI(token)
+  return api
+}
+
+module.exports = { getApiClient }

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -9,6 +9,7 @@ const { logFlags, logBuildDir, logConfigPath } = require('../log/main')
 const { addErrorInfo } = require('../error/info')
 const { removeFalsy } = require('../utils/remove_falsy')
 
+const { getApiClient } = require('./api')
 const { getSiteInfo } = require('./site_info')
 
 // Retrieve configuration object
@@ -45,7 +46,8 @@ const loadConfig = async function(flags) {
   logBuildDir(buildDir)
   logConfigPath(configPath)
 
-  const siteInfo = await getSiteInfo(token, siteId)
+  const api = getApiClient(token)
+  const siteInfo = await getSiteInfo(api, siteId)
   return { netlifyConfig, configPath, buildDir, nodePath, token, dry, siteInfo, context: contextA, branch: branchA }
 }
 

--- a/packages/build/src/core/site_info.js
+++ b/packages/build/src/core/site_info.js
@@ -2,23 +2,20 @@ const {
   env: { BUILD_SITE_INFO },
 } = require('process')
 
-const NetlifyAPI = require('netlify')
-
 const isNetlifyCI = require('../utils/is-netlify-ci')
 
 // Retrieve Netlify Site information, if availabled.
 // This is only used for local builds environment variables at the moment.
-const getSiteInfo = async function(token, id) {
-  if (token === undefined || id === undefined || isNetlifyCI()) {
-    return { id }
+const getSiteInfo = async function(api, siteId) {
+  if (api === undefined || siteId === undefined || isNetlifyCI()) {
+    return { id: siteId }
   }
 
-  const api = new NetlifyAPI(token)
-  const siteInfo = await getSite(id, api)
-  return { ...siteInfo, id }
+  const siteInfo = await getSite(siteId, api)
+  return { ...siteInfo, id: siteId }
 }
 
-const getSite = async function(site_id, api) {
+const getSite = async function(siteId, api) {
   try {
     // Used for testing.
     // TODO: find a better method not to pollute source code with test mocking.
@@ -26,7 +23,7 @@ const getSite = async function(site_id, api) {
       return JSON.parse(BUILD_SITE_INFO)
     }
 
-    return await api.getSite({ site_id })
+    return await api.getSite({ site_id: siteId })
     // Silently ignore errors. For example the network connection might be down,
     // but local builds should still work regardless.
   } catch (error) {


### PR DESCRIPTION
An API client is currently created in order to retrieve Site information in local builds (to set some environment variables like `REPOSITORY_URL`).

An upcoming feature (cancelling builds) requires this API client to be made available in order parts of the codebase. This PR implements this.