### PR TITLE
Improve Netlify Functions automatic install

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -5974,11 +5974,6 @@
         "es6-error": "^4.0.1"
       }
     },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -6950,24 +6945,6 @@
         "mkdirp": "^0.5.1",
         "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
-      }
-    },
-    "unixify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
-      "requires": {
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
       }
     },
     "unset-value": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -34,7 +34,6 @@
     "chalk": "^3.0.0",
     "clean-stack": "^2.2.0",
     "execa": "^3.3.0",
-    "fast-glob": "^3.1.0",
     "figures": "^3.2.0",
     "filter-obj": "^2.0.1",
     "global-cache-dir": "^1.0.1",
@@ -62,7 +61,6 @@
     "resolve": "^1.15.1",
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",
-    "unixify": "^1.0.0",
     "uuid": "^3.4.0",
     "yargs": "^15.1.0"
   },


### PR DESCRIPTION
When users specify Netlify Functions, we automatically install any dependencies those Functions might have with `npm install` (Yarn not supported yet), providing they have a `package.json`.

To do this, we need to find all the `package.json` inside Netlify Functions. The current code is quite slow since it's recurses over all subdirectories. This also requires ensuring we are not recursing inside `node_modules`. 

This PR implements a faster (and simpler) alternative that only looks for `functions/package.json` and `functions/*/package.json`. The behavior does not change otherwise.