### PR TITLE
Remove unused backward compatibility fix

### DIFF
--- a/packages/build/src/plugins/child/normalize.js
+++ b/packages/build/src/plugins/child/normalize.js
@@ -7,20 +7,13 @@ const normalizePlugin = function(logic) {
 }
 
 const normalizeProperty = function(key, value) {
-  const newKey = LEGACY_PROPERTIES[key]
+  const newKey = LEGACY_EVENTS[key]
 
   if (newKey === undefined) {
     return [key, value]
   }
 
   return [newKey, value]
-}
-
-const LEGACY_PROPERTIES = {
-  ...LEGACY_EVENTS,
-  // Backward compatibility with former name.
-  // TODO: remove after going out of beta.
-  config: 'inputs',
 }
 
 module.exports = { normalizePlugin }


### PR DESCRIPTION
`plugin.config` was previously renamed to `plugin.inputs`. We added a backward compatibility fix for people using the old names.

However now that `plugin.inputs` has been moved to `manifest.yml`, this fix is not needed anymore. Note that both `plugin.config` and `plugin.inputs` still do not error, they just don't do anything anymore.