### PR TITLE
Refactor serialization in logs

### DIFF
--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -10,7 +10,7 @@ const { serializeError } = require('../error/serialize')
 const isNetlifyCI = require('../utils/is-netlify-ci')
 
 const { log } = require('./logger')
-const { serialize, indent, SUBTEXT_PADDING } = require('./serialize')
+const { serialize, SUBTEXT_PADDING } = require('./serialize')
 const { EMPTY_LINE, HEADING_PREFIX, TICK, ARROW_DOWN } = require('./constants')
 
 const logBuildStart = function() {
@@ -22,7 +22,7 @@ ${EMPTY_LINE}`)
 
 const logFlags = function(flags) {
   const flagsA = omit(flags, HIDDEN_FLAGS)
-  log(cyanBright.bold(`${HEADING_PREFIX} Flags`), indent(serialize(flagsA)).trimRight(), EMPTY_LINE)
+  log(cyanBright.bold(`${HEADING_PREFIX} Flags`), serialize(flagsA), EMPTY_LINE)
 }
 
 const CI_HIDDEN_FLAGS = isNetlifyCI() ? ['nodePath'] : []

--- a/packages/build/src/log/serialize.js
+++ b/packages/build/src/log/serialize.js
@@ -3,6 +3,10 @@ const indentString = require('indent-string')
 
 // Serialize to string
 const serialize = function(arg) {
+  return indent(stringify(arg)).trimRight()
+}
+
+const stringify = function(arg) {
   if (typeof arg !== 'object' || arg === null) {
     return String(arg)
   }

--- a/packages/build/src/plugins/manifest/check.js
+++ b/packages/build/src/plugins/manifest/check.js
@@ -1,8 +1,7 @@
 const { redBright } = require('chalk')
-const { dump: serializeYaml } = require('js-yaml')
 
 const { addErrorInfo } = require('../../error/info')
-const { indent } = require('../../log/serialize')
+const { serialize } = require('../../log/serialize')
 
 // Check that plugin inputs match the validation specified in "manifest.yml"
 // Also assign default values
@@ -17,7 +16,7 @@ const checkInputs = function({ inputs, manifest: { inputs: rules = [] }, package
 
 ${redBright.bold('Plugin inputs')}
 
-${serializeInputs(inputs)}`
+${serialize(inputs)}`
     throw error
   }
 }
@@ -78,13 +77,6 @@ const addInputError = function({ error, name, package, packageJson, local }) {
     plugin: { package, packageJson },
     location: { event: 'load', package, input: name, local },
   })
-}
-
-// Serialize inputs to display in error messages
-const serializeInputs = function(inputs) {
-  const inputsA = serializeYaml(inputs, { noRefs: true }).trim()
-  const inputsB = indent(inputsA)
-  return inputsB
 }
 
 module.exports = { checkInputs }


### PR DESCRIPTION
We have some logic to serialize objects (with YAML) that should be printed in logs.
This logic is duplicated in two places. This PR refactors this so both places use the same code.