### PR TITLE
Fix randomly failing test

### DIFF
--- a/packages/config/tests/cwd/tests.js
+++ b/packages/config/tests/cwd/tests.js
@@ -35,7 +35,7 @@ test('No .git', async t => {
 })
 
 test('--cwd non-existing', async t => {
-  await runFixtureConfig(t, '', { flags: `--cwd=/invalid` })
+  await runFixtureConfig(t, '', { flags: `--cwd=/invalid --repository-root=${FIXTURES_DIR}/empty` })
 })
 
 test('--repositoryRoot non-existing', async t => {


### PR DESCRIPTION
An integration test is randomly failing due to a race condition. This PR fixes this.