### PR TITLE
Fix monorepo support

### DIFF
--- a/packages/config/src/utils/is-netlify-ci.js
+++ b/packages/config/src/utils/is-netlify-ci.js
@@ -1,0 +1,10 @@
+const {
+  env: { NETLIFY },
+} = require('process')
+
+// Check if inside Netlify Build CI
+const isNetlifyCI = function() {
+  return Boolean(NETLIFY)
+}
+
+module.exports = isNetlifyCI


### PR DESCRIPTION
Trying to address #918.

A user with a Yarn monorepo setup was using the Netlify Build beta and it worked until the latest changes related to configuration file parsing.

The "current directory" which is logged (which actually is what we internally call "base directory") used for the build commands was [correct before](https://app.netlify.com/sites/deputy/deploys/5e6090f7dad16feedd484c8f) (points to the subdirectory) but [not anymore](https://app.netlify.com/sites/deputy/deploys/5e67050ac2b0736048de28b5) (points to project root directory). 

The problem seems to be the following: the latest logic of `@netlify/config` assumes that the buildbot is passing the "Base directory" UI setting using the `--defaultConfig` CLI flag. This is what the buildbot will eventually do (there is ongoing work for it) but it's not the case yet. At the moment, if there is a "Base directory" UI setting, it will most likely be used as the build directory, which will be the current directory in which `@netlify/build` is called. 

This PR provides the following workaround until the buildbot uses the new `@netlify/config` setup: make `--defaultConfig` default to `{ build: { base: cwd() } }`. This is only applied:
  - if `--defaultConfig` is `undefined`, i.e. will be a noop once the buildbot uses the new setup
  - if not in the production CI (e.g. with Netlify CLI)
  - if inside integration tests

This also means the "Base directory" UI setting will always default to the "build directory" computed by the buildbot. Looking at the algorithm to locate the configuration file, this should not be an issue since the "build directory" is always searched anyway.