### PR TITLE
Remove `plugin.name` in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ Here is an example:
 // ./node_modules/netlify-plugin-awesome/index.js
 
 module.exports = {
-  name: 'netlify-plugin-awesome',
   onInit: () => {
     console.log('Run custom logic at beginning of build')
   },

--- a/packages/build/tests/cache/main/fixtures/cache_plugin.js
+++ b/packages/build/tests/cache/main/fixtures/cache_plugin.js
@@ -18,7 +18,6 @@ const pReadFile = promisify(readFile)
 const DUMMY_VALUE = String(Math.random())
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onPreBuild({ utils: { cache } }) {
     await cache.remove(TEST_CACHE_PATH)
     await makeDir(dirname(cachePath))

--- a/packages/build/tests/core/dry/fixtures/several/plugin.js
+++ b/packages/build/tests/core/dry/fixtures/several/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('test')
   },

--- a/packages/build/tests/core/flags/fixtures/node_version/plugin.js
+++ b/packages/build/tests/core/flags/fixtures/node_version/plugin.js
@@ -4,7 +4,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(execPath === TEST_NODE_PATH)
   },

--- a/packages/build/tests/core/lifecycle_end/fixtures/on_end_several/plugin_invalid.js
+++ b/packages/build/tests/core/lifecycle_end/fixtures/on_end_several/plugin_invalid.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-invalid',
   onEnd({
     utils: {
       build: { failBuild },

--- a/packages/build/tests/core/lifecycle_end/fixtures/on_end_several/plugin_valid.js
+++ b/packages/build/tests/core/lifecycle_end/fixtures/on_end_several/plugin_valid.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-valid',
   onEnd() {
     console.log('Plugin valid')
   },

--- a/packages/build/tests/core/lifecycle_end/fixtures/on_error_plugin/plugin.js
+++ b/packages/build/tests/core/lifecycle_end/fixtures/on_error_plugin/plugin.js
@@ -6,7 +6,6 @@ class TestError extends Error {
 }
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onBuild() {
     console.log('test')
     throw new TestError('test')

--- a/packages/build/tests/core/lifecycle_end/fixtures/on_error_several/plugin_invalid.js
+++ b/packages/build/tests/core/lifecycle_end/fixtures/on_error_several/plugin_invalid.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-invalid',
   onError({
     utils: {
       build: { failBuild },

--- a/packages/build/tests/core/lifecycle_end/fixtures/on_error_several/plugin_valid.js
+++ b/packages/build/tests/core/lifecycle_end/fixtures/on_error_several/plugin_valid.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-valid',
   onError({ error: { message } }) {
     console.log(message)
   },

--- a/packages/build/tests/core/secrets/fixtures/plugin/plugin.js
+++ b/packages/build/tests/core/secrets/fixtures/plugin/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('apiKey')
   },

--- a/packages/build/tests/error/build/fixtures/cancel/plugin.js
+++ b/packages/build/tests/error/build/fixtures/cancel/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({
     utils: {
       build: { cancelBuild },

--- a/packages/build/tests/error/build/fixtures/cancel_compat/plugin.js
+++ b/packages/build/tests/error/build/fixtures/cancel_compat/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({
     utils: {
       build: { cancel },

--- a/packages/build/tests/error/build/fixtures/cancel_error_option/plugin.js
+++ b/packages/build/tests/error/build/fixtures/cancel_error_option/plugin.js
@@ -3,7 +3,6 @@ const getError = function() {
 }
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({
     utils: {
       build: { cancelBuild },

--- a/packages/build/tests/error/build/fixtures/exception/plugin.js
+++ b/packages/build/tests/error/build/fixtures/exception/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     throw new Error('test')
   },

--- a/packages/build/tests/error/build/fixtures/exception_props/plugin.js
+++ b/packages/build/tests/error/build/fixtures/exception_props/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     const error = new Error('test')
     error.test = true

--- a/packages/build/tests/error/build/fixtures/fail_build/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_build/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({
     utils: {
       build: { failBuild },

--- a/packages/build/tests/error/build/fixtures/fail_build_compat/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_build_compat/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({
     utils: {
       build: { fail },

--- a/packages/build/tests/error/build/fixtures/fail_build_error_option/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_build_error_option/plugin.js
@@ -3,7 +3,6 @@ const getError = function() {
 }
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({
     utils: {
       build: { failBuild },

--- a/packages/build/tests/error/build/fixtures/fail_plugin/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_plugin/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-one',
   onInit({
     utils: {
       build: { failPlugin },

--- a/packages/build/tests/error/build/fixtures/fail_plugin/plugin_two.js
+++ b/packages/build/tests/error/build/fixtures/fail_plugin/plugin_two.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-two',
   onInit() {
     console.log('onInit')
   },

--- a/packages/build/tests/error/build/fixtures/fail_plugin_error_option/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_plugin_error_option/plugin.js
@@ -3,7 +3,6 @@ const getError = function() {
 }
 
 module.exports = {
-  name: 'netlify-plugin-one',
   onInit({
     utils: {
       build: { failPlugin },

--- a/packages/build/tests/error/build/fixtures/fail_plugin_error_option/plugin_two.js
+++ b/packages/build/tests/error/build/fixtures/fail_plugin_error_option/plugin_two.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-two',
   onInit() {
     console.log('onInit')
   },

--- a/packages/build/tests/error/clean_stack/fixtures/exception/plugin.js
+++ b/packages/build/tests/error/clean_stack/fixtures/exception/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-example',
   onInit() {
     throw new Error('test')
   },

--- a/packages/build/tests/error/clean_stack/fixtures/plugin/plugin.js
+++ b/packages/build/tests/error/clean_stack/fixtures/plugin/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-example',
   onInit({
     utils: {
       build: { failBuild },

--- a/packages/build/tests/error/plugin_load/fixtures/early_exit/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/early_exit/plugin.js
@@ -1,7 +1,6 @@
 const { exit } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onPreBuild() {
     console.log('onPreBuild')
     setTimeout(() => {

--- a/packages/build/tests/error/plugin_load/fixtures/early_exit/plugin_slow.js
+++ b/packages/build/tests/error/plugin_load/fixtures/early_exit/plugin_slow.js
@@ -3,7 +3,6 @@ const { promisify } = require('util')
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onBuild() {
     console.log('onBuild start')
     await pSetTimeout(1e3)

--- a/packages/build/tests/error/plugin_load/fixtures/full/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/error/plugin_load/fixtures/full/node_modules/netlify-plugin-test/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { build } }) {
     build.failBuild('test')
   }

--- a/packages/build/tests/error/plugin_load/fixtures/no_root/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/no_root/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     throw new Error('test')
   },

--- a/packages/build/tests/error/plugin_load/fixtures/partial/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/error/plugin_load/fixtures/partial/node_modules/netlify-plugin-test/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { build } }) {
     build.failBuild('test')
   }

--- a/packages/build/tests/error/plugin_load/fixtures/plugin_exit/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/plugin_exit/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     process.exit(1)
   },

--- a/packages/build/tests/error/plugin_load/fixtures/top/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/top/plugin.js
@@ -1,6 +1,4 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}
 
 const throwError = function() {
   throw new Error('test')

--- a/packages/build/tests/error/plugin_load/fixtures/uncaught/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/uncaught/plugin.js
@@ -3,7 +3,6 @@ const { promisify } = require('util')
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     setTimeout(function callback() {
       throw new Error('test')

--- a/packages/build/tests/error/plugin_load/fixtures/unhandled_promise/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/unhandled_promise/plugin.js
@@ -3,7 +3,6 @@ const { promisify } = require('util')
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     unhandledPromise()
     console.log('onInit')

--- a/packages/build/tests/error/plugin_load/fixtures/warning/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/warning/plugin.js
@@ -4,7 +4,6 @@ const { promisify } = require('util')
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     emitWarning('test')
     console.log('onInit')

--- a/packages/build/tests/error/stack/fixtures/plugin/plugin.js
+++ b/packages/build/tests/error/stack/fixtures/plugin/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     throw new Error('test')
   },

--- a/packages/build/tests/log/colors/fixtures/child/plugin.js
+++ b/packages/build/tests/log/colors/fixtures/child/plugin.js
@@ -1,7 +1,6 @@
 const { red } = require('chalk')
 
 module.exports = {
-  name: 'netlify-plugin-example',
   onInit() {
     console.log(red('onInit'))
   },

--- a/packages/build/tests/manifest/check/fixtures/default/plugin.js
+++ b/packages/build/tests/manifest/check/fixtures/default/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ inputs: { test } }) {
     console.log(test)
   },

--- a/packages/build/tests/manifest/check/fixtures/required/plugin.js
+++ b/packages/build/tests/manifest/check/fixtures/required/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/check/fixtures/unknown/plugin.js
+++ b/packages/build/tests/manifest/check/fixtures/unknown/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/load/fixtures/advanced_yaml/plugin.js
+++ b/packages/build/tests/manifest/load/fixtures/advanced_yaml/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/load/fixtures/missing/plugin.js
+++ b/packages/build/tests/manifest/load/fixtures/missing/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ inputs: { one } }) {
     console.log(one)
   },

--- a/packages/build/tests/manifest/load/fixtures/not_root_directory/plugin/main.js
+++ b/packages/build/tests/manifest/load/fixtures/not_root_directory/plugin/main.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/load/fixtures/parse_error/plugin.js
+++ b/packages/build/tests/manifest/load/fixtures/parse_error/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/load/fixtures/root_directory/plugin/main.js
+++ b/packages/build/tests/manifest/load/fixtures/root_directory/plugin/main.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/load/fixtures/same_directory/plugin.js
+++ b/packages/build/tests/manifest/load/fixtures/same_directory/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/inputs_array/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/inputs_array/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/inputs_array_objects/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/inputs_array_objects/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/inputs_name_string/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/inputs_name_string/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/inputs_name_undefined/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/inputs_name_undefined/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/inputs_required_boolean/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/inputs_required_boolean/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/inputs_unknown/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/inputs_unknown/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/module/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/manifest/validate/fixtures/module/node_modules/netlify-plugin-test/index.js
@@ -1,3 +1,2 @@
 module.exports = {
-  name: 'netlify-plugin-test'
 }

--- a/packages/build/tests/manifest/validate/fixtures/name_string/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/name_string/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/name_undefined/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/name_undefined/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/plain_object/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/plain_object/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/scopes_array/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/scopes_array/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/scopes_invalid/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/scopes_invalid/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/manifest/validate/fixtures/unknown/plugin.js
+++ b/packages/build/tests/manifest/validate/fixtures/unknown/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/plugins/api/fixtures/api_call/plugin.js
+++ b/packages/build/tests/plugins/api/fixtures/api_call/plugin.js
@@ -1,7 +1,6 @@
 const nock = require('nock')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ api: { scheme, host, pathPrefix, listSites } }) {
     const scope = nock(`${scheme}://${host}`)
     scope.get(`${pathPrefix}/sites`).reply(200, [{ id: 'test' }])

--- a/packages/build/tests/plugins/api/fixtures/default_scopes/plugin.js
+++ b/packages/build/tests/plugins/api/fixtures/default_scopes/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ api: { listSites } }) {
     await listSites('https://example.com')
   },

--- a/packages/build/tests/plugins/api/fixtures/feature_flag/plugin.js
+++ b/packages/build/tests/plugins/api/fixtures/feature_flag/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ api }) {
     console.log(api === undefined)
   },

--- a/packages/build/tests/plugins/api/fixtures/no_token/plugin.js
+++ b/packages/build/tests/plugins/api/fixtures/no_token/plugin.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/plugins/api/fixtures/star_scopes/plugin.js
+++ b/packages/build/tests/plugins/api/fixtures/star_scopes/plugin.js
@@ -1,7 +1,6 @@
 const nock = require('nock')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ api: { scheme, host, pathPrefix, listSites } }) {
     const scope = nock(`${scheme}://${host}`)
     scope.get(`${pathPrefix}/sites`).reply(200, [{ id: 'test' }])

--- a/packages/build/tests/plugins/api/fixtures/wrong_scopes/plugin.js
+++ b/packages/build/tests/plugins/api/fixtures/wrong_scopes/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ api }) {
     await api.listSites('https://example.com')
   },

--- a/packages/build/tests/plugins/constants/fixtures/build_dir/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/build_dir/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants, constants: { PUBLISH_DIR, BUILD_DIR } }) {
     console.log(PUBLISH_DIR, PUBLISH_DIR === BUILD_DIR, !Object.keys(constants).includes(BUILD_DIR))
   },

--- a/packages/build/tests/plugins/constants/fixtures/cache/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/cache/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ constants: { CACHE_DIR } }) {
     console.log(CACHE_DIR)
   },

--- a/packages/build/tests/plugins/constants/fixtures/config/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/config/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { CONFIG_PATH } }) {
     console.log(CONFIG_PATH)
   },

--- a/packages/build/tests/plugins/constants/fixtures/functions_dist/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/functions_dist/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { FUNCTIONS_DIST } }) {
     console.log(FUNCTIONS_DIST)
   },

--- a/packages/build/tests/plugins/constants/fixtures/functions_src_auto/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/functions_src_auto/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { FUNCTIONS_SRC } }) {
     console.log(FUNCTIONS_SRC)
   },

--- a/packages/build/tests/plugins/constants/fixtures/functions_src_default/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/functions_src_default/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { FUNCTIONS_SRC } }) {
     console.log(FUNCTIONS_SRC)
   },

--- a/packages/build/tests/plugins/constants/fixtures/functions_src_missing/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/functions_src_missing/plugin.js
@@ -1,7 +1,6 @@
 const pathExists = require('path-exists')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ constants: { FUNCTIONS_SRC } }) {
     console.log(FUNCTIONS_SRC, await pathExists(FUNCTIONS_SRC))
   },

--- a/packages/build/tests/plugins/constants/fixtures/functions_src_relative/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/functions_src_relative/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { FUNCTIONS_SRC } }) {
     console.log(FUNCTIONS_SRC)
   },

--- a/packages/build/tests/plugins/constants/fixtures/is_local/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/is_local/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { IS_LOCAL } }) {
     console.log(IS_LOCAL)
   },

--- a/packages/build/tests/plugins/constants/fixtures/publish_absolute/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/publish_absolute/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { PUBLISH_DIR } }) {
     console.log(PUBLISH_DIR)
   },

--- a/packages/build/tests/plugins/constants/fixtures/publish_default/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/publish_default/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { PUBLISH_DIR } }) {
     console.log(PUBLISH_DIR, PUBLISH_DIR === __dirname)
   },

--- a/packages/build/tests/plugins/constants/fixtures/publish_default_base/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/publish_default_base/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { PUBLISH_DIR } }) {
     console.log(PUBLISH_DIR, PUBLISH_DIR.endsWith('base'))
   },

--- a/packages/build/tests/plugins/constants/fixtures/publish_missing/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/publish_missing/plugin.js
@@ -1,7 +1,6 @@
 const pathExists = require('path-exists')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ constants: { PUBLISH_DIR } }) {
     console.log(PUBLISH_DIR, await pathExists(PUBLISH_DIR))
   },

--- a/packages/build/tests/plugins/constants/fixtures/publish_relative/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/publish_relative/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { PUBLISH_DIR } }) {
     console.log(PUBLISH_DIR)
   },

--- a/packages/build/tests/plugins/constants/fixtures/site_id/plugin.js
+++ b/packages/build/tests/plugins/constants/fixtures/site_id/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { SITE_ID } }) {
     console.log(SITE_ID)
   },

--- a/packages/build/tests/plugins/env/fixtures/build/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/build/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(TEST)
   },

--- a/packages/build/tests/plugins/env/fixtures/build_readonly/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/build_readonly/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(NETLIFY === undefined)
   },

--- a/packages/build/tests/plugins/env/fixtures/context/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/context/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(CONTEXT)
   },

--- a/packages/build/tests/plugins/env/fixtures/gatsby_telemetry/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/gatsby_telemetry/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(GATSBY_TELEMETRY_DISABLED)
   },

--- a/packages/build/tests/plugins/env/fixtures/git/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/git/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(Boolean(BRANCH))
     console.log(Boolean(HEAD))

--- a/packages/build/tests/plugins/env/fixtures/git_branch/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/git_branch/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(BRANCH, HEAD)
   },

--- a/packages/build/tests/plugins/env/fixtures/lang/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/lang/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(LANG)
   },

--- a/packages/build/tests/plugins/env/fixtures/language/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/language/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(LANGUAGE)
   },

--- a/packages/build/tests/plugins/env/fixtures/lc_all/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/lc_all/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(LC_ALL)
   },

--- a/packages/build/tests/plugins/env/fixtures/netlify/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/netlify/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(NETLIFY)
   },

--- a/packages/build/tests/plugins/env/fixtures/next_telemetry/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/next_telemetry/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(NEXT_TELEMETRY_DISABLED)
   },

--- a/packages/build/tests/plugins/env/fixtures/site_info/plugin.js
+++ b/packages/build/tests/plugins/env/fixtures/site_info/plugin.js
@@ -3,7 +3,6 @@ const {
 } = require('process')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ constants: { SITE_ID } }) {
     console.log({ SITE_ID, URL, REPOSITORY_URL })
   },

--- a/packages/build/tests/plugins/install/fixtures/already/plugin/main.js
+++ b/packages/build/tests/plugins/install/fixtures/already/plugin/main.js
@@ -2,7 +2,6 @@
 const avg = require('math-avg')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(avg([1, 2]))
   },

--- a/packages/build/tests/plugins/install/fixtures/error/plugin/main.js
+++ b/packages/build/tests/plugins/install/fixtures/error/plugin/main.js
@@ -1,3 +1,1 @@
-module.exports = {
-  name: 'netlify-plugin-test',
-}
+module.exports = {}

--- a/packages/build/tests/plugins/install/fixtures/no_package/plugin/main.js
+++ b/packages/build/tests/plugins/install/fixtures/no_package/plugin/main.js
@@ -2,7 +2,6 @@
 const avg = require('math-avg')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(avg([1, 2]))
   },

--- a/packages/build/tests/plugins/install/fixtures/no_root_package/plugin/main.js
+++ b/packages/build/tests/plugins/install/fixtures/no_root_package/plugin/main.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('test')
   },

--- a/packages/build/tests/plugins/install/fixtures/npm/plugin/main.js
+++ b/packages/build/tests/plugins/install/fixtures/npm/plugin/main.js
@@ -2,7 +2,6 @@
 const avg = require('math-avg')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(avg([1, 2]))
   },

--- a/packages/build/tests/plugins/install/fixtures/yarn/plugin/main.js
+++ b/packages/build/tests/plugins/install/fixtures/yarn/plugin/main.js
@@ -2,7 +2,6 @@
 const avg = require('math-avg')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log(avg([1, 2]))
   },

--- a/packages/build/tests/plugins/load/fixtures/local/plugin.js
+++ b/packages/build/tests/plugins/load/fixtures/local/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('test')
   },

--- a/packages/build/tests/plugins/load/fixtures/module/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/plugins/load/fixtures/module/node_modules/netlify-plugin-test/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('test')
   }

--- a/packages/build/tests/plugins/normalize/fixtures/lifecycle_name/plugin.js
+++ b/packages/build/tests/plugins/normalize/fixtures/lifecycle_name/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   build() {
     console.log('test')
   },

--- a/packages/build/tests/plugins/run/fixtures/big/plugin.js
+++ b/packages/build/tests/plugins/run/fixtures/big/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('a'.repeat(1e7))
   },

--- a/packages/build/tests/plugins/run/fixtures/ci/plugin.js
+++ b/packages/build/tests/plugins/run/fixtures/ci/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('a'.repeat(1e3))
     console.error('b'.repeat(1e3))

--- a/packages/build/tests/plugins/run/fixtures/ci/pluginTwo.js
+++ b/packages/build/tests/plugins/run/fixtures/ci/pluginTwo.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit() {
     console.log('a'.repeat(1e3))
     console.error('b'.repeat(1e3))

--- a/packages/build/tests/plugins/run/fixtures/interleave/plugin.js
+++ b/packages/build/tests/plugins/run/fixtures/interleave/plugin.js
@@ -3,7 +3,6 @@ const { promisify } = require('util')
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     console.log('one')
     await pSetTimeout(1e3)

--- a/packages/build/tests/plugins/run/fixtures/local_bin/plugin.js
+++ b/packages/build/tests/plugins/run/fixtures/local_bin/plugin.js
@@ -1,7 +1,6 @@
 const execa = require('execa')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit() {
     await execa('atob', ['dGVzdA=='], { stdio: 'inherit' })
   },

--- a/packages/build/tests/plugins/validate/fixtures/backward_compat/plugin.js
+++ b/packages/build/tests/plugins/validate/fixtures/backward_compat/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-example',
   config: {},
   inputs: {},
   scopes: [],

--- a/packages/build/tests/plugins/validate/fixtures/handler_function/plugin.js
+++ b/packages/build/tests/plugins/validate/fixtures/handler_function/plugin.js
@@ -1,4 +1,3 @@
 module.exports = {
-  name: 'netlify-plugin-example',
   onBuild: false,
 }

--- a/packages/build/tests/plugins/validate/fixtures/handler_name/plugin.js
+++ b/packages/build/tests/plugins/validate/fixtures/handler_name/plugin.js
@@ -1,4 +1,3 @@
 module.exports = {
-  name: 'netlify-plugin-example',
   onInvalid() {},
 }

--- a/packages/build/tests/utils/cache/fixtures/contents/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/contents/plugin.js
@@ -8,7 +8,6 @@ const pWriteFile = promisify(writeFile)
 const pReadFile = promisify(readFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/defined/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/defined/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { cache } }) {
     console.log(
       Object.keys(cache)

--- a/packages/build/tests/utils/cache/fixtures/digests/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/digests/plugin.js
@@ -7,7 +7,6 @@ const del = require('del')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const idOne = String(Math.random()).replace('.', '')
     const idTwo = String(Math.random()).replace('.', '')

--- a/packages/build/tests/utils/cache/fixtures/digests_many/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/digests_many/plugin.js
@@ -7,7 +7,6 @@ const del = require('del')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const idOne = String(Math.random()).replace('.', '')
     const idTwo = String(Math.random()).replace('.', '')

--- a/packages/build/tests/utils/cache/fixtures/digests_missing/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/digests_missing/plugin.js
@@ -7,7 +7,6 @@ const del = require('del')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const idOne = String(Math.random()).replace('.', '')
     const idTwo = String(Math.random()).replace('.', '')

--- a/packages/build/tests/utils/cache/fixtures/directory/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/directory/plugin.js
@@ -11,7 +11,6 @@ const makeDir = require('make-dir')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
     const dir = 'src'

--- a/packages/build/tests/utils/cache/fixtures/hash/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash/plugin.js
@@ -9,7 +9,6 @@ const pathExists = require('path-exists')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/hash_big/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash_big/plugin.js
@@ -11,7 +11,6 @@ const makeDir = require('make-dir')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const dir = 'src'
     await makeDir(dir)

--- a/packages/build/tests/utils/cache/fixtures/hash_directory/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash_directory/plugin.js
@@ -11,7 +11,6 @@ const makeDir = require('make-dir')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const dir = 'src'
     await makeDir(dir)

--- a/packages/build/tests/utils/cache/fixtures/home/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/home/plugin.js
@@ -13,7 +13,6 @@ const makeDir = require('make-dir')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
     const path = resolve(homedir(), id)

--- a/packages/build/tests/utils/cache/fixtures/list/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/list/plugin.js
@@ -8,7 +8,6 @@ const del = require('del')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/manifest_missing/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/manifest_missing/plugin.js
@@ -8,7 +8,6 @@ const pWriteFile = promisify(writeFile)
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/move/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/move/plugin.js
@@ -9,7 +9,6 @@ const pathExists = require('path-exists')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/no_options/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/no_options/plugin.js
@@ -9,7 +9,6 @@ const pathExists = require('path-exists')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/remove/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/remove/plugin.js
@@ -7,7 +7,6 @@ const del = require('del')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/remove_array/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/remove_array/plugin.js
@@ -7,7 +7,6 @@ const del = require('del')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/restore_already/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/restore_already/plugin.js
@@ -8,7 +8,6 @@ const pWriteFile = promisify(writeFile)
 const pReadFile = promisify(readFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/restore_non_cached/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/restore_non_cached/plugin.js
@@ -2,7 +2,6 @@
 const pathExists = require('path-exists')
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     console.log(await cache.restore('non_existing'))
     console.log(await pathExists('non_existing'))

--- a/packages/build/tests/utils/cache/fixtures/save/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/save/plugin.js
@@ -9,7 +9,6 @@ const pathExists = require('path-exists')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/save_array/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/save_array/plugin.js
@@ -9,7 +9,6 @@ const pathExists = require('path-exists')
 const pWriteFile = promisify(writeFile)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/save_non_existing/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/save_non_existing/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     await cache.save('non_existing')
     console.log(await cache.has('non_existing'))

--- a/packages/build/tests/utils/cache/fixtures/ttl/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/ttl/plugin.js
@@ -10,7 +10,6 @@ const pWriteFile = promisify(writeFile)
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/ttl_invalid/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/ttl_invalid/plugin.js
@@ -8,7 +8,6 @@ const pWriteFile = promisify(writeFile)
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/cache/fixtures/ttl_negative/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/ttl_negative/plugin.js
@@ -8,7 +8,6 @@ const pWriteFile = promisify(writeFile)
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { cache } }) {
     const id = String(Math.random()).replace('.', '')
 

--- a/packages/build/tests/utils/functions/fixtures/already/plugin.js
+++ b/packages/build/tests/utils/functions/fixtures/already/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'plugin-example',
   async onPostBuild({ utils: { functions } }) {
     await functions.add(`${__dirname}/test.js`)
   },

--- a/packages/build/tests/utils/functions/fixtures/directory/plugin.js
+++ b/packages/build/tests/utils/functions/fixtures/directory/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'plugin-example',
   async onPostBuild({ utils: { functions } }) {
     await functions.add(`${__dirname}/test`)
   },

--- a/packages/build/tests/utils/functions/fixtures/missing/plugin.js
+++ b/packages/build/tests/utils/functions/fixtures/missing/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'plugin-example',
   async onPostBuild({ utils: { functions } }) {
     await functions.add(`${__dirname}/test`)
   },

--- a/packages/build/tests/utils/functions/fixtures/simple/plugin.js
+++ b/packages/build/tests/utils/functions/fixtures/simple/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'plugin-example',
   async onPostBuild({ utils: { functions } }) {
     await functions.add(`${__dirname}/test.js`)
   },

--- a/packages/build/tests/utils/git/fixtures/commits/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/commits/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({
     utils: {
       git: { commits },

--- a/packages/build/tests/utils/git/fixtures/defined/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/defined/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { git } }) {
     console.log(
       Object.keys(git)

--- a/packages/build/tests/utils/git/fixtures/diff/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/diff/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({
     utils: {
       git: { modifiedFiles, createdFiles, deletedFiles },

--- a/packages/build/tests/utils/git/fixtures/file_match/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/file_match/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({
     utils: {
       git: { fileMatch },

--- a/packages/build/tests/utils/git/fixtures/full/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/full/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({
     utils: {
       git: { commits, ...git },

--- a/packages/build/tests/utils/git/fixtures/lines/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/lines/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({
     utils: {
       git: { linesOfCode },

--- a/packages/build/tests/utils/load/fixtures/error/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/error/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { git } }) {
     console.log(git.modifiedFiles)
   },

--- a/packages/build/tests/utils/load/fixtures/function_async/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/function_async/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { git } }) {
     console.log(
       Object.keys(git)

--- a/packages/build/tests/utils/load/fixtures/function_sync/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/function_sync/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { cache } }) {
     console.log(
       Object.keys(cache)

--- a/packages/build/tests/utils/load/fixtures/none/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/none/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils }) {
     console.log(
       Object.keys(utils)

--- a/packages/build/tests/utils/run/fixtures/command/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/command/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     await run.command('ava --version')
   },

--- a/packages/build/tests/utils/run/fixtures/defined/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/defined/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   onInit({ utils: { run } }) {
     console.log(
       Object.keys(run)

--- a/packages/build/tests/utils/run/fixtures/local/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/local/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     await run('ava', ['--version'])
   },

--- a/packages/build/tests/utils/run/fixtures/no_args/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/no_args/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     await run('echo')
   },

--- a/packages/build/tests/utils/run/fixtures/no_args_options/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/no_args_options/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     await run('echo', {})
   },

--- a/packages/build/tests/utils/run/fixtures/stderr/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/stderr/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     const { stdout } = await run('ava', ['--version'], { stderr: 'pipe' })
     console.log({ stdout })

--- a/packages/build/tests/utils/run/fixtures/stdio/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/stdio/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     const { stdout } = await run('ava', ['--version'], { stdio: 'pipe' })
     console.log({ stdout })

--- a/packages/build/tests/utils/run/fixtures/stdout/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/stdout/plugin.js
@@ -1,5 +1,4 @@
 module.exports = {
-  name: 'netlify-plugin-test',
   async onInit({ utils: { run } }) {
     const { stdout } = await run('ava', ['--version'], { stdout: 'pipe' })
     console.log({ stdout })

--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -11,7 +11,6 @@ Utility for caching files in Netlify Build.
 
 ```js
 module.exports = {
-  name: 'example-plugin',
   // Restore file/directory cached in previous builds.
   // Does not do anything if:
   //  - the file/directory already exists locally
@@ -35,7 +34,6 @@ module.exports = {
 ```js
 // Restore/cache several files/directories
 module.exports = {
-  name: 'example-plugin',
   async onPreBuild({ utils }) {
     await utils.cache.restore(['./path/to/file', './path/to/other'])
   }
@@ -74,7 +72,6 @@ done when those files won't be used anymore by the current build.
 // removes local files, so should only be done when those files won't be used
 // anymore by the current build.
 module.exports = {
-  name: 'example-plugin',
   async onPreBuild({ utils }) {
     await utils.cache.restore('./path/to/file', { move: true })
   }
@@ -94,7 +91,6 @@ Only cache the file/directory for a specific amount of time.
 ```js
 // Only cache the following file/directory for 1 hour
 module.exports = {
-  name: 'example-plugin',
   async onPreBuild({ utils }) {
     await utils.cache.restore('./path/to/file')
   }
@@ -120,7 +116,6 @@ speeds up caching.
 // For example, `package-lock.json` and `yarn.lock` are digest files for the
 // `node_modules` directory.
 module.exports = {
-  name: 'example-plugin',
   async onPreBuild({ utils }) {
     await utils.cache.restore('node_modules')
   }
@@ -161,7 +156,6 @@ Returns `true` if the file/directory cache was removed, `false` otherwise.
 
 ```js
 module.exports = {
-  name: 'example-plugin',
   async onPostBuild({ utils }) {
     await utils.cache.remove('./path/to/file')
   },
@@ -181,7 +175,6 @@ Returns whether a file/directory is currently cached.
 const path = './path/to/file'
 
 module.exports = {
-  name: 'example-plugin',
   async onPreBuild({ utils }) {
     if (!(await utils.cache.has(path))) {
       console.log(`File ${path} not cached`)
@@ -210,7 +203,6 @@ being restored), not while being cached.
 
 ```js
 module.exports = {
-  name: 'example-plugin',
   async onPreBuild({ utils }) {
     const files = await utils.cache.list()
     console.log('Cached files', files)

--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -11,7 +11,6 @@ This allows plugins to dynamically inject Netlify Functions inside users builds.
 
 ```js
 module.exports = {
-  name: 'example-plugin',
   // Add a Netlify Functions file or directory to a build
   async onPostBuild({ utils }) {
     await utils.functions.add('./path/to/function')

--- a/packages/git-utils/README.md
+++ b/packages/git-utils/README.md
@@ -12,7 +12,6 @@ Utility for dealing with modified, created, deleted files since a git commit.
 ```js
 /* Export the Netlify Plugin */
 module.exports = {
-  name: 'netlify-plugin-one',
   // On the "init" lifecycle event, run this logic
   onInit: ({ utils }) => {
     const { git } = utils
@@ -54,7 +53,6 @@ The `git` util includes the following signature.
 
 ```js
 module.exports = {
-  name: 'netlify-plugin-one',
   // On the "init" lifecycle event, run this logic
   onInit: ({ utils }) => {
     console.log(utils.git)

--- a/packages/run-utils/README.md
+++ b/packages/run-utils/README.md
@@ -12,7 +12,6 @@ over `execa` defaulting to `{ preferLocal: true, stdio: 'inherit' }`.
 // Runs `eslint src/ test/` and prints the result
 // Either local or global binaries can be run
 const exampleNetlifyPlugin = {
-  name: 'example-netlify-plugin',
   async onBuild({ utils: { run } }) {
     await run('eslint', ['src/', 'test/'])
   },
@@ -22,7 +21,6 @@ const exampleNetlifyPlugin = {
 ```js
 // Same but with a more convenient syntax
 const exampleNetlifyPlugin = {
-  name: 'example-netlify-plugin',
   async onBuild({ utils: { run } }) {
     await run.command('eslint src/ test/')
   },
@@ -32,7 +30,6 @@ const exampleNetlifyPlugin = {
 ```js
 // Retrieve command's output and exit code as variables
 const exampleNetlifyPlugin = {
-  name: 'example-netlify-plugin',
   async onBuild({ utils: { run } }) {
     const { stdout, stderr, exitCode } = await run('eslint', ['src/', 'test/'])
     console.log({ stdout, stderr, exitCode })
@@ -43,7 +40,6 @@ const exampleNetlifyPlugin = {
 ```js
 // Streaming mode
 const exampleNetlifyPlugin = {
-  name: 'example-netlify-plugin',
   async onBuild({ utils: { run } }) {
     const { stdout } = run('eslint', ['src/', 'test/'])
     stdout.pipe(fs.createWriteStream('stdout.txt'))
@@ -55,7 +51,6 @@ const exampleNetlifyPlugin = {
 // If the command exit code is not 0 or was terminated by a signal, an error
 // is thrown with failure information
 const exampleNetlifyPlugin = {
-  name: 'example-netlify-plugin',
   async onBuild({ utils: { run } }) {
     try {
       await run('eslint', ['does_not_exist'])
@@ -69,7 +64,6 @@ const exampleNetlifyPlugin = {
 ```js
 // Pass environment variables
 const exampleNetlifyPlugin = {
-  name: 'example-netlify-plugin',
   async onBuild({ utils: { run } }) {
     await run('eslint', ['src/', 'test/'], { env: { TEST: 'true' } })
   },


### PR DESCRIPTION
`plugin.name` has been moved to `manifest.yml`. Therefore this PR removes `plugin.name` from all test fixtures. It also removes it from some `README`.

At the moment, the `name` property is optional in `manifest.yml`, so this PR does not add it. But a follow-up PR will add all `manifest.yml` in all test fixtures.