### PR TITLE
Improve stack trace cleaning

### DIFF
--- a/packages/build/src/error/clean_stack.js
+++ b/packages/build/src/error/clean_stack.js
@@ -69,7 +69,7 @@ const isInternalStack = function(line) {
   return INTERNAL_STACK_REGEXP.test(line)
 }
 
-const INTERNAL_STACK_REGEXP = /packages[/\\]build[/\\](src|node_modules)[/\\]/
+const INTERNAL_STACK_REGEXP = /(packages|@netlify)[/\\]build[/\\](src|node_modules)[/\\]/
 
 const INITIAL_NEWLINES = /^\n+/
 


### PR DESCRIPTION
Stack trace cleaning removes the stack trace lines coming from internal `@netlify/build` code. However the current RegExp was working locally but not when `@netlify/build` is installed as a npm dependency. This PR fixes that.