### PR TITLE
Move some code from plugins to the parent process

### DIFF
--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -16,16 +16,16 @@ const loadPlugin = function(payload) {
 
   const logicA = normalizePlugin(logic)
 
-  const pluginCommands = getPluginCommands(logicA, payload)
+  const pluginCommands = getPluginCommands(logicA)
 
   const context = getContext(pluginCommands, payload)
   return { context, pluginCommands }
 }
 
-const getPluginCommands = function(logic, { package, core, local, packageJson }) {
+const getPluginCommands = function(logic) {
   return Object.entries(logic)
     .filter(isEventHandler)
-    .map(([event, method]) => ({ method, event, package, core, local, packageJson }))
+    .map(([event, method]) => ({ method, event }))
 }
 
 const isEventHandler = function([, value]) {

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -40,19 +40,22 @@ const loadPlugin = async function(
 
   try {
     const { pluginCommands } = await callChild(childProcess, 'load', {
-      package,
       pluginPath,
       manifest,
       inputs,
       netlifyConfig,
       utilsData,
-      core,
-      local,
       token,
       constants,
-      packageJson,
     })
-    const pluginCommandsA = pluginCommands.map(pluginCommand => ({ ...pluginCommand, childProcess }))
+    const pluginCommandsA = pluginCommands.map(pluginCommand => ({
+      ...pluginCommand,
+      package,
+      core,
+      local,
+      packageJson,
+      childProcess,
+    }))
     return pluginCommandsA
   } catch (error) {
     addErrorInfo(error, { plugin: { package, packageJson }, location: { event: 'load', package, local } })


### PR DESCRIPTION
This PR moves some of the code from the plugins child process to the parent process instead. Plugins child processes have stronger requirements (such as the Node.js minimum allowed version), so we need to keep their code as minimal as possible.

This PR just moves code around. The behavior does not change otherwise.