### PR TITLE
Revert monorepo bug workaround

### DIFF
--- a/packages/config/src/utils/is-netlify-ci.js
+++ b/packages/config/src/utils/is-netlify-ci.js
@@ -1,8 +1,0 @@
-const { env } = require('process')
-
-// Check if inside Netlify Build CI
-const isNetlifyCI = function() {
-  return Boolean(env.NETLIFY)
-}
-
-module.exports = isNetlifyCI


### PR DESCRIPTION
#943 introduced a workaround for a bug (#918) with monorepos. 

This workaround is not needed anymore now that the buildbot is using `@netlify/config` (https://github.com/netlify/buildbot/pull/629, not deployed to production yet). Therefore this PR removes the workaround.