### PR TITLE
Simplify some code related to local plugins

### DIFF
--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -12,21 +12,18 @@ const { useManifest } = require('./manifest/main')
 const pResolve = promisify(resolve)
 
 // Load plugin options (specified by user in `config.plugins`)
-const getPluginsOptions = async function({ plugins: pluginsOptions }, buildDir, configPath) {
-  const pluginsOptionsA = [...CORE_PLUGINS, ...pluginsOptions].map(normalizePluginOptions)
-  const pluginsOptionsB = await Promise.all(
-    pluginsOptionsA.map(pluginOptions => resolvePlugin(pluginOptions, buildDir, configPath)),
+const getPluginsOptions = async function({ plugins }, buildDir, configPath) {
+  const pluginsOptions = [...CORE_PLUGINS, ...plugins].map(normalizePluginOptions)
+  const pluginsOptionsA = await Promise.all(
+    pluginsOptions.map(pluginOptions => resolvePlugin(pluginOptions, buildDir, configPath)),
   )
-  return pluginsOptionsB
+  return pluginsOptionsA
 }
 
-const normalizePluginOptions = function(pluginOptions) {
-  const { package, core, inputs } = { ...DEFAULT_PLUGIN_OPTIONS, ...pluginOptions }
+const normalizePluginOptions = function({ package, location = package, core = false, inputs = {} }) {
   const local = package.startsWith('.') || package.startsWith('/')
-  return { package, local, core, inputs }
+  return { package, location, local, core, inputs }
 }
-
-const DEFAULT_PLUGIN_OPTIONS = { inputs: {} }
 
 const resolvePlugin = async function(pluginOptions, buildDir, configPath) {
   const pluginPath = await getPluginPath(pluginOptions, buildDir, configPath)
@@ -37,8 +34,7 @@ const resolvePlugin = async function(pluginOptions, buildDir, configPath) {
 // We use `resolve` because `require()` should be relative to `buildDir` not to
 // this `__filename`
 // Automatically installing the dependency if it is missing.
-const getPluginPath = async function({ package, core }, buildDir, configPath) {
-  const location = core === undefined ? package : core
+const getPluginPath = async function({ location }, buildDir, configPath) {
   try {
     return await tryGetPluginPath({ location, buildDir, configPath })
   } catch (error) {

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -22,7 +22,7 @@ const getPluginsOptions = async function({ plugins: pluginsOptions }, buildDir, 
 
 const normalizePluginOptions = function(pluginOptions) {
   const { package, core, inputs } = { ...DEFAULT_PLUGIN_OPTIONS, ...pluginOptions }
-  const local = core === undefined && (package.startsWith('.') || package.startsWith('/'))
+  const local = package.startsWith('.') || package.startsWith('/')
   return { package, local, core, inputs }
 }
 

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -7,10 +7,10 @@ const CACHE_PLUGIN = `${__dirname}/cache/plugin.js`
 
 // Plugins that are installed and enabled by default
 const CORE_PLUGINS = [
-  { package: '@netlify/plugin-functions-core', core: FUNCTIONS_PLUGIN },
+  { package: '@netlify/plugin-functions-core', location: FUNCTIONS_PLUGIN, core: true },
   // TODO: remove NETLIFY_BUILD_SAVE_CACHE once integrated in the buildbot
   ...(NETLIFY_BUILD_SAVE_CACHE === '1'
-    ? [{ package: '@netlify/plugin-cache-core', core: CACHE_PLUGIN }]
+    ? [{ package: '@netlify/plugin-cache-core', location: CACHE_PLUGIN, core: true }]
     : // istanbul ignore next
       []),
 ]


### PR DESCRIPTION
We have 3 kinds of plugins:
  - core plugins are installed by us on every build: `{ package: '@netlify/plugin-functions-core', location: '/path/to/main/file.js', core: true }`
  - module plugins are installed by users and target a Node module: `{ package: 'netlify-plugin-example' }`
  - local plugins are installed by users and target a local file: `{ package: '/path/to/main/file.js' }`

This PR simplifies the code related to differentiating between each of those and assigning default values. It is refactoring-only (does not change behavior).

Note: this PR makes the `core` attribute go from `string | undefined` to `boolean`. I checked the codebase and this (rarely used) attribute is always transtyped to a boolean at the moment, so no issues there. 