### PR TITLE
Add a test helper

### DIFF
--- a/packages/build/tests/error/plugin_load/tests.js
+++ b/packages/build/tests/error/plugin_load/tests.js
@@ -1,10 +1,8 @@
 const { platform } = require('process')
 
 const test = require('ava')
-const cpy = require('cpy')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
-const { createRepoDir, removeDir } = require('../../helpers/dir')
+const { runFixture } = require('../../helpers/main')
 
 test('Top-level errors', async t => {
   await runFixture(t, 'top')
@@ -23,13 +21,7 @@ test('Node module partial fields', async t => {
 })
 
 test('No repository root', async t => {
-  const cwd = await createRepoDir({ git: false })
-  try {
-    await cpy(`${FIXTURES_DIR}/no_root/*`, cwd)
-    await runFixture(t, 'no_root', { repositoryRoot: cwd })
-  } finally {
-    await removeDir(cwd)
-  }
+  await runFixture(t, 'no_root', { copyRoot: { git: false } })
 })
 
 test('Process warnings', async t => {

--- a/packages/build/tests/plugins/env/tests.js
+++ b/packages/build/tests/plugins/env/tests.js
@@ -2,10 +2,8 @@ const { platform } = require('process')
 
 const test = require('ava')
 const isCI = require('is-ci')
-const cpy = require('cpy')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
-const { createRepoDir, removeDir } = require('../../helpers/dir')
+const { runFixture } = require('../../helpers/main')
 const { startServer } = require('../../helpers/server')
 
 // Windows environment variables work differently
@@ -59,13 +57,7 @@ test('Environment variable git with --branch', async t => {
 })
 
 test('Environment variable git no repository', async t => {
-  const cwd = await createRepoDir({ git: false })
-  try {
-    await cpy(`${FIXTURES_DIR}/git/*`, cwd)
-    await runFixture(t, 'git', { repositoryRoot: cwd })
-  } finally {
-    await removeDir(cwd)
-  }
+  await runFixture(t, 'git', { copyRoot: { git: false } })
 })
 
 const SITE_INFO_PATH = '/api/v1/sites/test'

--- a/packages/build/tests/plugins/install/tests.js
+++ b/packages/build/tests/plugins/install/tests.js
@@ -1,9 +1,8 @@
 const test = require('ava')
-const cpy = require('cpy')
 const pathExists = require('path-exists')
 
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
-const { createRepoDir, removeDir } = require('../../helpers/dir')
+const { removeDir } = require('../../helpers/dir')
 
 test('Install local plugin dependencies: with npm', async t => {
   await removeDir(`${FIXTURES_DIR}/npm/plugin/node_modules`)
@@ -32,11 +31,5 @@ test('Install local plugin dependencies: no package.json', async t => {
 })
 
 test('Install local plugin dependencies: no root package.json', async t => {
-  const tmpDir = await createRepoDir()
-  try {
-    await cpy('**', tmpDir, { cwd: `${FIXTURES_DIR}/no_root_package`, parents: true })
-    await runFixture(t, 'no_root_package', { repositoryRoot: tmpDir })
-  } finally {
-    await removeDir(tmpDir)
-  }
+  await runFixture(t, 'no_root_package', { copyRoot: {} })
 })

--- a/packages/build/tests/plugins/load/tests.js
+++ b/packages/build/tests/plugins/load/tests.js
@@ -1,8 +1,7 @@
 const test = require('ava')
-const cpy = require('cpy')
 
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
-const { createRepoDir, removeDir } = require('../../helpers/dir')
+const { removeDir } = require('../../helpers/dir')
 
 test('Local plugins', async t => {
   await runFixture(t, 'local')
@@ -22,13 +21,7 @@ test('Non-existing plugins', async t => {
 
 test('Install missing plugins', async t => {
   await removeDir(`${FIXTURES_DIR}/install_missing/node_modules`)
-  const tmpDir = await createRepoDir()
-  try {
-    await cpy('**', tmpDir, { cwd: `${FIXTURES_DIR}/install_missing`, parents: true })
-    await runFixture(t, 'install_missing', { repositoryRoot: tmpDir })
-  } finally {
-    await removeDir(tmpDir)
-  }
+  await runFixture(t, 'install_missing', { copyRoot: {} })
 })
 
 test('Already installed plugins', async t => {

--- a/packages/build/tests/utils/git/tests.js
+++ b/packages/build/tests/utils/git/tests.js
@@ -1,8 +1,6 @@
 const test = require('ava')
-const cpy = require('cpy')
 
-const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
-const { createRepoDir, removeDir } = require('../../helpers/dir')
+const { runFixture } = require('../../helpers/main')
 
 // Runs the git utils against very old commits of @netlify/build so that the
 // tests are stable
@@ -13,13 +11,7 @@ test('git-utils defined', async t => {
 })
 
 test('git-utils cwd', async t => {
-  const tmpDir = await createRepoDir()
-  try {
-    await cpy('**', tmpDir, { cwd: `${FIXTURES_DIR}/defined`, parents: true })
-    await runFixture(t, 'defined', { repositoryRoot: tmpDir })
-  } finally {
-    await removeDir(tmpDir)
-  }
+  await runFixture(t, 'defined', { copyRoot: {} })
 })
 
 test('git-utils linesOfCode', async t => {

--- a/packages/config/tests/context/tests.js
+++ b/packages/config/tests/context/tests.js
@@ -1,8 +1,6 @@
 const test = require('ava')
-const cpy = require('cpy')
-const execa = require('execa')
 
-const { runFixtureConfig, FIXTURES_DIR, createRepoDir, removeDir } = require('../helpers/main')
+const { runFixtureConfig } = require('../helpers/main')
 
 test('Context with context CLI flag', async t => {
   await runFixtureConfig(t, 'context_flag', { flags: '--context=testContext' })
@@ -25,24 +23,11 @@ test('Context with branch environment variable', async t => {
 })
 
 test('Context with branch git', async t => {
-  const cwd = await createRepoDir()
-  try {
-    await cpy(`${FIXTURES_DIR}/branch/*`, cwd)
-    await execa.command('git checkout -b testBranch', { cwd })
-    await runFixtureConfig(t, 'branch', { repositoryRoot: cwd, env: { BRANCH: '' } })
-  } finally {
-    await removeDir(cwd)
-  }
+  await runFixtureConfig(t, 'branch', { copyRoot: { branch: 'testBranch' }, env: { BRANCH: '' } })
 })
 
 test('Context with branch fallback', async t => {
-  const cwd = await createRepoDir({ git: false })
-  try {
-    await cpy(`${FIXTURES_DIR}/branch_fallback/*`, cwd)
-    await runFixtureConfig(t, 'branch_fallback', { repositoryRoot: cwd, env: { BRANCH: '' } })
-  } finally {
-    await removeDir(cwd)
-  }
+  await runFixtureConfig(t, 'branch_fallback', { copyRoot: { git: false }, env: { BRANCH: '' } })
 })
 
 test('Context deep merge', async t => {

--- a/packages/config/tests/cwd/tests.js
+++ b/packages/config/tests/cwd/tests.js
@@ -2,9 +2,8 @@ const { cwd } = require('process')
 const { relative } = require('path')
 
 const test = require('ava')
-const cpy = require('cpy')
 
-const { runFixtureConfig, FIXTURES_DIR, createRepoDir, removeDir } = require('../helpers/main')
+const { runFixtureConfig, FIXTURES_DIR } = require('../helpers/main')
 
 test('--cwd with no config', async t => {
   await runFixtureConfig(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty` })
@@ -25,13 +24,7 @@ test('--repository-root', async t => {
 })
 
 test('No .git', async t => {
-  const cwd = await createRepoDir({ git: false })
-  try {
-    await cpy(`${FIXTURES_DIR}/empty/*`, cwd)
-    await runFixtureConfig(t, '', { flags: `--cwd=${cwd}` })
-  } finally {
-    await removeDir(cwd)
-  }
+  await runFixtureConfig(t, 'empty', { copyRoot: {}, flags: '--cwd=.' })
 })
 
 test('--cwd non-existing', async t => {

--- a/packages/config/tests/helpers/main.js
+++ b/packages/config/tests/helpers/main.js
@@ -1,6 +1,6 @@
 // Tests require the full monorepo to be present at the moment
 // TODO: split tests utility into its own package
 const { runFixtureConfig, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../../../build/tests/helpers/main')
-const { createRepoDir, removeDir } = require('../../../build/tests/helpers/dir')
+const { removeDir } = require('../../../build/tests/helpers/dir')
 
-module.exports = { runFixtureConfig, FIXTURES_DIR, createRepoDir, removeDir, getJsonOpt, escapeExecaOpt }
+module.exports = { runFixtureConfig, FIXTURES_DIR, removeDir, getJsonOpt, escapeExecaOpt }

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -4,14 +4,7 @@ const { relative } = require('path')
 const test = require('ava')
 
 const resolveConfig = require('../..')
-const {
-  runFixtureConfig,
-  FIXTURES_DIR,
-  createRepoDir,
-  removeDir,
-  getJsonOpt,
-  escapeExecaOpt,
-} = require('../helpers/main')
+const { runFixtureConfig, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../helpers/main')
 
 test('Empty configuration', async t => {
   await runFixtureConfig(t, 'empty')
@@ -28,12 +21,7 @@ test('Can define configuration as environment variables', async t => {
 })
 
 test('No --config but none found', async t => {
-  const cwd = await createRepoDir()
-  try {
-    await runFixtureConfig(t, '', { cwd })
-  } finally {
-    await removeDir(cwd)
-  }
+  await runFixtureConfig(t, 'none', { copyRoot: {} })
 })
 
 test('Several configuration files', async t => {


### PR DESCRIPTION
Many tests are testing builds that are either:
  - not inside a git repository
  - not inside a Node.js directory (with a `package.json`)

However `@netlify/build` itself is both. Those tests must then copy the test fixture to a temporary directory and use that instead. 

Since this is a common pattern and is quite verbose, this PR adds a test helper to be able to perform this operation. This is used through the `copyRoot` option.

```js
test('No repository root', async t => {
  await runFixture(t, 'no_root', { copyRoot: {} })
})
```

The `copyRoot` option is an object has two additional parameters:
  - `git` `{boolean}` (default: `true`): whether the test fixture should be inside a git repository
  - `branch` `{string}`: create a new git branch and switch to it

This PR only adds this test helper, simplifying some tests along the way. This does not change behavior nor test logic.