### PR TITLE
Upgrade Prettier to v2

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "printWidth": 120,
   "endOfLine": "lf",
   "proseWrap": "always",
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "arrowParens": "avoid"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ This is a monorepo. Below are a list of packages included.
   commit [npm link](https://www.npmjs.com/package/@netlify/git-utils).
 - [@netlify/run-utils](./packages/run-utils) Utility for running commands inside Netlify Build
   [npm link](https://www.npmjs.com/package/@netlify/run-utils).
-  <!-- AUTO-GENERATED-CONTENT:END (PACKAGES) -->
+
+<!-- AUTO-GENERATED-CONTENT:END (PACKAGES) -->
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4595,9 +4595,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -9608,9 +9608,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "^10.0.3",
     "dox": "^0.9.0",
     "eslint": "6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "2.20.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
@@ -43,7 +43,7 @@
     "markdown-magic": "^1.0.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.1"
   },
   "dependencies": {},
   "engines": {

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -419,193 +419,16 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
-      }
-    },
-    "@netlify/cache-utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.2.2.tgz",
-      "integrity": "sha512-wZMn77Xiao895lju6fLhH9z/ocnRV79rU8z1GqmnfFDPa1o7CKV3xGLQKkMDvUopHGJRMM3Op9sIP7aWSUmqdg==",
-      "requires": {
-        "cpy": "^8.0.0",
-        "del": "^5.1.0",
-        "get-stream": "^5.1.0",
-        "global-cache-dir": "^1.0.1",
-        "junk": "^3.1.0",
-        "move-file": "^1.2.0",
-        "p-map": "^3.0.0",
-        "path-exists": "^4.0.0",
-        "readdirp": "^3.3.0"
-      }
-    },
-    "@netlify/config": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.4.8.tgz",
-      "integrity": "sha512-Hev0CcDJP37c0a1xue48u4tBiJhrM7Q9KKJm5OsFYxp5UnMM427NRs0gw5k+tfin3/FzOI677kkQ67Op5s1NaA==",
-      "requires": {
-        "array-flat-polyfill": "^1.0.1",
-        "chalk": "^3.0.0",
-        "deepmerge": "^4.2.2",
-        "dot-prop": "^5.2.0",
-        "execa": "^3.4.0",
-        "filter-obj": "^2.0.1",
-        "find-up": "^4.1.0",
-        "indent-string": "^4.0.0",
-        "is-plain-obj": "^2.1.0",
-        "js-yaml": "^3.13.1",
-        "map-obj": "^4.1.0",
-        "omit.js": "^1.0.2",
-        "p-filter": "^2.1.0",
-        "path-exists": "^4.0.0",
-        "toml": "^3.0.0",
-        "yargs": "^15.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "yargs": {
-          "version": "15.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-          "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
-    "@netlify/functions-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.1.tgz",
-      "integrity": "sha512-uLNCkMZoOEMEqU24E9DKHE5JeFMqP7LJHjgcFPv9vyG57BIEuiePDeuvhUDl++79ViSmVs/dbQThlr7Jerebsw==",
-      "requires": {
-        "cpy": "^8.0.0",
-        "path-exists": "^4.0.0"
-      }
-    },
-    "@netlify/git-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-0.2.0.tgz",
-      "integrity": "sha512-hdLPGAbSS1wtk/hUs0ed1Udr/l1itb9788yPV2MVwSwhMZ/M1DEKOJRVNSUORPrbkQtkltIzNITPaQV9PeTnQQ==",
-      "requires": {
-        "execa": "^3.4.0",
-        "map-obj": "^4.1.0",
-        "micromatch": "^4.0.2",
-        "moize": "^5.4.5"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "@netlify/open-api": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.2.tgz",
       "integrity": "sha512-OcA/IdyDv1JF4tsrb7sNu77otewa1G0mzBOcFOi9IL0CwAyGxQWolDptILFyrVQIbHban2b6l4LPFvdnVaF6bA=="
-    },
-    "@netlify/run-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-0.1.0.tgz",
-      "integrity": "sha512-Rv37jYppU6rzdv1EpMvTJ0EhAT+2fYV9MaxbbQQlObslwlRlVr5+bjhXsoIzqflobRcoh6mxwKGWITXl8C7CfA==",
-      "requires": {
-        "execa": "^3.4.0"
-      }
     },
     "@netlify/zip-it-and-ship-it": {
       "version": "0.4.0-9",
@@ -714,6 +537,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
       "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
@@ -722,19 +546,22 @@
         "@nodelib/fs.stat": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
         }
       }
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
       "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
@@ -761,12 +588,14 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -798,12 +627,14 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/node": {
       "version": "12.12.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
-      "integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA=="
+      "integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -984,17 +815,20 @@
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -1011,6 +845,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
       "requires": {
         "array-uniq": "^1.0.1"
       }
@@ -1018,12 +853,14 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -1034,7 +871,8 @@
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
     },
     "ast-module-types": {
       "version": "2.6.0",
@@ -1058,7 +896,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "ava": {
       "version": "2.4.0",
@@ -1510,6 +1349,7 @@
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -1524,6 +1364,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -1532,6 +1373,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1540,6 +1382,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1548,6 +1391,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1664,6 +1508,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
       "requires": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -1681,6 +1526,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -1711,6 +1557,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -1772,7 +1619,8 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "call-signature": {
       "version": "0.0.2",
@@ -1946,6 +1794,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -1957,6 +1806,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -2084,6 +1934,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -2115,7 +1966,8 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
     },
     "component-props": {
       "version": "1.1.1",
@@ -2265,7 +2117,8 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "core-js": {
       "version": "3.5.0",
@@ -2293,6 +2146,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.0.0.tgz",
       "integrity": "sha512-iTjLUqtVr45e17GFAyxA0lqFinbGMblMCTtAqrPzT/IETNtDuyyhDDk8weEZ08MiCc6EcuyNq2KtGH5J2BIAoQ==",
+      "dev": true,
       "requires": {
         "arrify": "^2.0.1",
         "cp-file": "^7.0.0",
@@ -2306,12 +2160,14 @@
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
         },
         "cp-file": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-7.0.0.tgz",
           "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "make-dir": "^3.0.0",
@@ -2410,7 +2266,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -2445,11 +2302,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -2476,6 +2328,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -2485,6 +2338,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2493,6 +2347,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2501,6 +2356,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -2513,6 +2369,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
       "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "dev": true,
       "requires": {
         "globby": "^10.0.1",
         "graceful-fs": "^4.2.2",
@@ -2527,12 +2384,14 @@
         "array-union": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
         },
         "dir-glob": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
           "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
           "requires": {
             "path-type": "^4.0.0"
           }
@@ -2541,6 +2400,7 @@
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
           "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
           "requires": {
             "@types/glob": "^7.1.1",
             "array-union": "^2.1.0",
@@ -2555,17 +2415,20 @@
         "ignore": {
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
         },
         "path-type": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
         },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
         }
       }
     },
@@ -2658,6 +2521,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
       "requires": {
         "path-type": "^3.0.0"
       }
@@ -2666,6 +2530,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
       "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+      "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
       }
@@ -2883,6 +2748,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -2897,6 +2763,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2905,6 +2772,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -2913,6 +2781,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2920,7 +2789,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2928,6 +2798,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -2937,6 +2808,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -2947,6 +2819,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -2962,6 +2835,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -2970,6 +2844,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2978,6 +2853,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2986,6 +2862,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2994,6 +2871,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -3017,6 +2895,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
       "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3028,12 +2907,14 @@
         "@nodelib/fs.stat": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
         },
         "braces": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
           }
@@ -3042,6 +2923,7 @@
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
           }
@@ -3050,6 +2932,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
           "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -3057,12 +2940,14 @@
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
         },
         "micromatch": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
@@ -3072,6 +2957,7 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
           "requires": {
             "is-number": "^7.0.0"
           }
@@ -3092,6 +2978,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
       "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
       "requires": {
         "reusify": "^1.0.0"
       }
@@ -3108,6 +2995,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -3119,6 +3007,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -3164,12 +3053,14 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -3327,7 +3218,8 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -3346,6 +3238,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
       "requires": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -3355,6 +3248,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -3364,7 +3258,8 @@
     "glob-to-regexp": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
     },
     "global-cache-dir": {
       "version": "1.0.1",
@@ -3395,6 +3290,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
       "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+      "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
         "array-union": "^1.0.2",
@@ -3410,6 +3306,7 @@
           "version": "2.2.7",
           "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
           "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
           "requires": {
             "@mrmlnc/readdir-enhanced": "^2.2.1",
             "@nodelib/fs.stat": "^1.1.2",
@@ -3501,6 +3398,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -3511,6 +3409,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -3520,6 +3419,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3570,7 +3470,8 @@
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -3648,6 +3549,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -3656,6 +3558,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3685,7 +3588,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.5",
@@ -3704,6 +3608,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -3712,6 +3617,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3727,6 +3633,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -3736,7 +3643,8 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
         }
       }
     },
@@ -3749,7 +3657,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -3800,6 +3709,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -3808,6 +3718,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3817,7 +3728,8 @@
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
     },
     "is-observable": {
       "version": "2.0.0",
@@ -3828,7 +3740,8 @@
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
@@ -3853,7 +3766,8 @@
     "is-path-inside": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -3864,6 +3778,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -3916,7 +3831,8 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -3937,7 +3853,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "jest-get-type": {
       "version": "24.9.0",
@@ -4046,7 +3963,8 @@
     "junk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
-      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ=="
+      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+      "dev": true
     },
     "keyv": {
       "version": "3.1.0",
@@ -4059,7 +3977,8 @@
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "latest-version": {
       "version": "5.1.0",
@@ -4337,7 +4256,8 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
     },
     "map-obj": {
       "version": "4.1.0",
@@ -4348,6 +4268,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -4495,7 +4416,8 @@
     "merge2": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
     },
     "micro-api-client": {
       "version": "3.3.0",
@@ -4511,6 +4433,7 @@
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -4572,6 +4495,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -4581,6 +4505,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -4623,51 +4548,6 @@
         "micro-memoize": "^2.1.1"
       }
     },
-    "move-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/move-file/-/move-file-1.2.0.tgz",
-      "integrity": "sha512-USHrRmxzGowUWAGBbJPdFjHzEqtxDU03pLHY0Rfqgtnq+q8FOIs8wvkkf+Udmg77SJKs47y9sI0jJvQeYsmiCA==",
-      "requires": {
-        "cp-file": "^6.1.0",
-        "make-dir": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "dependencies": {
-        "cp-file": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-          "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^2.0.0",
-            "nested-error-stacks": "^2.0.0",
-            "pify": "^4.0.1",
-            "safe-buffer": "^5.0.1"
-          },
-          "dependencies": {
-            "make-dir": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-              "requires": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
-              }
-            }
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4677,6 +4557,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -4904,6 +4785,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -4914,6 +4796,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -4922,6 +4805,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4948,6 +4832,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.0"
       }
@@ -4976,6 +4861,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -5439,12 +5325,14 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
@@ -5495,7 +5383,8 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -5597,7 +5486,8 @@
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "postcss": {
       "version": "7.0.24",
@@ -5895,6 +5785,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -5977,12 +5868,14 @@
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "replacestream": {
       "version": "4.0.3",
@@ -6057,7 +5950,8 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
     },
     "responselike": {
       "version": "1.0.2",
@@ -6080,17 +5974,20 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
       "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -6098,7 +5995,8 @@
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -6109,6 +6007,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -6150,6 +6049,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -6161,6 +6061,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -6188,7 +6089,8 @@
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "3.0.0",
@@ -6238,6 +6140,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -6253,6 +6156,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6261,6 +6165,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -6269,6 +6174,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -6276,12 +6182,14 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -6289,6 +6197,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -6299,6 +6208,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -6307,6 +6217,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -6315,6 +6226,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -6323,6 +6235,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -6335,6 +6248,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
       },
@@ -6343,6 +6257,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6358,6 +6273,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -6379,7 +6295,8 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -6413,6 +6330,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -6432,6 +6350,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -6441,6 +6360,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -6776,6 +6696,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -6784,6 +6705,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6799,6 +6721,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -6810,15 +6733,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
-    },
-    "toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "trim-newlines": {
       "version": "2.0.0",
@@ -6916,6 +6835,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -6951,6 +6871,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -6960,6 +6881,7 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -6970,6 +6892,7 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -6979,7 +6902,8 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
         }
       }
     },
@@ -7028,7 +6952,8 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -7041,7 +6966,8 @@
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/build/src/core/api.js
+++ b/packages/build/src/core/api.js
@@ -9,7 +9,7 @@ const { addErrorInfo } = require('../error/info')
 const { removeFalsy } = require('../utils/remove_falsy')
 
 // Retrieve Netlify API client, if an access token was passed
-const getApiClient = function(token) {
+const getApiClient = function (token) {
   if (token === undefined) {
     return
   }
@@ -21,11 +21,11 @@ const getApiClient = function(token) {
   return apiA
 }
 
-const addErrorHandlers = function(api) {
+const addErrorHandlers = function (api) {
   return mapObj(api, addErrorHandler)
 }
 
-const addErrorHandler = function(key, value) {
+const addErrorHandler = function (key, value) {
   if (typeof value !== 'function') {
     return [key, value]
   }
@@ -34,7 +34,7 @@ const addErrorHandler = function(key, value) {
   return [key, valueA]
 }
 
-const apiMethodHandler = async function(endpoint, method, parameters, ...args) {
+const apiMethodHandler = async function (endpoint, method, parameters, ...args) {
   try {
     return await method(parameters, ...args)
   } catch (error) {

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -14,7 +14,7 @@ const build = require('./main')
 const pSetTimeout = promisify(setTimeout)
 
 // CLI entry point
-const runCli = async function() {
+const runCli = async function () {
   const flags = parseFlags()
   const { features, ...flagsA } = filterObj(flags, isUserFlag)
 
@@ -36,11 +36,8 @@ const runCli = async function() {
   exit(exitCode)
 }
 
-const parseFlags = function() {
-  return yargs
-    .options(FLAGS)
-    .usage(USAGE)
-    .parse()
+const parseFlags = function () {
+  return yargs.options(FLAGS).usage(USAGE).parse()
 }
 
 const FLAGS = {
@@ -128,13 +125,13 @@ NETLIFY_BUILD_. For example the environment variable NETLIFY_BUILD_DRY=true can
 be used instead of the CLI flag --dry.`
 
 // Remove `yargs`-specific options, shortcuts, dash-cased and aliases
-const isUserFlag = function(key, value) {
+const isUserFlag = function (key, value) {
   return value !== undefined && !INTERNAL_KEYS.includes(key) && key.length !== 1 && !key.includes('-')
 }
 
 const INTERNAL_KEYS = ['help', 'version', '_', '$0', 'dryRun']
 
-const printFeatures = function() {
+const printFeatures = function () {
   console.log(['', ...FEATURES, ''].join(FEATURES_DELIMITER))
   exit(0)
 }

--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -9,7 +9,7 @@ const { startOutput, stopOutput } = require('../log/stream')
 const { addErrorInfo, getErrorInfo } = require('../error/info')
 
 // Get commands for all events
-const getCommands = function({ pluginsCommands, netlifyConfig }) {
+const getCommands = function ({ pluginsCommands, netlifyConfig }) {
   const commands = EVENTS.flatMap(event => getEventCommands({ event, pluginsCommands, netlifyConfig }))
 
   const buildCommands = commands.filter(command => !isEndCommand(command) && !isErrorCommand(command))
@@ -22,7 +22,7 @@ const getCommands = function({ pluginsCommands, netlifyConfig }) {
 }
 
 // Get commands for a specific event
-const getEventCommands = function({
+const getEventCommands = function ({
   event,
   pluginsCommands: { [event]: pluginCommands = [] },
   netlifyConfig: {
@@ -39,18 +39,18 @@ const getEventCommands = function({
   return [shellCommandA, ...pluginCommands]
 }
 
-const isEndCommand = function({ event }) {
+const isEndCommand = function ({ event }) {
   return event === 'onEnd'
 }
 
-const isErrorCommand = function({ event }) {
+const isErrorCommand = function ({ event }) {
   return event === 'onError'
 }
 
 // Run all commands.
 // If an error arises, runs `onError` events.
 // Runs `onEnd` events at the end, whether an error was thrown or not.
-const runCommands = async function({
+const runCommands = async function ({
   buildCommands,
   endCommands,
   errorCommands,
@@ -81,7 +81,7 @@ const runCommands = async function({
 // of the same name keep running. However the failure is still eventually
 // thrown. This allows users to be notified of issues inside their `onError` or
 // `onEnd` events.
-const execCommands = async function(commands, { configPath, buildDir, state, nodePath, childEnv, failFast, error }) {
+const execCommands = async function (commands, { configPath, buildDir, state, nodePath, childEnv, failFast, error }) {
   const { failure } = await pReduce(
     commands,
     ({ failure, failedPlugins }, command) =>
@@ -95,7 +95,7 @@ const execCommands = async function(commands, { configPath, buildDir, state, nod
 }
 
 // Run a command (shell or plugin)
-const runCommand = async function(
+const runCommand = async function (
   command,
   { configPath, buildDir, state, nodePath, childEnv, error, failure, failedPlugins, failFast },
 ) {
@@ -125,7 +125,7 @@ const runCommand = async function(
   }
 }
 
-const fireCommand = function(command, { buildDir, nodePath, childEnv, error }) {
+const fireCommand = function (command, { buildDir, nodePath, childEnv, error }) {
   if (command.shellCommand !== undefined) {
     return fireShellCommand(command, { buildDir, nodePath, childEnv })
   }
@@ -134,7 +134,7 @@ const fireCommand = function(command, { buildDir, nodePath, childEnv, error }) {
 }
 
 // Fire a `config.lifecycle.*` shell command
-const fireShellCommand = async function({ prop, shellCommand }, { buildDir, nodePath, childEnv }) {
+const fireShellCommand = async function ({ prop, shellCommand }, { buildDir, nodePath, childEnv }) {
   logShellCommandStart(shellCommand)
 
   const childProcess = execa(shellCommand, {
@@ -158,7 +158,7 @@ const fireShellCommand = async function({ prop, shellCommand }, { buildDir, node
 }
 
 // Fire a plugin command
-const firePluginCommand = async function({ childProcess, event, package, packageJson, local }, { error }) {
+const firePluginCommand = async function ({ childProcess, event, package, packageJson, local }, { error }) {
   const outputState = startOutput(childProcess)
 
   try {
@@ -177,7 +177,7 @@ const firePluginCommand = async function({ childProcess, event, package, package
 //    handlers of the same type have been triggered before propagating
 //  - if `utils.build.failPlugin()` was used, print an error and skip next event
 //    handlers of that plugin. But do not stop build.
-const handleCommandError = function({ newFailure, failedPlugins, failure, failFast }) {
+const handleCommandError = function ({ newFailure, failedPlugins, failure, failFast }) {
   const { type, location: { package } = {} } = getErrorInfo(newFailure)
 
   if (type === 'failPlugin') {

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -14,7 +14,7 @@ const { getSiteInfo } = require('./site_info')
 const { getConstants } = require('./constants')
 
 // Retrieve configuration object
-const loadConfig = async function(flags) {
+const loadConfig = async function (flags) {
   const flagsA = removeFalsy(flags)
   logFlags(flagsA)
 
@@ -75,7 +75,7 @@ const DEFAULT_FLAGS = {
 
 // Retrieve configuration file and related information
 // (path, build directory, etc.)
-const resolveFullConfig = async function({
+const resolveFullConfig = async function ({
   config,
   defaultConfig,
   cachedConfig,

--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -10,7 +10,7 @@ const { getCacheDir } = require('@netlify/cache-utils')
 const isNetlifyCI = require('../utils/is-netlify-ci')
 
 // Retrieve constants passed to plugins
-const getConstants = async function({
+const getConstants = async function ({
   configPath,
   buildDir,
   netlifyConfig: {
@@ -59,7 +59,7 @@ const getConstants = async function({
 }
 
 const LOCAL_FUNCTIONS_DIST = '.netlify/functions/'
-const getFunctionsDist = function(isLocal) {
+const getFunctionsDist = function (isLocal) {
   if (isLocal) {
     return LOCAL_FUNCTIONS_DIST
   }
@@ -70,7 +70,7 @@ const getFunctionsDist = function(isLocal) {
 // The current directory is `buildDir`. Most constants are inside this `buildDir`.
 // Instead of passing absolute paths, we pass paths relative to `buildDir`, so
 // that logs are less verbose.
-const normalizePath = function(path, buildDir, key) {
+const normalizePath = function (path, buildDir, key) {
   if (path === undefined || NOT_PATHS.includes(key)) {
     return path
   }

--- a/packages/build/src/core/dry.js
+++ b/packages/build/src/core/dry.js
@@ -1,7 +1,7 @@
 const { logDryRunStart, logDryRunCommand, logDryRunEnd } = require('../log/main')
 
 // If the `dry` flag is specified, do a dry run
-const doDryRun = function({ mainCommands, commandsCount, configPath }) {
+const doDryRun = function ({ mainCommands, commandsCount, configPath }) {
   const eventWidth = Math.max(...mainCommands.map(getEventLength))
 
   logDryRunStart(eventWidth, commandsCount)
@@ -13,7 +13,7 @@ const doDryRun = function({ mainCommands, commandsCount, configPath }) {
   logDryRunEnd()
 }
 
-const getEventLength = function({ event }) {
+const getEventLength = function ({ event }) {
   return event.length
 }
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -31,7 +31,7 @@ const { doDryRun } = require('./dry')
  * @param  {string} [flags.context] - Build context
  * @param  {boolean} [flags.dry] - printing commands without executing them
  */
-const build = async function(flags) {
+const build = async function (flags) {
   try {
     const buildTimer = startTimer()
 
@@ -88,7 +88,7 @@ const build = async function(flags) {
   }
 }
 
-const buildRun = async function({
+const buildRun = async function ({
   pluginsOptions,
   netlifyConfig,
   configPath,
@@ -124,7 +124,7 @@ const buildRun = async function({
   }
 }
 
-const executeCommands = async function({
+const executeCommands = async function ({
   pluginsOptions,
   childProcesses,
   netlifyConfig,

--- a/packages/build/src/core/site_info.js
+++ b/packages/build/src/core/site_info.js
@@ -2,7 +2,7 @@ const isNetlifyCI = require('../utils/is-netlify-ci')
 
 // Retrieve Netlify Site information, if availabled.
 // This is only used for local builds environment variables at the moment.
-const getSiteInfo = async function(api, siteId) {
+const getSiteInfo = async function (api, siteId) {
   if (api === undefined || siteId === undefined || isNetlifyCI()) {
     return { id: siteId }
   }
@@ -11,7 +11,7 @@ const getSiteInfo = async function(api, siteId) {
   return { ...siteInfo, id: siteId }
 }
 
-const getSite = async function(siteId, api) {
+const getSite = async function (siteId, api) {
   try {
     return await api.getSite({ site_id: siteId })
     // Silently ignore errors. For example the network connection might be down,

--- a/packages/build/src/error/build.js
+++ b/packages/build/src/error/build.js
@@ -2,7 +2,7 @@ const { addErrorInfo } = require('./info')
 
 // Retrieve error information from child process and re-build it in current
 // process. We need this since errors are not JSON-serializable.
-const buildError = function({ type, name, message, stack, ...errorProps }) {
+const buildError = function ({ type, name, message, stack, ...errorProps }) {
   const error = new Error('')
 
   assignErrorProps(error, { name, message, stack })
@@ -17,7 +17,7 @@ const buildError = function({ type, name, message, stack, ...errorProps }) {
 }
 
 // Make sure `name`, `message` and `stack` are not enumerable
-const assignErrorProps = function(error, values) {
+const assignErrorProps = function (error, values) {
   ERROR_PROPS.forEach(name => {
     assignErrorProp(error, name, values[name])
   })
@@ -25,7 +25,7 @@ const assignErrorProps = function(error, values) {
 
 const ERROR_PROPS = ['name', 'message', 'stack']
 
-const assignErrorProp = function(error, name, value) {
+const assignErrorProp = function (error, name, value) {
   Object.defineProperty(error, name, { value, enumerable: false, writable: true, configurable: true })
 }
 

--- a/packages/build/src/error/clean_stack.js
+++ b/packages/build/src/error/clean_stack.js
@@ -11,19 +11,16 @@ const stripAnsi = require('strip-ansi')
 // Keep non stack trace lines as is.
 // We do not use libraries that patch `Error.prepareStackTrace()` because they
 // tend to create issues.
-const cleanStacks = function(string, rawStack) {
+const cleanStacks = function (string, rawStack) {
   // Internal errors / bugs keep their full stack trace
   if (rawStack || string === undefined) {
     return string
   }
 
-  return String(string)
-    .split('\n')
-    .reduce(cleanStackLine, '')
-    .replace(INITIAL_NEWLINES, '')
+  return String(string).split('\n').reduce(cleanStackLine, '').replace(INITIAL_NEWLINES, '')
 }
 
-const cleanStackLine = function(lines, line) {
+const cleanStackLine = function (lines, line) {
   const lineA = line.replace(cwd(), '')
   const lineB = stripAnsi(lineA)
 
@@ -51,7 +48,7 @@ const cleanStackLine = function(lines, line) {
 // Check if a line is part of a stack trace
 const STACK_LINE_REGEXP = /^\s+at /
 
-const isUselessStack = function(line) {
+const isUselessStack = function (line) {
   const lineA = line.replace(BACKLASH_REGEXP, '/')
   return (
     // Anonymous function
@@ -64,7 +61,7 @@ const isUselessStack = function(line) {
 
 const BACKLASH_REGEXP = /\\/g
 
-const isInternalStack = function(line) {
+const isInternalStack = function (line) {
   // This is only needed for local builds
   return INTERNAL_STACK_REGEXP.test(line)
 }

--- a/packages/build/src/error/handle.js
+++ b/packages/build/src/error/handle.js
@@ -6,13 +6,13 @@ const { getTypeInfo } = require('./type')
 
 // Handle top-level build errors.
 // Logging is done separately.
-const handleBuildError = async function(error, api) {
+const handleBuildError = async function (error, api) {
   const { shouldCancel } = getTypeInfo(error)
   await cancelBuild(shouldCancel, api)
 }
 
 // Cancel builds, for example when a plugin uses `utils.build.cancelBuild()`
-const cancelBuild = async function(shouldCancel, api) {
+const cancelBuild = async function (shouldCancel, api) {
   if (!shouldCancel || api === undefined || !DEPLOY_ID) {
     return
   }

--- a/packages/build/src/error/info.js
+++ b/packages/build/src/error/info.js
@@ -1,9 +1,9 @@
 // Add information related to an error without colliding with existing properties
-const addErrorInfo = function(error, info) {
+const addErrorInfo = function (error, info) {
   error[INFO_SYM] = { ...error[INFO_SYM], ...info }
 }
 
-const getErrorInfo = function(error) {
+const getErrorInfo = function (error) {
   return error[INFO_SYM] || {}
 }
 

--- a/packages/build/src/error/location.js
+++ b/packages/build/src/error/location.js
@@ -2,7 +2,7 @@ const { white } = require('chalk')
 
 // Retrieve an error's location to print in logs.
 // Each error type has its own logic (or none if there's no location to print).
-const getLocationBlock = function({ stack, location, getLocation }) {
+const getLocationBlock = function ({ stack, location, getLocation }) {
   // No location to print
   if (getLocation === undefined && stack === undefined) {
     return
@@ -12,7 +12,7 @@ const getLocationBlock = function({ stack, location, getLocation }) {
   return { name: 'Error location', value: locationString }
 }
 
-const serializeLocation = function({ stack, location, getLocation }) {
+const serializeLocation = function ({ stack, location, getLocation }) {
   // The location is only the stack trace
   if (getLocation === undefined) {
     return stack
@@ -22,18 +22,18 @@ const serializeLocation = function({ stack, location, getLocation }) {
   return [locationString, stack].filter(Boolean).join('\n')
 }
 
-const getShellCommandLocation = function({ prop, shellCommand }) {
+const getShellCommandLocation = function ({ prop, shellCommand }) {
   return `In configuration "${white.bold(prop)}" command:
 ${white.bold(shellCommand)}`
 }
 
-const getBuildFailLocation = function({ event, package, local }) {
+const getBuildFailLocation = function ({ event, package, local }) {
   const eventMessage = getEventMessage(event)
   const packageLocation = getPackageLocation(package, local)
   return `${eventMessage} ${packageLocation}`
 }
 
-const getEventMessage = function(event) {
+const getEventMessage = function (event) {
   if (event === 'load') {
     return `While ${white.bold('loading')}`
   }
@@ -41,12 +41,12 @@ const getEventMessage = function(event) {
   return `In "${white.bold(event)}" event in`
 }
 
-const getPackageLocation = function(package, local) {
+const getPackageLocation = function (package, local) {
   const localString = local ? 'local plugin' : 'npm package'
   return `${localString} "${white.bold(package)}"`
 }
 
-const getApiLocation = function({ endpoint, parameters }) {
+const getApiLocation = function ({ endpoint, parameters }) {
   return `While calling the Netlify API endpoint '${endpoint}' with:\n${JSON.stringify(parameters, null, 2)}`
 }
 

--- a/packages/build/src/error/plugin.js
+++ b/packages/build/src/error/plugin.js
@@ -1,6 +1,6 @@
 // Retrieve plugin's package.json details to include in error messages.
 // Please note `packageJson` has been normalized by `normalize-package-data`.
-const getPluginBlock = function({ packageJson = {} }, { package }) {
+const getPluginBlock = function ({ packageJson = {} }, { package }) {
   if (Object.keys(packageJson).length === 0) {
     return
   }
@@ -10,7 +10,7 @@ const getPluginBlock = function({ packageJson = {} }, { package }) {
 }
 
 // Iterate over a series of package.json fields, serialize each then join them
-const serializeFields = function(packageJson, package) {
+const serializeFields = function (packageJson, package) {
   return Object.entries(FIELDS)
     .map(([name, getField]) => serializeField({ name, getField, packageJson, package }))
     .filter(Boolean)
@@ -18,7 +18,7 @@ const serializeFields = function(packageJson, package) {
 }
 
 // Serialize a single package.json field
-const serializeField = function({ name, getField, packageJson, package }) {
+const serializeField = function ({ name, getField, packageJson, package }) {
   const field = getField(packageJson, package)
   if (field === undefined) {
     return
@@ -30,11 +30,11 @@ const serializeField = function({ name, getField, packageJson, package }) {
 
 const NAME_PADDING = 16
 
-const getPackage = function(packageJson, package) {
+const getPackage = function (packageJson, package) {
   return package
 }
 
-const getVersion = function({ version }) {
+const getVersion = function ({ version }) {
   if (version === '') {
     return
   }
@@ -42,11 +42,11 @@ const getVersion = function({ version }) {
   return version
 }
 
-const getRepository = function({ repository: { url } = {} }) {
+const getRepository = function ({ repository: { url } = {} }) {
   return url
 }
 
-const getNpmLink = function({ name }) {
+const getNpmLink = function ({ name }) {
   if (name === '') {
     return
   }
@@ -54,7 +54,7 @@ const getNpmLink = function({ name }) {
   return `https://www.npmjs.com/package/${name}`
 }
 
-const getIssuesLink = function({ bugs: { url } = {} }) {
+const getIssuesLink = function ({ bugs: { url } = {} }) {
   return url
 }
 

--- a/packages/build/src/error/serialize.js
+++ b/packages/build/src/error/serialize.js
@@ -13,7 +13,7 @@ const { getPluginBlock } = require('./plugin')
 const { getLocationBlock } = require('./location')
 
 // Serialize an error object into a header|body string to print in logs
-const serializeError = function({ message, stack, ...errorProps }) {
+const serializeError = function ({ message, stack, ...errorProps }) {
   const { header, color = redBright, ...typeInfo } = getTypeInfo(errorProps)
   const errorInfo = getErrorInfo(errorProps)
   const errorPropsA = cleanErrorProps(errorProps)
@@ -23,14 +23,14 @@ const serializeError = function({ message, stack, ...errorProps }) {
 }
 
 // Remove error static properties that should not be logged
-const cleanErrorProps = function(errorProps) {
+const cleanErrorProps = function (errorProps) {
   return omit(errorProps, CLEANED_ERROR_PROPS)
 }
 
 const CLEANED_ERROR_PROPS = [INFO_SYM, 'requireStack']
 
 // Retrieve header to print in logs
-const getHeader = function(header, errorInfo) {
+const getHeader = function (header, errorInfo) {
   if (typeof header !== 'function') {
     return header
   }
@@ -39,7 +39,7 @@ const getHeader = function(header, errorInfo) {
 }
 
 // Retrieve body to print in logs
-const getBody = function({
+const getBody = function ({
   typeInfo: { stackType, getLocation, showErrorProps, rawStack },
   color,
   message,
@@ -60,7 +60,7 @@ const getBody = function({
 }
 
 // In uncaught exceptions, print error static properties
-const getErrorPropsBlock = function(errorProps, showErrorProps) {
+const getErrorPropsBlock = function (errorProps, showErrorProps) {
   if (!showErrorProps || Object.keys(errorProps).length === 0) {
     return
   }
@@ -69,7 +69,7 @@ const getErrorPropsBlock = function(errorProps, showErrorProps) {
   return { name: 'Error properties', value }
 }
 
-const serializeBlock = function({ name, value, color }) {
+const serializeBlock = function ({ name, value, color }) {
   return `${color.bold(`${HEADING_PREFIX} ${name}`)}
 ${indent(value)}`
 }

--- a/packages/build/src/error/stack.js
+++ b/packages/build/src/error/stack.js
@@ -1,13 +1,13 @@
 const { cleanStacks } = require('./clean_stack')
 
 // Retrieve the stack trace
-const getStackInfo = function({ message, stack, stackType, rawStack }) {
+const getStackInfo = function ({ message, stack, stackType, rawStack }) {
   const { message: messageA, stack: stackA } = splitStackInfo({ message, stack, stackType })
   const stackB = cleanStacks(stackA, rawStack)
   return { message: messageA, stack: stackB }
 }
 
-const splitStackInfo = function({ message, stack, stackType }) {
+const splitStackInfo = function ({ message, stack, stackType }) {
   // Some errors should not show any stack trace
   if (stackType === 'none') {
     return { message }
@@ -22,7 +22,7 @@ const splitStackInfo = function({ message, stack, stackType }) {
   return splitStack(stack)
 }
 
-const splitStack = function(string) {
+const splitStack = function (string) {
   const lines = string.split('\n')
   const stackIndex = lines.findIndex(isStackTrace)
 
@@ -35,7 +35,7 @@ const splitStack = function(string) {
   return { message: messageA, stack: stackA }
 }
 
-const isStackTrace = function(line) {
+const isStackTrace = function (line) {
   return line.trim().startsWith('at ')
 }
 

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -4,7 +4,7 @@ const { getShellCommandLocation, getBuildFailLocation, getApiLocation } = requir
 const { getErrorInfo } = require('./info')
 
 // Retrieve error-type specific information
-const getTypeInfo = function(errorProps) {
+const getTypeInfo = function (errorProps) {
   const { type } = getErrorInfo(errorProps)
 
   if (TYPES[type] === undefined) {

--- a/packages/build/src/install/functions.js
+++ b/packages/build/src/install/functions.js
@@ -5,7 +5,7 @@ const readdirp = require('readdirp')
 const { installDependencies } = require('./main')
 
 // Install dependencies of Netlify Functions
-const installFunctionDependencies = async function(functionsSrc) {
+const installFunctionDependencies = async function (functionsSrc) {
   const packagePaths = await readdirp.promise(functionsSrc, { depth: 1, fileFilter: 'package.json' })
   if (packagePaths.length === 0) {
     return
@@ -16,7 +16,7 @@ const installFunctionDependencies = async function(functionsSrc) {
   await Promise.all(packageRoots.map(packageRoot => installDependencies({ packageRoot })))
 }
 
-const getPackageRoot = function({ fullPath }) {
+const getPackageRoot = function ({ fullPath }) {
   return dirname(fullPath)
 }
 

--- a/packages/build/src/install/local.js
+++ b/packages/build/src/install/local.js
@@ -5,7 +5,7 @@ const { logInstallLocalPluginsDeps } = require('../log/main')
 const { installDependencies } = require('./main')
 
 // Install dependencies of local plugins.
-const installLocalPluginsDependencies = async function(pluginsOptions, buildDir) {
+const installLocalPluginsDependencies = async function (pluginsOptions, buildDir) {
   const localPluginsOptions = getLocalPluginsOptions(pluginsOptions)
   if (localPluginsOptions.length === 0) {
     return
@@ -21,21 +21,21 @@ const installLocalPluginsDependencies = async function(pluginsOptions, buildDir)
 }
 
 // Core plugins and non-local plugins already have their dependencies installed
-const getLocalPluginsOptions = function(pluginsOptions) {
+const getLocalPluginsOptions = function (pluginsOptions) {
   return pluginsOptions.filter(isLocalPlugin).filter(isUnique)
 }
 
-const isLocalPlugin = function({ local }) {
+const isLocalPlugin = function ({ local }) {
   return local
 }
 
 // Remove duplicates
-const isUnique = function({ packageDir }, index, pluginsOptions) {
+const isUnique = function ({ packageDir }, index, pluginsOptions) {
   return pluginsOptions.slice(index + 1).every(pluginOption => pluginOption.packageDir !== packageDir)
 }
 
 // We only install dependencies of local plugins that have their own `package.json`
-const removeMainRoot = async function(localPluginsOptions, buildDir) {
+const removeMainRoot = async function (localPluginsOptions, buildDir) {
   const mainPackageDir = await pkgDir(buildDir)
   return localPluginsOptions.filter(({ packageDir }) => packageDir !== mainPackageDir)
 }

--- a/packages/build/src/install/main.js
+++ b/packages/build/src/install/main.js
@@ -3,7 +3,7 @@ const execa = require('execa')
 const { addErrorInfo } = require('../error/info')
 
 // Install Node.js dependencies in a specific directory
-const installDependencies = async function({ packageRoot }) {
+const installDependencies = async function ({ packageRoot }) {
   try {
     await execa.command('npm install --no-progress --no-audit --no-fund', {
       cwd: packageRoot,
@@ -17,7 +17,7 @@ const installDependencies = async function({ packageRoot }) {
 }
 
 // Add new Node.js dependencies
-const addDependencies = async function({ packageRoot, packages }) {
+const addDependencies = async function ({ packageRoot, packages }) {
   try {
     await execa.command(`npm install --no-progress --no-audit --no-fund ${packages.join(' ')}`, {
       cwd: packageRoot,

--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -10,7 +10,7 @@ const { addDependencies } = require('./main')
 const pResolve = promisify(resolve)
 
 // Automatically install plugins if not installed already
-const installMissingPlugins = async function(pluginsOptions, basedir) {
+const installMissingPlugins = async function (pluginsOptions, basedir) {
   const missingPlugins = await pFilter(pluginsOptions, pluginOptions => isMissingPlugin(pluginOptions, basedir))
   if (missingPlugins.length === 0) {
     return
@@ -21,7 +21,7 @@ const installMissingPlugins = async function(pluginsOptions, basedir) {
   await addDependencies({ packageRoot: basedir, packages })
 }
 
-const isMissingPlugin = async function({ location }, basedir) {
+const isMissingPlugin = async function ({ location }, basedir) {
   try {
     await pResolve(location, { basedir })
     return false
@@ -30,7 +30,7 @@ const isMissingPlugin = async function({ location }, basedir) {
   }
 }
 
-const getPackage = function({ package }) {
+const getPackage = function ({ package }) {
   return package
 }
 

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -11,12 +11,12 @@ const isNetlifyCI = require('../utils/is-netlify-ci')
 
 // Set the amount of colors to use by `chalk` (and underlying `supports-color`)
 // 0 is no colors, 1 is 16 colors, 2 is 256 colors, 3 is 16 million colors.
-const setColorLevel = function() {
+const setColorLevel = function () {
   env.FORCE_COLOR = getColorLevel()
   defaultOptions.colors = hasColors()
 }
 
-const getColorLevel = function() {
+const getColorLevel = function () {
   // Allow user overridding this logic
   if (env.FORCE_COLOR) {
     return env.FORCE_COLOR
@@ -57,7 +57,7 @@ const getColorLevel = function() {
 
 const DEPTH_TO_LEVEL = { 1: '0', 4: '1', 8: '2', 24: '3' }
 
-const hasColors = function() {
+const hasColors = function () {
   return env.FORCE_COLOR !== '0' && env.FORCE_COLOR !== 'false'
 }
 

--- a/packages/build/src/log/logger.js
+++ b/packages/build/src/log/logger.js
@@ -1,7 +1,7 @@
 const { redactString } = require('./redact')
 
 // This should be used instead of `console.log()`
-const log = function(...args) {
+const log = function (...args) {
   const string = args.map(redactString).join('\n')
   console.log(string)
 }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -17,14 +17,14 @@ const { log } = require('./logger')
 const { serialize, SUBTEXT_PADDING, indent } = require('./serialize')
 const { EMPTY_LINE, HEADING_PREFIX, TICK, ARROW_DOWN } = require('./constants')
 
-const logBuildStart = function() {
+const logBuildStart = function () {
   log(`${EMPTY_LINE}
 ${greenBright.bold(`${HEADING_PREFIX} Starting Netlify Build v${version}`)}
 ${SUBTEXT_PADDING}https://github.com/netlify/build
 ${EMPTY_LINE}`)
 }
 
-const logFlags = function(flags) {
+const logFlags = function (flags) {
   const flagsA = omit(flags, HIDDEN_FLAGS)
   log(cyanBright.bold(`${HEADING_PREFIX} Flags`), serialize(flagsA), EMPTY_LINE)
 }
@@ -32,13 +32,13 @@ const logFlags = function(flags) {
 const CI_HIDDEN_FLAGS = isNetlifyCI() ? ['nodePath'] : []
 const HIDDEN_FLAGS = ['token', 'cachedConfig', 'defaultConfig', ...CI_HIDDEN_FLAGS]
 
-const logBuildDir = function(buildDir) {
+const logBuildDir = function (buildDir) {
   log(`${cyanBright.bold(`${HEADING_PREFIX} Current directory`)}
 ${SUBTEXT_PADDING}${buildDir}
 ${EMPTY_LINE}`)
 }
 
-const logConfigPath = function(configPath) {
+const logConfigPath = function (configPath) {
   if (configPath === undefined) {
     log(`${cyanBright.bold(`${HEADING_PREFIX} No config file was defined: using default values.`)}
 ${EMPTY_LINE}`)
@@ -50,7 +50,7 @@ ${SUBTEXT_PADDING}${configPath}
 ${EMPTY_LINE}`)
 }
 
-const logConfig = function(config) {
+const logConfig = function (config) {
   if (!NETLIFY_BUILD_DEBUG) {
     return
   }
@@ -61,7 +61,7 @@ const logConfig = function(config) {
 // The resolved configuration gets assigned some default values (empty objects and arrays)
 // to make it more convenient to use without checking for `undefined`.
 // However those empty values are not useful to users, so we don't log them.
-const simplifyConfig = function({ build: { environment, lifecycle, ...build }, plugins, ...config }) {
+const simplifyConfig = function ({ build: { environment, lifecycle, ...build }, plugins, ...config }) {
   const simplifiedBuild = {
     ...build,
     ...removeEmptyObject(environment, 'environment'),
@@ -74,15 +74,15 @@ const simplifyConfig = function({ build: { environment, lifecycle, ...build }, p
   }
 }
 
-const removeEmptyObject = function(object, propName) {
+const removeEmptyObject = function (object, propName) {
   return Object.keys(object).length === 0 ? {} : { [propName]: object }
 }
 
-const removeEmptyArray = function(array, propName) {
+const removeEmptyArray = function (array, propName) {
   return array.length === 0 ? {} : { [propName]: array }
 }
 
-const logContext = function(context) {
+const logContext = function (context) {
   if (context === undefined) {
     return
   }
@@ -92,53 +92,50 @@ ${SUBTEXT_PADDING}${context}
 ${EMPTY_LINE}`)
 }
 
-const logInstallMissingPlugins = function(packages) {
+const logInstallMissingPlugins = function (packages) {
   log(`${cyanBright.bold(`${HEADING_PREFIX} Installing plugins`)}
 ${indent(serializeList(packages))}
 ${EMPTY_LINE}`)
 }
 
-const logInstallLocalPluginsDeps = function(localPluginsOptions) {
+const logInstallLocalPluginsDeps = function (localPluginsOptions) {
   const packages = localPluginsOptions.map(getPackage)
   log(`${cyanBright.bold(`${HEADING_PREFIX} Installing local plugins dependencies`)}
 ${indent(serializeList(packages))}
 ${EMPTY_LINE}`)
 }
 
-const getPackage = function({ package }) {
+const getPackage = function ({ package }) {
   return package
 }
 
-const logLoadPlugins = function() {
+const logLoadPlugins = function () {
   log(cyanBright.bold(`${HEADING_PREFIX} Loading plugins`))
 }
 
-const logLoadedPlugins = function(pluginCommands) {
-  const loadedPlugins = pluginCommands
-    .filter(isNotDuplicate)
-    .map(getLoadedPlugin)
-    .join('\n')
+const logLoadedPlugins = function (pluginCommands) {
+  const loadedPlugins = pluginCommands.filter(isNotDuplicate).map(getLoadedPlugin).join('\n')
   log(loadedPlugins)
 }
 
-const isNotDuplicate = function(pluginCommand, index, pluginCommands) {
+const isNotDuplicate = function (pluginCommand, index, pluginCommands) {
   return !pluginCommands
     .slice(index + 1)
     .some(laterPluginCommand => laterPluginCommand.package === pluginCommand.package)
 }
 
-const getLoadedPlugin = function({ package, core, packageJson: { version } }) {
+const getLoadedPlugin = function ({ package, core, packageJson: { version } }) {
   const location = core ? ' from build core' : version === undefined ? '' : `@${version}`
   return `${SUBTEXT_PADDING} - ${greenBright.bold(package)}${location}`
 }
 
-const logCommandsStart = function(commandsCount) {
+const logCommandsStart = function (commandsCount) {
   log(`${EMPTY_LINE}
 ${greenBright.bold(`${HEADING_PREFIX} Running Netlify Build Lifecycle`)}
 ${SUBTEXT_PADDING}Found ${commandsCount} commands. Lets do this!`)
 }
 
-const logDryRunStart = function(eventWidth, commandsCount) {
+const logDryRunStart = function (eventWidth, commandsCount) {
   const columnWidth = getDryColumnWidth(eventWidth, commandsCount)
   const line = '─'.repeat(columnWidth)
   const secondLine = '─'.repeat(columnWidth)
@@ -154,7 +151,7 @@ ${SUBTEXT_PADDING}│ ${DRY_HEADER_NAMES[0].padEnd(columnWidth)} │ ${DRY_HEADE
 ${SUBTEXT_PADDING}└─${line}─┴─${secondLine}─┘`)}`)
 }
 
-const logDryRunCommand = function({
+const logDryRunCommand = function ({
   command: { prop, event, package, core },
   index,
   configPath,
@@ -175,7 +172,7 @@ ${SUBTEXT_PADDING}└─${line}─┘ `),
   )
 }
 
-const getPluginLocation = function({ prop, package, core, configPath }) {
+const getPluginLocation = function ({ prop, package, core, configPath }) {
   if (prop !== undefined) {
     return `${white('Config')} ${cyanBright(basename(configPath))} ${yellowBright(prop)}`
   }
@@ -187,20 +184,20 @@ const getPluginLocation = function({ prop, package, core, configPath }) {
   return `${white('Plugin')} ${yellowBright(package)}`
 }
 
-const getDryColumnWidth = function(eventWidth, commandsCount) {
+const getDryColumnWidth = function (eventWidth, commandsCount) {
   const symbolsWidth = `${commandsCount}`.length + 4
   return Math.max(eventWidth + symbolsWidth, DRY_HEADER_NAMES[0].length)
 }
 
 const DRY_HEADER_NAMES = ['Event', 'Location']
 
-const logDryRunEnd = function() {
+const logDryRunEnd = function () {
   log(`${EMPTY_LINE}
 ${SUBTEXT_PADDING}If this looks good to you, run \`netlify build\` to execute the build
 ${EMPTY_LINE}`)
 }
 
-const logCommand = function({ event, prop, package }, { index, configPath, error }) {
+const logCommand = function ({ event, prop, package }, { index, configPath, error }) {
   const configName = configPath === undefined ? '' : ` from ${basename(configPath)} config file`
   const description =
     prop === undefined ? `${bold(event)} command from ${bold(package)}` : `${bold(prop)} command${configName}`
@@ -213,34 +210,34 @@ ${EMPTY_LINE}`),
   )
 }
 
-const logShellCommandStart = function(shellCommand) {
+const logShellCommandStart = function (shellCommand) {
   log(yellowBright(`Running command "${shellCommand}"`))
 }
 
-const logCommandSuccess = function() {
+const logCommandSuccess = function () {
   log(EMPTY_LINE)
 }
 
-const logTimer = function(durationMs, timerName) {
+const logTimer = function (durationMs, timerName) {
   log(` ${greenBright(TICK)}  ${greenBright.bold(timerName)} completed in ${durationMs}ms`)
 }
 
-const logCacheStart = function() {
+const logCacheStart = function () {
   log(cyanBright.bold(`${HEADING_PREFIX} Caching artifacts`))
 }
 
-const logCacheDir = function(path) {
+const logCacheDir = function (path) {
   log(`${SUBTEXT_PADDING}Caching ${path}`)
 }
 
-const logPluginError = function(error) {
+const logPluginError = function (error) {
   const { header, body, color } = serializeError(error)
   log(`${color.bold(getHeader(header))}
 ${EMPTY_LINE}
 ${body}`)
 }
 
-const logBuildError = function(error) {
+const logBuildError = function (error) {
   const { header, body, color } = serializeError(error)
   log(`${EMPTY_LINE}
 ${color.bold(getHeader(header))}
@@ -249,7 +246,7 @@ ${body}
 ${EMPTY_LINE}`)
 }
 
-const logBuildSuccess = function() {
+const logBuildSuccess = function () {
   log(
     greenBright.bold(`${EMPTY_LINE}
 ${getHeader('Netlify Build Complete')}
@@ -257,7 +254,7 @@ ${EMPTY_LINE}`),
   )
 }
 
-const logBuildEnd = function() {
+const logBuildEnd = function () {
   log(`${EMPTY_LINE}
 ${cyanBright(SPARKLES)} Have a nice day!
 ${EMPTY_LINE}`)
@@ -266,7 +263,7 @@ ${EMPTY_LINE}`)
 const SPARKLES = platform === 'win32' ? '(/Ò_Ò)/' : '(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧'
 
 // Print a rectangular header
-const getHeader = function(message) {
+const getHeader = function (message) {
   const messageWidth = stringWidth(message)
   const headerWidth = Math.max(HEADER_MIN_WIDTH, messageWidth + MIN_PADDING * 2)
   const line = '─'.repeat(headerWidth)

--- a/packages/build/src/log/redact.js
+++ b/packages/build/src/log/redact.js
@@ -1,12 +1,12 @@
 const redactEnv = require('redact-env')
 const replaceStream = require('replacestream')
 
-const redactString = function(string) {
+const redactString = function (string) {
   return redactEnv.redact(string, secrets)
 }
 
 // istanbul ignore next
-const redactStream = function(stream) {
+const redactStream = function (stream) {
   return stream.pipe(replaceStream(secrets, '[secure]'))
 }
 

--- a/packages/build/src/log/serialize.js
+++ b/packages/build/src/log/serialize.js
@@ -2,11 +2,11 @@ const { dump, JSON_SCHEMA } = require('js-yaml')
 const indentString = require('indent-string')
 
 // Serialize to string
-const serialize = function(arg) {
+const serialize = function (arg) {
   return indent(stringify(arg)).trimRight()
 }
 
-const stringify = function(arg) {
+const stringify = function (arg) {
   if (typeof arg !== 'object' || arg === null) {
     return String(arg)
   }
@@ -15,7 +15,7 @@ const stringify = function(arg) {
 }
 
 // Add indentation
-const indent = function(arg) {
+const indent = function (arg) {
   return indentString(arg, INDENT_SIZE)
 }
 

--- a/packages/build/src/log/stream.js
+++ b/packages/build/src/log/stream.js
@@ -10,7 +10,7 @@ const isNetlifyCI = require('../utils/is-netlify-ci')
 // But locally we want to stream output instead for a better developer
 // experience.
 // See https://github.com/netlify/build/issues/343
-const startOutput = function(childProcess) {
+const startOutput = function (childProcess) {
   if (shouldBuffer()) {
     return bufferOutput(childProcess)
   }
@@ -19,7 +19,7 @@ const startOutput = function(childProcess) {
 }
 
 // Stop streaming/buffering Bash command or plugin command output
-const stopOutput = async function(childProcess, outputState) {
+const stopOutput = async function (childProcess, outputState) {
   if (shouldBuffer()) {
     return unbufferOutput(childProcess, outputState)
   }
@@ -27,12 +27,12 @@ const stopOutput = async function(childProcess, outputState) {
   await unpipeOutput(childProcess)
 }
 
-const pipeOutput = function(childProcess) {
+const pipeOutput = function (childProcess) {
   childProcess.stdout.pipe(stdout)
   childProcess.stderr.pipe(stderr)
 }
 
-const unpipeOutput = async function(childProcess) {
+const unpipeOutput = async function (childProcess) {
   await Promise.all([waitForFlush(childProcess.stdout), waitForFlush(childProcess.stderr)])
 
   childProcess.stdout.unpipe(stdout)
@@ -42,7 +42,7 @@ const unpipeOutput = async function(childProcess) {
 // childProcess.stdout|stderr might have some writes not piped|written to
 // parent process.stdout|stderr yet.
 // TODO: find a more reliable way
-const waitForFlush = async function(stream) {
+const waitForFlush = async function (stream) {
   // istanbul ignore next
   while (stream._readableState.paused) {
     await pSetTimeout(1e3)
@@ -52,7 +52,7 @@ const waitForFlush = async function(stream) {
   await pSetTimeout(0)
 }
 
-const bufferOutput = function(childProcess) {
+const bufferOutput = function (childProcess) {
   const chunks = []
   const dataListener = pushChunk.bind(null, chunks)
   childProcess.stdout.on('data', dataListener)
@@ -60,18 +60,18 @@ const bufferOutput = function(childProcess) {
   return { chunks, dataListener }
 }
 
-const pushChunk = function(chunks, chunk) {
+const pushChunk = function (chunks, chunk) {
   chunks.push(chunk)
 }
 
-const unbufferOutput = function(childProcess, { chunks, dataListener }) {
+const unbufferOutput = function (childProcess, { chunks, dataListener }) {
   childProcess.stderr.removeListener('data', dataListener)
   childProcess.stdout.removeListener('data', dataListener)
   const output = chunks.join('')
   process.stdout.write(`${output}\n`)
 }
 
-const shouldBuffer = function() {
+const shouldBuffer = function () {
   return isNetlifyCI()
 }
 

--- a/packages/build/src/log/timer.js
+++ b/packages/build/src/log/timer.js
@@ -3,12 +3,12 @@ const { hrtime } = require('process')
 const { logTimer } = require('./main')
 
 // Starts a timer
-const startTimer = function() {
+const startTimer = function () {
   return hrtime()
 }
 
 // Stops a timer
-const endTimerDuration = function([startSecs, startNsecs]) {
+const endTimerDuration = function ([startSecs, startNsecs]) {
   const [endSecs, endNsecs] = hrtime()
   const durationNs = (endSecs - startSecs) * NANOSECS_TO_SECS + endNsecs - startNsecs
   const durationMs = Math.ceil(durationNs / NANOSECS_TO_MSECS)
@@ -16,7 +16,7 @@ const endTimerDuration = function([startSecs, startNsecs]) {
 }
 
 // Ends a timer and prints the result on console
-const endTimer = function(hrTime, timerName) {
+const endTimer = function (hrTime, timerName) {
   const durationMs = endTimerDuration(hrTime)
 
   logTimer(durationMs, timerName)

--- a/packages/build/src/plugins/child/api.js
+++ b/packages/build/src/plugins/child/api.js
@@ -7,7 +7,7 @@ const NetlifyAPI = require('netlify')
 const { failBuild } = require('../error')
 
 // Retrieve Netlify API client, providing a authentication token was provided
-const getApiClient = function({ manifest: { scopes = DEFAULT_SCOPES }, token }) {
+const getApiClient = function ({ manifest: { scopes = DEFAULT_SCOPES }, token }) {
   // This feature is not currently finished due to lack of API support
   // See https://github.com/netlify/build/issues/585
   if (NETLIFY_BUILD_API_CLIENT !== '1') {
@@ -32,7 +32,7 @@ const getApiClient = function({ manifest: { scopes = DEFAULT_SCOPES }, token }) 
 const DEFAULT_SCOPES = []
 
 // Redact API methods to scopes
-const disableApiMethods = function(api, scopes) {
+const disableApiMethods = function (api, scopes) {
   if (scopes.includes('*')) {
     return
   }
@@ -42,17 +42,17 @@ const disableApiMethods = function(api, scopes) {
   })
 }
 
-const getApiMethods = function() {
+const getApiMethods = function () {
   return NetlifyAPI.methods.map(getApiMethod)
 }
 
-const getApiMethod = function({ operationId }) {
+const getApiMethod = function ({ operationId }) {
   return operationId
 }
 
 const API_METHODS = getApiMethods()
 
-const disabledApiMethod = async function(method) {
+const disabledApiMethod = async function (method) {
   failBuild(`This plugin is not authorized to use "api.${method}". Please update the plugin scopes.`)
 }
 

--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -9,7 +9,7 @@ const { getUtils } = require('./utils')
 // This also validates the plugin.
 // Do it when parent requests it using the `load` event.
 // Also figure out the list of plugin commands. This is also passed to the parent.
-const loadPlugin = function(payload) {
+const loadPlugin = function (payload) {
   const logic = getLogic(payload)
 
   validatePlugin(logic)
@@ -22,18 +22,18 @@ const loadPlugin = function(payload) {
   return { context, pluginCommands }
 }
 
-const getPluginCommands = function(logic) {
+const getPluginCommands = function (logic) {
   return Object.entries(logic)
     .filter(isEventHandler)
     .map(([event, method]) => ({ method, event }))
 }
 
-const isEventHandler = function([, value]) {
+const isEventHandler = function ([, value]) {
   return typeof value === 'function'
 }
 
 // Retrieve context passed to every event handler
-const getContext = function(pluginCommands, { manifest, inputs, netlifyConfig, constants, utilsData, token }) {
+const getContext = function (pluginCommands, { manifest, inputs, netlifyConfig, constants, utilsData, token }) {
   const utils = getUtils({ utilsData, constants })
   const api = getApiClient({ manifest, token, utils })
   return { pluginCommands, api, utils, constants, inputs, netlifyConfig }

--- a/packages/build/src/plugins/child/logic.js
+++ b/packages/build/src/plugins/child/logic.js
@@ -1,12 +1,12 @@
 // Require the plugin file and fire its top-level function.
 // The returned object is the `logic` which includes all event handlers.
-const getLogic = function({ pluginPath, inputs, constants }) {
+const getLogic = function ({ pluginPath, inputs, constants }) {
   const logic = requireLogic(pluginPath)
   const logicA = loadLogic({ logic, inputs, constants })
   return logicA
 }
 
-const requireLogic = function(pluginPath) {
+const requireLogic = function (pluginPath) {
   try {
     return require(pluginPath)
   } catch (error) {
@@ -15,7 +15,7 @@ const requireLogic = function(pluginPath) {
   }
 }
 
-const loadLogic = function({ logic, inputs, constants }) {
+const loadLogic = function ({ logic, inputs, constants }) {
   if (typeof logic !== 'function') {
     return logic
   }

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -13,7 +13,7 @@ const { ERROR_TYPE_SYM } = require('../error')
 const { loadPlugin } = require('./load')
 
 // Boot plugin child process.
-const bootPlugin = async function() {
+const bootPlugin = async function () {
   try {
     handleProcessErrors()
 
@@ -29,11 +29,11 @@ const bootPlugin = async function() {
 
 // On uncaught exceptions and unhandled rejections, print the stack trace.
 // Also, prevent child processes from crashing on uncaught exceptions.
-const handleProcessErrors = function() {
+const handleProcessErrors = function () {
   logProcessErrors({ log: handleProcessError, colors: hasColors(), exitOn: [], level: { multipleResolves: 'silent' } })
 }
 
-const handleProcessError = async function(error, level) {
+const handleProcessError = async function (error, level) {
   if (level !== 'error') {
     console[level](error)
     return
@@ -42,7 +42,7 @@ const handleProcessError = async function(error, level) {
   await handleError(error)
 }
 
-const handleError = async function({
+const handleError = async function ({
   name,
   message,
   stack,
@@ -55,24 +55,24 @@ const handleError = async function({
 const DEFAULT_ERROR_TYPE = 'pluginInternalError'
 
 // Wait for events from parent to perform plugin methods
-const handleEvents = async function(state) {
+const handleEvents = async function (state) {
   await getEventsFromParent((callId, eventName, payload) => handleEvent(callId, eventName, payload, state))
 }
 
-const handleEvent = async function(callId, eventName, payload, state) {
+const handleEvent = async function (callId, eventName, payload, state) {
   const response = await EVENTS[eventName](payload, state)
   await sendEventToParent(callId, response)
 }
 
 // Initial plugin load
-const load = function(payload, state) {
+const load = function (payload, state) {
   const { context, pluginCommands } = loadPlugin(payload)
   state.context = context
   return { pluginCommands }
 }
 
 // Run a specific plugin event handler
-const run = async function(
+const run = async function (
   { event, error },
   { context: { pluginCommands, api, utils, constants, inputs, netlifyConfig } },
 ) {
@@ -84,7 +84,7 @@ const run = async function(
 
 // Add older names, kept for backward compatibility. Non-enumerable.
 // TODO: remove after being out of beta
-const addBackwardCompatibility = function(runOptions) {
+const addBackwardCompatibility = function (runOptions) {
   Object.defineProperties(runOptions, {
     pluginConfig: { value: runOptions.inputs },
   })

--- a/packages/build/src/plugins/child/normalize.js
+++ b/packages/build/src/plugins/child/normalize.js
@@ -2,11 +2,11 @@ const mapObj = require('map-obj')
 const { LEGACY_EVENTS } = require('@netlify/config')
 
 // Normalize plugin shape
-const normalizePlugin = function(logic) {
+const normalizePlugin = function (logic) {
   return mapObj(logic, normalizeProperty)
 }
 
-const normalizeProperty = function(key, value) {
+const normalizeProperty = function (key, value) {
   const newKey = LEGACY_EVENTS[key]
 
   if (newKey === undefined) {

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -8,13 +8,13 @@ const { failBuild, failPlugin, cancelBuild } = require('../error')
 // Some utilities need to perform some async initialization logic first.
 // We do it once for all plugins in the parent process then pass it to the child
 // processes.
-const startUtils = async function(buildDir) {
+const startUtils = async function (buildDir) {
   const git = await gitUtils({ cwd: buildDir })
   return { git }
 }
 
 // Retrieve the `utils` argument.
-const getUtils = function({ utilsData: { git }, constants }) {
+const getUtils = function ({ utilsData: { git }, constants }) {
   const buildUtils = { failBuild, failPlugin, cancelBuild }
   const gitA = gitUtils.load(git)
   // eslint-disable-next-line no-unused-vars

--- a/packages/build/src/plugins/child/validate.js
+++ b/packages/build/src/plugins/child/validate.js
@@ -5,7 +5,7 @@ const { serializeList } = require('../../utils/list')
 const { failBuild } = require('../error')
 
 // Validate the shape of a plugin return value
-const validatePlugin = function(logic) {
+const validatePlugin = function (logic) {
   if (!isPlainObj(logic)) {
     failBuild('Plugin must be an object or a function')
   }
@@ -13,7 +13,7 @@ const validatePlugin = function(logic) {
   Object.entries(logic).forEach(([propName, value]) => validateProperty(value, propName))
 }
 
-const validateProperty = function(value, propName) {
+const validateProperty = function (value, propName) {
   if (DEPRECATED_PROPERTIES.includes(propName)) {
     return
   }
@@ -26,7 +26,7 @@ const validateProperty = function(value, propName) {
 // TODO: remove after migrating existing plugins
 const DEPRECATED_PROPERTIES = ['name', 'inputs', 'config', 'scopes']
 
-const validateEventHandler = function(value, propName) {
+const validateEventHandler = function (value, propName) {
   if (!EVENTS.includes(propName) && LEGACY_EVENTS[propName] === undefined) {
     failBuild(`Invalid event '${propName}'.
 Please use a valid event name. One of:

--- a/packages/build/src/plugins/env.js
+++ b/packages/build/src/plugins/env.js
@@ -7,7 +7,7 @@ const { getGitEnv } = require('./git')
 
 // Retrieve the environment variables passed to plugins and lifecycle commands.
 // When run locally, this tries to emulate the production environment.
-const getChildEnv = async function({ netlifyConfig, buildDir, branch, context, siteInfo }) {
+const getChildEnv = async function ({ netlifyConfig, buildDir, branch, context, siteInfo }) {
   if (isNetlifyCI()) {
     return process.env
   }
@@ -26,12 +26,12 @@ const getChildEnv = async function({ netlifyConfig, buildDir, branch, context, s
 }
 
 // Environment variables that can be unset by local ones or configuration ones
-const getDefaultEnv = function() {
+const getDefaultEnv = function () {
   return {}
 }
 
 // Environment variables that can be unset by configuration ones but not local
-const getConfigurableEnv = function() {
+const getConfigurableEnv = function () {
   return {
     // Localization
     LANG: 'en_US.UTF-8',
@@ -44,7 +44,7 @@ const getConfigurableEnv = function() {
 }
 
 // Environment variables specified in UI settings or in `build.environment`
-const getConfigEnv = function({ build: { environment } }) {
+const getConfigEnv = function ({ build: { environment } }) {
   return omit(environment, READONLY_ENV)
 }
 
@@ -78,7 +78,7 @@ const READONLY_ENV = [
 ]
 
 // Environment variables that can be unset by neither local nor configuration
-const getForcedEnv = async function({
+const getForcedEnv = async function ({
   buildDir,
   branch,
   context,

--- a/packages/build/src/plugins/error.js
+++ b/packages/build/src/plugins/error.js
@@ -1,29 +1,29 @@
 // Stop build.
 // As opposed to throwing an error directly or to uncaught exceptions, this is
 // displayed as a user error, not an implementation error.
-const failBuild = function(message, opts) {
+const failBuild = function (message, opts) {
   throw normalizeError('failBuild', failBuild, message, opts)
 }
 
 // Stop plugin. Same as `failBuild` but only stops plugin not whole build
-const failPlugin = function(message, opts) {
+const failPlugin = function (message, opts) {
   throw normalizeError('failPlugin', failPlugin, message, opts)
 }
 
 // Cancel build. Same as `failBuild` except it marks the build as "canceled".
-const cancelBuild = function(message, opts) {
+const cancelBuild = function (message, opts) {
   throw normalizeError('cancelBuild', cancelBuild, message, opts)
 }
 
 // An `error` option can be passed to keep the original error message and
 // stack trace. An additional `message` string is always required.
-const normalizeError = function(type, func, message, { error } = {}) {
+const normalizeError = function (type, func, message, { error } = {}) {
   const errorA = getError(error, message, func)
   errorA[ERROR_TYPE_SYM] = type
   return errorA
 }
 
-const getError = function(error, message, func) {
+const getError = function (error, message, func) {
   if (error instanceof Error) {
     error.message = `${message}\n${error.message}`
     return error

--- a/packages/build/src/plugins/git.js
+++ b/packages/build/src/plugins/git.js
@@ -5,7 +5,7 @@ const { removeFalsy } = require('../utils/remove_falsy')
 // Retrieve git-related information for use in environment variables.
 // git is optional and there might be not git repository.
 // We purposely keep this decoupled from the git utility.
-const getGitEnv = async function(buildDir, branch) {
+const getGitEnv = async function (buildDir, branch) {
   const [COMMIT_REF, CACHED_COMMIT_REF] = await Promise.all([
     git(['rev-parse', 'HEAD'], buildDir),
     git(['rev-parse', 'HEAD^'], buildDir),
@@ -15,7 +15,7 @@ const getGitEnv = async function(buildDir, branch) {
   return gitEnvA
 }
 
-const git = async function(args, cwd) {
+const git = async function (args, cwd) {
   try {
     const { stdout } = await execa('git', args, { cwd })
     return stdout

--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -9,7 +9,7 @@ const { addErrorInfo } = require('../error/info')
 // Send event from child to parent process then wait for response
 // We need to fire them in parallel because `process.send()` can be slow
 // to await, i.e. child might send response before parent start listening for it
-const callChild = async function(childProcess, eventName, payload) {
+const callChild = async function (childProcess, eventName, payload) {
   const callId = uuidv4()
   const [response] = await Promise.all([
     getEventFromChild(childProcess, callId),
@@ -26,7 +26,7 @@ const callChild = async function(childProcess, eventName, payload) {
 //  - child process `exit`
 // In the later two cases, we propagate the error.
 // We need to make `p-event` listeners are properly cleaned up too.
-const getEventFromChild = async function(childProcess, callId) {
+const getEventFromChild = async function (childProcess, callId) {
   if (!childProcess.connected) {
     const error = new Error('Could not receive event from child process because it already exited')
     addErrorInfo(error, { type: 'ipc' })
@@ -45,17 +45,17 @@ const getEventFromChild = async function(childProcess, callId) {
   }
 }
 
-const getMessage = async function(messagePromise) {
+const getMessage = async function (messagePromise) {
   const [, response] = await messagePromise
   return response
 }
 
-const getError = async function(errorPromise) {
+const getError = async function (errorPromise) {
   const [, { errorProps, ...values }] = await errorPromise
   throw buildError({ ...values, ...errorProps })
 }
 
-const getExit = async function(exitPromise) {
+const getExit = async function (exitPromise) {
   const [exitCode, signal] = await exitPromise
   const error = new Error(`Plugin exited with exit code ${exitCode} and signal ${signal}.
 Instead of calling process.exit(), plugin methods should either return (on success) or throw errors (on failure).`)
@@ -64,14 +64,14 @@ Instead of calling process.exit(), plugin methods should either return (on succe
 }
 
 // Send event from parent to child process
-const sendEventToChild = async function(childProcess, callId, eventName, payload) {
+const sendEventToChild = async function (childProcess, callId, eventName, payload) {
   const payloadA = serializePayload(payload)
   await promisify(childProcess.send.bind(childProcess))([callId, eventName, payloadA])
 }
 
 // Respond to events from parent to child process.
 // This runs forever until `childProcess.kill()` is called.
-const getEventsFromParent = async function(callback) {
+const getEventsFromParent = async function (callback) {
   return new Promise((resolve, reject) => {
     process.on('message', async message => {
       try {
@@ -86,7 +86,7 @@ const getEventsFromParent = async function(callback) {
 }
 
 // Send event from child to parent process
-const sendEventToParent = async function(callId, payload) {
+const sendEventToParent = async function (callId, payload) {
   await promisify(process.send.bind(process))([callId, payload])
 }
 
@@ -94,7 +94,7 @@ const sendEventToParent = async function(callId, payload) {
 // convert from/to plain objects.
 // TODO: use `child_process.spawn()` `serialization: 'advanced'` option after
 // dropping support for Node.js <=13.2.0
-const serializePayload = function({ error: { name, message, stack, ...errorProps } = {}, ...payload }) {
+const serializePayload = function ({ error: { name, message, stack, ...errorProps } = {}, ...payload }) {
   if (name === undefined) {
     return payload
   }
@@ -102,7 +102,7 @@ const serializePayload = function({ error: { name, message, stack, ...errorProps
   return { ...payload, error: { ...errorProps, name, message, stack } }
 }
 
-const parsePayload = function({ error = {}, ...payload }) {
+const parsePayload = function ({ error = {}, ...payload }) {
   if (error.name === undefined) {
     return payload
   }

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -7,7 +7,7 @@ const { callChild } = require('./ipc')
 
 // Retrieve all plugins commands
 // Can use either a module name or a file path to the plugin.
-const loadPlugins = async function({ pluginsOptions, childProcesses, netlifyConfig, utilsData, token, constants }) {
+const loadPlugins = async function ({ pluginsOptions, childProcesses, netlifyConfig, utilsData, token, constants }) {
   logLoadPlugins()
 
   const pluginCommands = await Promise.all(
@@ -32,7 +32,7 @@ const loadPlugins = async function({ pluginsOptions, childProcesses, netlifyConf
 
 // Retrieve plugin commands for one plugin.
 // Do it by executing the plugin `load` event handler.
-const loadPlugin = async function(
+const loadPlugin = async function (
   { package, packageJson, pluginPath, manifest, inputs, core, local },
   { childProcesses, index, netlifyConfig, utilsData, token, constants },
 ) {

--- a/packages/build/src/plugins/manifest/check.js
+++ b/packages/build/src/plugins/manifest/check.js
@@ -5,7 +5,7 @@ const { serialize } = require('../../log/serialize')
 
 // Check that plugin inputs match the validation specified in "manifest.yml"
 // Also assign default values
-const checkInputs = function({ inputs, manifest: { inputs: rules = [] }, package, packageJson, local }) {
+const checkInputs = function ({ inputs, manifest: { inputs: rules = [] }, package, packageJson, local }) {
   try {
     const inputsA = addDefaults(inputs, rules)
     checkRequiredInputs({ inputs: inputsA, rules, package, packageJson, local })
@@ -22,21 +22,21 @@ ${serialize(inputs)}`
 }
 
 // Add "inputs[*].default"
-const addDefaults = function(inputs, rules) {
+const addDefaults = function (inputs, rules) {
   const defaults = rules.filter(hasDefault).map(getDefault)
   return Object.assign({}, ...defaults, inputs)
 }
 
-const hasDefault = function(rule) {
+const hasDefault = function (rule) {
   return rule.default !== undefined
 }
 
-const getDefault = function({ name, default: defaultValue }) {
+const getDefault = function ({ name, default: defaultValue }) {
   return { [name]: defaultValue }
 }
 
 // Check "inputs[*].required"
-const checkRequiredInputs = function({ inputs, rules, package, packageJson, local }) {
+const checkRequiredInputs = function ({ inputs, rules, package, packageJson, local }) {
   const missingInputs = rules.filter(rule => isMissingRequired(inputs, rule))
   if (missingInputs.length === 0) {
     return
@@ -48,16 +48,16 @@ const checkRequiredInputs = function({ inputs, rules, package, packageJson, loca
   throw error
 }
 
-const isMissingRequired = function(inputs, { name, required }) {
+const isMissingRequired = function (inputs, { name, required }) {
   return required && inputs[name] === undefined
 }
 
-const getName = function({ name }) {
+const getName = function ({ name }) {
   return name
 }
 
 // Check each "inputs[*].*" property for a specific input
-const checkInput = function({ name, rules, package, packageJson, local }) {
+const checkInput = function ({ name, rules, package, packageJson, local }) {
   const ruleA = rules.find(rule => rule.name === name)
   if (ruleA === undefined) {
     const error = new Error(`Invalid input "${name}" for plugin "${package}".
@@ -71,7 +71,7 @@ Check your plugin configuration to be sure that:
 }
 
 // Add error information
-const addInputError = function({ error, name, package, packageJson, local }) {
+const addInputError = function ({ error, name, package, packageJson, local }) {
   addErrorInfo(error, {
     type: 'pluginInput',
     plugin: { package, packageJson },

--- a/packages/build/src/plugins/manifest/load.js
+++ b/packages/build/src/plugins/manifest/load.js
@@ -10,7 +10,7 @@ const { validateManifest } = require('./validate')
 const pReadFile = promisify(readFile)
 
 // Load "manifest.yml" using its file path
-const loadManifest = async function({ manifestPath, package, packageJson, local }) {
+const loadManifest = async function ({ manifestPath, package, packageJson, local }) {
   try {
     const rawManifest = await loadRawManifest(manifestPath)
     const manifest = await parseManifest(rawManifest)
@@ -26,7 +26,7 @@ const loadManifest = async function({ manifestPath, package, packageJson, local 
   }
 }
 
-const loadRawManifest = async function(manifestPath) {
+const loadRawManifest = async function (manifestPath) {
   try {
     return await pReadFile(manifestPath, 'utf8')
   } catch (error) {
@@ -35,7 +35,7 @@ const loadRawManifest = async function(manifestPath) {
   }
 }
 
-const parseManifest = async function(rawManifest) {
+const parseManifest = async function (rawManifest) {
   try {
     return await loadYaml(rawManifest, { schema: JSON_SCHEMA, json: true })
   } catch (error) {

--- a/packages/build/src/plugins/manifest/main.js
+++ b/packages/build/src/plugins/manifest/main.js
@@ -3,7 +3,7 @@ const { loadManifest } = require('./load')
 const { checkInputs } = require('./check')
 
 // Load plugin's `manifest.yml`
-const useManifest = async function({ package, local, inputs }, { pluginDir, packageDir, packageJson }) {
+const useManifest = async function ({ package, local, inputs }, { pluginDir, packageDir, packageJson }) {
   const manifestPath = await getManifestPath(pluginDir, packageDir)
 
   if (manifestPath === undefined) {

--- a/packages/build/src/plugins/manifest/path.js
+++ b/packages/build/src/plugins/manifest/path.js
@@ -1,7 +1,7 @@
 const locatePath = require('locate-path')
 
 // Retrieve "manifest.yml" path for a specific plugin
-const getManifestPath = async function(pluginDir, packageDir) {
+const getManifestPath = async function (pluginDir, packageDir) {
   const dirs = [pluginDir, packageDir].filter(Boolean).map(dir => `${dir}/${MANIFEST_FILENAME}`)
   const manifestPath = await locatePath(dirs)
   return manifestPath

--- a/packages/build/src/plugins/manifest/validate.js
+++ b/packages/build/src/plugins/manifest/validate.js
@@ -6,7 +6,7 @@ const { indent } = require('../../log/serialize')
 const { API_METHODS } = require('../child/api')
 
 // Validate `manifest.yml` syntax
-const validateManifest = function(manifest, rawManifest) {
+const validateManifest = function (manifest, rawManifest) {
   try {
     validateBasic(manifest)
     validateUnknownProps(manifest)
@@ -23,13 +23,13 @@ ${indent(rawManifest.trim())}`
   }
 }
 
-const validateBasic = function(manifest) {
+const validateBasic = function (manifest) {
   if (!isPlainObj(manifest)) {
     throw new Error('must be a plain object')
   }
 }
 
-const validateUnknownProps = function(manifest) {
+const validateUnknownProps = function (manifest) {
   const unknownProp = Object.keys(manifest).find(key => !VALID_PROPS.includes(key))
   if (unknownProp !== undefined) {
     throw new Error(`unknown property "${unknownProp}"`)
@@ -38,7 +38,7 @@ const validateUnknownProps = function(manifest) {
 
 const VALID_PROPS = ['name', 'inputs', 'scopes']
 
-const validateName = function({ name }) {
+const validateName = function ({ name }) {
   if (name === undefined) {
     throw new Error('must contain a "name" property')
   }
@@ -48,7 +48,7 @@ const validateName = function({ name }) {
   }
 }
 
-const validateScopes = function({ scopes }) {
+const validateScopes = function ({ scopes }) {
   if (scopes === undefined) {
     return
   }
@@ -65,13 +65,13 @@ ${serializeList(ALLOWED_SCOPES)}`)
   }
 }
 
-const isValidScope = function(scope) {
+const isValidScope = function (scope) {
   return ALLOWED_SCOPES.includes(scope)
 }
 
 const ALLOWED_SCOPES = ['*', ...API_METHODS]
 
-const validateInputs = function({ inputs }) {
+const validateInputs = function ({ inputs }) {
   if (inputs === undefined) {
     return
   }
@@ -83,11 +83,11 @@ const validateInputs = function({ inputs }) {
   inputs.forEach(validateInput)
 }
 
-const isArrayOfObjects = function(objects) {
+const isArrayOfObjects = function (objects) {
   return Array.isArray(objects) && objects.every(isPlainObj)
 }
 
-const validateInput = function(input, index) {
+const validateInput = function (input, index) {
   try {
     validateUnknownInputProps(input)
     validateInputName(input)
@@ -99,7 +99,7 @@ Input at position ${index} ${error.message}.`
   }
 }
 
-const validateUnknownInputProps = function(input) {
+const validateUnknownInputProps = function (input) {
   const unknownProp = Object.keys(input).find(key => !VALID_INPUT_PROPS.includes(key))
   if (unknownProp !== undefined) {
     throw new Error(`has an unknown property "${unknownProp}"`)
@@ -108,7 +108,7 @@ const validateUnknownInputProps = function(input) {
 
 const VALID_INPUT_PROPS = ['name', 'required', 'default']
 
-const validateInputName = function({ name }) {
+const validateInputName = function ({ name }) {
   if (name === undefined) {
     throw new Error('must contain a "name" property')
   }
@@ -118,7 +118,7 @@ const validateInputName = function({ name }) {
   }
 }
 
-const validateInputRequired = function({ required }) {
+const validateInputRequired = function ({ required }) {
   if (required !== undefined && typeof required !== 'boolean') {
     throw new Error('"required" property must be a boolean')
   }

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -12,7 +12,7 @@ const { useManifest } = require('./manifest/main')
 const pResolve = promisify(resolve)
 
 // Load plugin options (specified by user in `config.plugins`)
-const getPluginsOptions = async function({ plugins }, buildDir, configPath) {
+const getPluginsOptions = async function ({ plugins }, buildDir, configPath) {
   const pluginsOptions = [...CORE_PLUGINS, ...plugins].map(normalizePluginOptions)
   const basedir = getBasedir(buildDir, configPath)
   await installMissingPlugins(pluginsOptions, basedir)
@@ -22,7 +22,7 @@ const getPluginsOptions = async function({ plugins }, buildDir, configPath) {
   return pluginsOptionsA
 }
 
-const normalizePluginOptions = function({ package, location = package, core = false, inputs = {} }) {
+const normalizePluginOptions = function ({ package, location = package, core = false, inputs = {} }) {
   const local = package.startsWith('.') || package.startsWith('/')
   return { package, location, local, core, inputs }
 }
@@ -32,7 +32,7 @@ const normalizePluginOptions = function({ package, location = package, core = fa
 // what users would expect. If no configuration file is present, we use
 // `buildDir`.
 // We use `resolve` because `require()` does not allow custom base directory.
-const getBasedir = function(buildDir, configPath) {
+const getBasedir = function (buildDir, configPath) {
   if (configPath === undefined) {
     return buildDir
   }
@@ -42,7 +42,7 @@ const getBasedir = function(buildDir, configPath) {
 
 // Retrieve plugin's main file path.
 // Then load plugin's `package.json` and `manifest.yml`.
-const loadPluginFiles = async function({ pluginOptions, pluginOptions: { location, local }, basedir }) {
+const loadPluginFiles = async function ({ pluginOptions, pluginOptions: { location, local }, basedir }) {
   const pluginPath = await pResolve(location, { basedir })
   const pluginDir = dirname(pluginPath)
   const { packageDir, packageJson } = await getPackageJson({ pluginDir, local })

--- a/packages/build/src/plugins/package.js
+++ b/packages/build/src/plugins/package.js
@@ -3,7 +3,7 @@ const { dirname } = require('path')
 const readPkgUp = require('read-pkg-up')
 
 // Retrieve plugin's `package.json`
-const getPackageJson = async function({ pluginDir, local }) {
+const getPackageJson = async function ({ pluginDir, local }) {
   const packageObj = await readPkgUp({ cwd: pluginDir })
   if (packageObj === undefined) {
     return { packageJson: {} }

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -10,11 +10,11 @@ const CHILD_MAIN_FILE = `${__dirname}/child/main.js`
 //    (for both security and safety reasons)
 //  - logs can be buffered which allows manipulating them for log shipping,
 //    secrets redacting and parallel plugins
-const startPlugins = function({ pluginsOptions, buildDir, nodePath, childEnv }) {
+const startPlugins = function ({ pluginsOptions, buildDir, nodePath, childEnv }) {
   return Promise.all(pluginsOptions.map(() => startPlugin({ buildDir, nodePath, childEnv })))
 }
 
-const startPlugin = async function({ buildDir, nodePath, childEnv }) {
+const startPlugin = async function ({ buildDir, nodePath, childEnv }) {
   const childProcess = execa.node(CHILD_MAIN_FILE, {
     cwd: buildDir,
     preferLocal: true,
@@ -28,11 +28,11 @@ const startPlugin = async function({ buildDir, nodePath, childEnv }) {
 }
 
 // Stop all plugins child processes
-const stopPlugins = async function(childProcesses) {
+const stopPlugins = async function (childProcesses) {
   await Promise.all(childProcesses.map(stopPlugin))
 }
 
-const stopPlugin = async function({ childProcess }) {
+const stopPlugin = async function ({ childProcess }) {
   if (childProcess.connected) {
     childProcess.disconnect()
   }

--- a/packages/build/src/plugins_core/cache/plugin.js
+++ b/packages/build/src/plugins_core/cache/plugin.js
@@ -17,7 +17,7 @@ const cachePlugin = {
 }
 
 // Cache a single directory
-const saveCache = async function(path, digests, cache) {
+const saveCache = async function (path, digests, cache) {
   // In tests we don't run caching since it is slow and make source directory
   // much bigger
   if (TEST_CACHE_PATH !== undefined && TEST_CACHE_PATH !== path) {

--- a/packages/build/src/plugins_core/functions/plugin.js
+++ b/packages/build/src/plugins_core/functions/plugin.js
@@ -6,7 +6,7 @@ const { installFunctionDependencies } = require('../../install/functions')
 const { serializeList } = require('../../utils/list')
 
 // Plugin to package Netlify functions with @netlify/zip-it-and-ship-it
-const functionsPlugins = function(inputs, { constants: { FUNCTIONS_SRC } }) {
+const functionsPlugins = function (inputs, { constants: { FUNCTIONS_SRC } }) {
   // When `config.build.functions` is not defined, it means users does not use
   // Netlify Functions. However when it is defined but points to a non-existing
   // directory, this might mean the directory is created later one, so we cannot
@@ -18,7 +18,7 @@ const functionsPlugins = function(inputs, { constants: { FUNCTIONS_SRC } }) {
   return { onPreBuild, onPostBuild }
 }
 
-const onPreBuild = async function({ constants: { FUNCTIONS_SRC } }) {
+const onPreBuild = async function ({ constants: { FUNCTIONS_SRC } }) {
   if (!(await pathExists(FUNCTIONS_SRC))) {
     return
   }
@@ -27,7 +27,7 @@ const onPreBuild = async function({ constants: { FUNCTIONS_SRC } }) {
 }
 
 // Package Netlify functions
-const onPostBuild = async function({ constants: { FUNCTIONS_SRC, FUNCTIONS_DIST } }) {
+const onPostBuild = async function ({ constants: { FUNCTIONS_SRC, FUNCTIONS_DIST } }) {
   if (!(await pathExists(FUNCTIONS_SRC))) {
     return
   }
@@ -39,7 +39,7 @@ const onPostBuild = async function({ constants: { FUNCTIONS_SRC, FUNCTIONS_DIST 
 }
 
 // Print the list of paths to the packaged functions
-const logResults = async function(FUNCTIONS_DIST) {
+const logResults = async function (FUNCTIONS_DIST) {
   const files = await readdirp.promise(FUNCTIONS_DIST)
 
   if (files.length === 0) {
@@ -52,7 +52,7 @@ const logResults = async function(FUNCTIONS_DIST) {
 ${serializeList(paths)}`)
 }
 
-const getLoggedPath = function({ path }) {
+const getLoggedPath = function ({ path }) {
   return path
 }
 

--- a/packages/build/src/telemetry/complete.js
+++ b/packages/build/src/telemetry/complete.js
@@ -9,13 +9,13 @@ const isNetlifyCI = require('../utils/is-netlify-ci')
 const { telemetry } = require('./track')
 
 // Send telemetry request when build completes
-const trackBuildComplete = async function({ commandsCount, netlifyConfig, duration, siteInfo }) {
+const trackBuildComplete = async function ({ commandsCount, netlifyConfig, duration, siteInfo }) {
   const payload = getPayload({ commandsCount, netlifyConfig, duration, siteInfo })
   await telemetry.track('netlifyCI:buildComplete', payload)
 }
 
 // Retrieve telemetry information
-const getPayload = function({ commandsCount, netlifyConfig, duration, siteInfo: { id: siteId } }) {
+const getPayload = function ({ commandsCount, netlifyConfig, duration, siteInfo: { id: siteId } }) {
   const plugins = Object.values(netlifyConfig.plugins).map(getPluginPackage)
   return {
     steps: commandsCount,
@@ -32,7 +32,7 @@ const getPayload = function({ commandsCount, netlifyConfig, duration, siteInfo: 
   }
 }
 
-const getPluginPackage = function({ package }) {
+const getPluginPackage = function ({ package }) {
   return package
 }
 

--- a/packages/build/src/telemetry/request.js
+++ b/packages/build/src/telemetry/request.js
@@ -8,7 +8,7 @@ const got = require('got')
 const { version } = require('../../package.json')
 
 // Send HTTP request to telemetry.
-const sendRequest = async function() {
+const sendRequest = async function () {
   const json = JSON.parse(argv[2])
   await got({ ...GOT_OPTS, json: true, body: json })
 }

--- a/packages/build/src/telemetry/track.js
+++ b/packages/build/src/telemetry/track.js
@@ -11,7 +11,7 @@ const REQUEST_FILE = `${__dirname}/request.js`
 // Send HTTP request to telemetry.
 // Telemetry should not impact build speed, so we do not wait for the request
 // to complete, by using a child process.
-const track = async function({ payload }) {
+const track = async function ({ payload }) {
   if (BUILD_TELEMETRY_DISABLED) {
     return
   }

--- a/packages/build/src/utils/is-netlify-ci.js
+++ b/packages/build/src/utils/is-netlify-ci.js
@@ -3,7 +3,7 @@ const {
 } = require('process')
 
 // Check if inside Netlify Build CI
-const isNetlifyCI = function() {
+const isNetlifyCI = function () {
   return Boolean(NETLIFY)
 }
 

--- a/packages/build/src/utils/list.js
+++ b/packages/build/src/utils/list.js
@@ -2,11 +2,11 @@
 //  - 1
 //  - 2
 //  - 3
-const serializeList = function(array) {
+const serializeList = function (array) {
   return array.map(addDash).join('\n')
 }
 
-const addDash = function(string) {
+const addDash = function (string) {
   return ` - ${string}`
 }
 

--- a/packages/build/src/utils/remove_falsy.js
+++ b/packages/build/src/utils/remove_falsy.js
@@ -1,11 +1,11 @@
 const filterObj = require('filter-obj')
 
 // Remove falsy values from object
-const removeFalsy = function(obj) {
+const removeFalsy = function (obj) {
   return filterObj(obj, isDefined)
 }
 
-const isDefined = function(key, value) {
+const isDefined = function (key, value) {
   return value !== undefined && value !== ''
 }
 

--- a/packages/build/tests/core/telemetry/tests.js
+++ b/packages/build/tests/core/telemetry/tests.js
@@ -4,11 +4,11 @@ const { runFixture } = require('../../helpers/main')
 const { startServer } = require('../../helpers/server.js')
 
 // Normalize telemetry request so it can be snapshot
-const normalizeSnapshot = function({ body, ...request }) {
+const normalizeSnapshot = function ({ body, ...request }) {
   return { ...request, body: normalizeBody(body) }
 }
 
-const normalizeBody = function({
+const normalizeBody = function ({
   anonymousId,
   meta: { timestamp, ...meta } = {},
   properties: { duration, isCI, buildVersion, nodeVersion, osPlatform, osName, ...properties } = {},

--- a/packages/build/tests/error/build/fixtures/cancel_error_option/plugin.js
+++ b/packages/build/tests/error/build/fixtures/cancel_error_option/plugin.js
@@ -1,4 +1,4 @@
-const getError = function() {
+const getError = function () {
   return new Error('innerTest')
 }
 

--- a/packages/build/tests/error/build/fixtures/fail_build_error_option/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_build_error_option/plugin.js
@@ -1,4 +1,4 @@
-const getError = function() {
+const getError = function () {
   return new Error('innerTest')
 }
 

--- a/packages/build/tests/error/build/fixtures/fail_plugin_error_option/plugin.js
+++ b/packages/build/tests/error/build/fixtures/fail_plugin_error_option/plugin.js
@@ -1,4 +1,4 @@
-const getError = function() {
+const getError = function () {
   return new Error('innerTest')
 }
 

--- a/packages/build/tests/error/clean_stack/tests.js
+++ b/packages/build/tests/error/clean_stack/tests.js
@@ -28,11 +28,11 @@ test('Clean stack traces of config validation', async t => {
   t.is(count, 0)
 })
 
-const getStackLinesCount = function(stdout) {
+const getStackLinesCount = function (stdout) {
   return stdout.split('\n').filter(isStackLine).length
 }
 
-const isStackLine = function(line) {
+const isStackLine = function (line) {
   return line.trim().startsWith('at ')
 }
 

--- a/packages/build/tests/error/plugin_load/fixtures/top/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/top/plugin.js
@@ -1,6 +1,6 @@
 module.exports = {}
 
-const throwError = function() {
+const throwError = function () {
   throw new Error('test')
 }
 

--- a/packages/build/tests/error/plugin_load/fixtures/unhandled_promise/plugin.js
+++ b/packages/build/tests/error/plugin_load/fixtures/unhandled_promise/plugin.js
@@ -10,6 +10,6 @@ module.exports = {
   },
 }
 
-const unhandledPromise = async function() {
+const unhandledPromise = async function () {
   throw new Error('test')
 }

--- a/packages/build/tests/error/stack/fixtures/lifecycle_stack/onBuild.js
+++ b/packages/build/tests/error/stack/fixtures/lifecycle_stack/onBuild.js
@@ -1,4 +1,4 @@
-const test = function() {
+const test = function () {
   console.log(new Error('test'))
   process.exit(2)
 }

--- a/packages/build/tests/error/stack/fixtures/plugin_load/plugin.js
+++ b/packages/build/tests/error/stack/fixtures/plugin_load/plugin.js
@@ -1,4 +1,4 @@
-const test = function() {
+const test = function () {
   throw new Error('test')
 }
 

--- a/packages/build/tests/helpers/dir.js
+++ b/packages/build/tests/helpers/dir.js
@@ -5,13 +5,13 @@ const { getTempDir } = require('./temp')
 
 // Create a temporary directory with a `.git` directory, which can be used as
 // the current directory of a build. Otherwise the `git` utility does not load.
-const createRepoDir = async function({ git = true } = {}) {
+const createRepoDir = async function ({ git = true } = {}) {
   const cwd = await getTempDir()
   await createGit(cwd, git)
   return cwd
 }
 
-const createGit = async function(cwd, git) {
+const createGit = async function (cwd, git) {
   if (!git) {
     return
   }
@@ -27,7 +27,7 @@ const createGit = async function(cwd, git) {
 // Removing a directory sometimes fails on Windows in CI due to Windows
 // directory locking.
 // This results in `EBUSY: resource busy or locked, rmdir /path/to/dir`
-const removeDir = async function(dir) {
+const removeDir = async function (dir) {
   try {
     await del(dir, { force: true })
     // eslint-disable-next-line no-empty

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -35,7 +35,7 @@ const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
 //  - `copyRoot.git` {boolean}: whether the copied directory should have a `.git`
 //    Default: true
 //  - `copyRoot.branch` {string}: create a git branch after copy
-const runFixture = async function(
+const runFixture = async function (
   t,
   fixtureName,
   {
@@ -72,7 +72,7 @@ const runFixture = async function(
 }
 
 // Same with @netlify/config
-const runFixtureConfig = function(t, fixtureName, opts) {
+const runFixtureConfig = function (t, fixtureName, opts) {
   return runFixture(t, fixtureName, { ...opts, type: 'config' })
 }
 
@@ -107,7 +107,7 @@ const TIMEOUT = 6e5
 
 // The `repositoryRoot` flag can be overriden, but defaults to the fixture
 // directory
-const getRepositoryRootFlag = function({ fixtureName, copyRootDir, repositoryRoot }) {
+const getRepositoryRootFlag = function ({ fixtureName, copyRootDir, repositoryRoot }) {
   if (fixtureName === '') {
     return ''
   }
@@ -119,7 +119,7 @@ const getRepositoryRootFlag = function({ fixtureName, copyRootDir, repositoryRoo
   return `--repositoryRoot=${normalize(repositoryRoot)}`
 }
 
-const getCopyRootDir = function({ copyRoot, copyRoot: { git } = {} }) {
+const getCopyRootDir = function ({ copyRoot, copyRoot: { git } = {} }) {
   if (copyRoot === undefined) {
     return
   }
@@ -127,7 +127,7 @@ const getCopyRootDir = function({ copyRoot, copyRoot: { git } = {} }) {
   return createRepoDir({ git })
 }
 
-const runCommand = async function({
+const runCommand = async function ({
   binaryPath,
   repositoryRootFlag,
   flags,
@@ -156,7 +156,7 @@ const runCommand = async function({
   }
 }
 
-const execCommand = function({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv }) {
+const execCommand = function ({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv }) {
   return execa.command(`${binaryPath} ${repositoryRootFlag} ${flags}`, {
     all: isPrint && snapshot,
     reject: false,
@@ -168,7 +168,7 @@ const execCommand = function({ binaryPath, repositoryRootFlag, flags, isPrint, s
 // The `PRINT` environment variable can be set to `1` to run the test in print
 // mode. Print mode is a debugging mode which shows the test output but does
 // not create nor compare its snapshot.
-const doTestAction = function({ t, type, stdout, stderr, all, isPrint, normalize = !isPrint, snapshot }) {
+const doTestAction = function ({ t, type, stdout, stderr, all, isPrint, normalize = !isPrint, snapshot }) {
   if (!snapshot) {
     return
   }
@@ -192,7 +192,7 @@ const doTestAction = function({ t, type, stdout, stderr, all, isPrint, normalize
   t.snapshot(allB)
 }
 
-const normalizeOutputString = function(outputString, type, normalize) {
+const normalizeOutputString = function (outputString, type, normalize) {
   if (!normalize) {
     return outputString
   }
@@ -200,7 +200,7 @@ const normalizeOutputString = function(outputString, type, normalize) {
   return normalizeOutput(outputString, type)
 }
 
-const printOutput = function(t, all) {
+const printOutput = function (t, all) {
   console.log(`
 ${magentaBright.bold(`${LINE}
   ${t.title}
@@ -212,7 +212,7 @@ ${all}`)
 
 const LINE = '='.repeat(50)
 
-const shouldIgnoreSnapshot = function(all) {
+const shouldIgnoreSnapshot = function (all) {
   return IGNORE_REGEXPS.some(regExp => regExp.test(all))
 }
 
@@ -223,12 +223,12 @@ const IGNORE_REGEXPS = [
 
 // Get an CLI flag whose value is a JSON object, to be passed to `execa.command()`
 // Used for example by --defaultConfig and --cachedConfig.
-const getJsonOpt = function(object) {
+const getJsonOpt = function (object) {
   return escapeExecaOpt(JSON.stringify(object))
 }
 
 // Escape CLI flag value that might contain a space
-const escapeExecaOpt = function(string) {
+const escapeExecaOpt = function (string) {
   return string.replace(EXECA_COMMAND_REGEXP, '\\ ')
 }
 

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -2,12 +2,12 @@ const stripAnsi = require('strip-ansi')
 const { tick, pointer, arrowDown } = require('figures')
 
 // Normalize log output so it can be snapshot consistently across test runs
-const normalizeOutput = function(output, type) {
+const normalizeOutput = function (output, type) {
   const outputA = stripAnsi(output)
   return NORMALIZE_REGEXPS[type].reduce(replaceOutput, outputA)
 }
 
-const replaceOutput = function(output, [regExp, replacement]) {
+const replaceOutput = function (output, [regExp, replacement]) {
   return output.replace(regExp, replacement)
 }
 

--- a/packages/build/tests/helpers/server.js
+++ b/packages/build/tests/helpers/server.js
@@ -4,7 +4,7 @@ const { promisify } = require('util')
 // Start an HTTP server to mock API calls (telemetry server and Bitballoon)
 // Tests are using child processes, so we cannot use `nock` or similar library
 // that relies on monkey-patching global variables.
-const startServer = async function(path, response = {}) {
+const startServer = async function (path, response = {}) {
   const request = { sent: false, headers: {}, body: {} }
   const server = createServer((req, res) => requestHandler({ req, res, request, response, path }))
   await promisify(server.listen.bind(server))(0)
@@ -15,12 +15,12 @@ const startServer = async function(path, response = {}) {
   return { scheme: 'http', host, request, stopServer }
 }
 
-const getHost = function(server) {
+const getHost = function (server) {
   const port = server.address().port
   return `localhost:${port}`
 }
 
-const requestHandler = function({ req, res, request, response, path }) {
+const requestHandler = function ({ req, res, request, response, path }) {
   let rawBody = ''
   req.on('data', data => {
     rawBody += data.toString()
@@ -30,13 +30,13 @@ const requestHandler = function({ req, res, request, response, path }) {
   })
 }
 
-const onRequestEnd = function({ req: { method, url, headers }, res, request, response, path, rawBody }) {
+const onRequestEnd = function ({ req: { method, url, headers }, res, request, response, path, rawBody }) {
   addRequestInfo({ method, url, headers, request, path, rawBody })
   res.setHeader('Content-Type', 'application/json')
   res.end(JSON.stringify(response))
 }
 
-const addRequestInfo = function({ method, url, headers, request, path, rawBody }) {
+const addRequestInfo = function ({ method, url, headers, request, path, rawBody }) {
   if (url !== path) {
     return
   }
@@ -46,7 +46,7 @@ const addRequestInfo = function({ method, url, headers, request, path, rawBody }
   Object.assign(request, { sent: true, method, headers: headersA, body })
 }
 
-const parseBody = function(rawBody) {
+const parseBody = function (rawBody) {
   try {
     return JSON.parse(rawBody)
   } catch (error) {

--- a/packages/build/tests/helpers/temp.js
+++ b/packages/build/tests/helpers/temp.js
@@ -11,7 +11,7 @@ const cpFile = require('cp-file')
 const pRealpath = promisify(realpath)
 
 // Copy a file to a temporary one
-const copyToTemp = async function(path) {
+const copyToTemp = async function (path) {
   const filename = basename(path)
   const tempDir = await getTempDir()
   const tempFile = normalize(`${tempDir}/${filename}`)
@@ -20,7 +20,7 @@ const copyToTemp = async function(path) {
 }
 
 // Create and retrieve a new temporary sub-directory
-const getTempDir = async function() {
+const getTempDir = async function () {
   const id = String(Math.random()).replace('.', '')
   const tempDir = normalize(`${tmpdir()}/netlify-build-${id}`)
   await makeDir(tempDir)

--- a/packages/build/tests/utils/cache/fixtures/defined/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/defined/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onInit({ utils: { cache } }) {
-    console.log(
-      Object.keys(cache)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(cache).sort().join(' '))
   },
 }

--- a/packages/build/tests/utils/cache/fixtures/hash_big/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash_big/plugin.js
@@ -24,11 +24,11 @@ module.exports = {
   },
 }
 
-const makeFiles = function(dir) {
+const makeFiles = function (dir) {
   return Promise.all(Array.from({ length: 100 }, () => makeFile(dir)))
 }
 
-const makeFile = async function(dir) {
+const makeFile = async function (dir) {
   const id = String(Math.random()).replace('.', '')
   const content = 'a'.repeat(2e5)
   const path = `${dir}/${id}`

--- a/packages/build/tests/utils/cache/fixtures/hash_directory/plugin.js
+++ b/packages/build/tests/utils/cache/fixtures/hash_directory/plugin.js
@@ -24,11 +24,11 @@ module.exports = {
   },
 }
 
-const makeFiles = function(dir) {
+const makeFiles = function (dir) {
   return Promise.all(Array.from({ length: 100 }, () => makeFile(dir)))
 }
 
-const makeFile = async function(dir) {
+const makeFile = async function (dir) {
   const id = String(Math.random()).replace('.', '')
   const path = `${dir}/${id}`
   await pWriteFile(path, id)

--- a/packages/build/tests/utils/git/fixtures/defined/plugin.js
+++ b/packages/build/tests/utils/git/fixtures/defined/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onInit({ utils: { git } }) {
-    console.log(
-      Object.keys(git)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(git).sort().join(' '))
   },
 }

--- a/packages/build/tests/utils/load/fixtures/function_async/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/function_async/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onInit({ utils: { git } }) {
-    console.log(
-      Object.keys(git)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(git).sort().join(' '))
   },
 }

--- a/packages/build/tests/utils/load/fixtures/function_sync/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/function_sync/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onInit({ utils: { cache } }) {
-    console.log(
-      Object.keys(cache)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(cache).sort().join(' '))
   },
 }

--- a/packages/build/tests/utils/load/fixtures/none/plugin.js
+++ b/packages/build/tests/utils/load/fixtures/none/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onInit({ utils }) {
-    console.log(
-      Object.keys(utils)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(utils).sort().join(' '))
   },
 }

--- a/packages/build/tests/utils/run/fixtures/defined/plugin.js
+++ b/packages/build/tests/utils/run/fixtures/defined/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onInit({ utils: { run } }) {
-    console.log(
-      Object.keys(run)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(run).sort().join(' '))
   },
 }

--- a/packages/cache-utils/src/ci.js
+++ b/packages/cache-utils/src/ci.js
@@ -3,7 +3,7 @@ const {
 } = require('process')
 
 // Check if inside Netlify Build CI
-const isNetlifyCI = function() {
+const isNetlifyCI = function () {
   return Boolean(NETLIFY)
 }
 

--- a/packages/cache-utils/src/dir.js
+++ b/packages/cache-utils/src/dir.js
@@ -8,7 +8,7 @@ const globalCacheDir = require('global-cache-dir')
 const { isNetlifyCI } = require('./ci')
 
 // Retrieve the cache directory location
-const getCacheDir = function() {
+const getCacheDir = function () {
   if (!isNetlifyCI()) {
     return LOCAL_CACHE_DIR
   }

--- a/packages/cache-utils/src/expire.js
+++ b/packages/cache-utils/src/expire.js
@@ -1,5 +1,5 @@
 // Retrieve the expiration date when caching a file
-const getExpires = function(ttl) {
+const getExpires = function (ttl) {
   if (!Number.isInteger(ttl) || ttl < 1) {
     return
   }
@@ -10,7 +10,7 @@ const getExpires = function(ttl) {
 const SECS_TO_MSECS = 1e3
 
 // Check if a file about to be restored is expired
-const checkExpires = function(expires) {
+const checkExpires = function (expires) {
   return expires !== undefined && Date.now() > expires
 }
 

--- a/packages/cache-utils/src/fs.js
+++ b/packages/cache-utils/src/fs.js
@@ -8,7 +8,7 @@ const moveFile = require('move-file')
 const pStat = promisify(stat)
 
 // Move or copy a cached file/directory from/to a local one
-const moveCacheFile = async function(src, dest, move) {
+const moveCacheFile = async function (src, dest, move) {
   // Moving is faster but removes the source files locally
   if (move) {
     return moveFile(src, dest, { overwrite: false })
@@ -18,7 +18,7 @@ const moveCacheFile = async function(src, dest, move) {
   return cpy(srcGlob, dirname(dest), { cwd: dirname(src), parents: true, overwrite: false })
 }
 
-const getSrcGlob = async function(src) {
+const getSrcGlob = async function (src) {
   const srcBasename = basename(src)
   const stat = await pStat(src)
 

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -7,20 +7,20 @@ const { BASES } = require('./path')
 const { isManifest } = require('./manifest')
 
 // List all cached files
-const list = async function() {
+const list = async function () {
   const cacheDir = await getCacheDir()
   const files = await Promise.all(BASES.map(baseInfo => listBase(baseInfo, cacheDir)))
   const filesA = files.flat()
   return filesA
 }
 
-const listBase = async function({ name, base }, cacheDir) {
+const listBase = async function ({ name, base }, cacheDir) {
   const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter })
   const filesA = files.map(({ path }) => join(base, path))
   return filesA
 }
 
-const fileFilter = function({ basename }) {
+const fileFilter = function ({ basename }) {
   return !isManifest(basename)
 }
 

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -8,7 +8,7 @@ const { getCacheDir } = require('./dir')
 const { list } = require('./list')
 
 // Cache a file
-const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [] } = {}) {
+const saveOne = async function (path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [] } = {}) {
   const { srcPath, cachePath, base } = await parsePath(path)
 
   if (!(await pathExists(srcPath))) {
@@ -28,7 +28,7 @@ const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, d
 }
 
 // Restore a cached file
-const restoreOne = async function(path, { move = DEFAULT_MOVE } = {}) {
+const restoreOne = async function (path, { move = DEFAULT_MOVE } = {}) {
   const { srcPath, cachePath } = await parsePath(path)
 
   if (!(await pathExists(cachePath))) {
@@ -46,7 +46,7 @@ const restoreOne = async function(path, { move = DEFAULT_MOVE } = {}) {
 }
 
 // Remove the cache of a file
-const removeOne = async function(path) {
+const removeOne = async function (path) {
   const { cachePath } = await parsePath(path)
 
   if (!(await pathExists(cachePath))) {
@@ -60,7 +60,7 @@ const removeOne = async function(path) {
 }
 
 // Check if a file is cached
-const hasOne = async function(path) {
+const hasOne = async function (path) {
   const { cachePath } = await parsePath(path)
 
   return (await pathExists(cachePath)) && !(await isExpired(cachePath))
@@ -71,7 +71,7 @@ const DEFAULT_TTL = undefined
 
 // Allow each of the main functions to take either a single path or an array of
 // paths as arguments
-const allowMany = async function(func, paths, ...args) {
+const allowMany = async function (func, paths, ...args) {
   if (!Array.isArray(paths)) {
     return func(paths, ...args)
   }

--- a/packages/cache-utils/src/manifest.js
+++ b/packages/cache-utils/src/manifest.js
@@ -12,7 +12,7 @@ const pReadFile = promisify(readFile)
 
 // Retrieve cache manifest of a file to cache, which contains the file/directory
 // contents hash and the `expires` date.
-const getManifestInfo = async function({ srcPath, cachePath, move, ttl, digests, base }) {
+const getManifestInfo = async function ({ srcPath, cachePath, move, ttl, digests, base }) {
   const manifestPath = getManifestPath(cachePath)
   const expires = getExpires(ttl)
   const hash = await getHash({ srcPath, move, digests, base })
@@ -23,7 +23,7 @@ const getManifestInfo = async function({ srcPath, cachePath, move, ttl, digests,
 }
 
 // Whether the cache manifest has changed
-const isIdentical = async function({ manifestPath, manifestString, move }) {
+const isIdentical = async function ({ manifestPath, manifestString, move }) {
   // Moving files is faster than computing hashes
   if (move) {
     return false
@@ -38,29 +38,29 @@ const isIdentical = async function({ manifestPath, manifestString, move }) {
 }
 
 // Persist the cache manifest to filesystem
-const writeManifest = async function({ manifestPath, manifestString }) {
+const writeManifest = async function ({ manifestPath, manifestString }) {
   await pWriteFile(manifestPath, manifestString)
 }
 
 // Remove the cache manifest from filesystem
-const removeManifest = async function(cachePath) {
+const removeManifest = async function (cachePath) {
   const manifestPath = getManifestPath(cachePath)
   await del(manifestPath, { force: true })
 }
 
 // Retrieve the cache manifest filepath
-const getManifestPath = function(cachePath) {
+const getManifestPath = function (cachePath) {
   return `${cachePath}${CACHE_EXTENSION}`
 }
 
-const isManifest = function(filePath) {
+const isManifest = function (filePath) {
   return filePath.endsWith(CACHE_EXTENSION)
 }
 
 const CACHE_EXTENSION = '.netlify.cache.json'
 
 // Check whether a file/directory is expired by checking its cache manifest
-const isExpired = async function(cachePath) {
+const isExpired = async function (cachePath) {
   const manifestPath = getManifestPath(cachePath)
   if (!(await pathExists(manifestPath))) {
     return false
@@ -70,7 +70,7 @@ const isExpired = async function(cachePath) {
   return checkExpires(expires)
 }
 
-const readManifest = async function(cachePath) {
+const readManifest = async function (cachePath) {
   const manifestPath = getManifestPath(cachePath)
   const manifestString = await pReadFile(manifestPath, 'utf8')
   const manifest = JSON.parse(manifestString)

--- a/packages/cache-utils/src/path.js
+++ b/packages/cache-utils/src/path.js
@@ -5,7 +5,7 @@ const { cwd } = require('process')
 const { getCacheDir } = require('./dir')
 
 // Find the paths of the file before/after caching
-const parsePath = async function(path) {
+const parsePath = async function (path) {
   const cacheDir = await getCacheDir()
 
   const { name, base, relPath } = findBase(path)
@@ -17,11 +17,11 @@ const parsePath = async function(path) {
 // The cached path is the path relative to the base which can be either the
 // current directory, the home directory or the root directory. Each is tried
 // in order.
-const findBase = function(path) {
+const findBase = function (path) {
   return BASES.map(({ name, base }) => parseBase(name, base, path)).find(isChildPath)
 }
 
-const parseBase = function(name, base, path) {
+const parseBase = function (name, base, path) {
   const relPath = relative(base, path)
   return { name, base, relPath }
 }
@@ -32,7 +32,7 @@ const BASES = [
   { name: 'root', base: normalize('/') },
 ]
 
-const isChildPath = function({ relPath }) {
+const isChildPath = function ({ relPath }) {
   return !relPath.startsWith('..') && relPath !== ''
 }
 

--- a/packages/config/src/bin/flags.js
+++ b/packages/config/src/bin/flags.js
@@ -2,11 +2,8 @@ const yargs = require('yargs')
 const filterObj = require('filter-obj')
 
 // Parse CLI flags
-const parseFlags = function() {
-  const flags = yargs
-    .options(FLAGS)
-    .usage(USAGE)
-    .parse()
+const parseFlags = function () {
+  const flags = yargs.options(FLAGS).usage(USAGE).parse()
   const flagsA = filterObj(flags, isUserFlag)
   return flagsA
 }
@@ -73,7 +70,7 @@ The result is printed as a JSON object on stdout with the following properties:
   - branch     {string}  Repository branch`
 
 // Remove `yargs`-specific options, shortcuts, dash-cased and aliases
-const isUserFlag = function(key, value) {
+const isUserFlag = function (key, value) {
   return value !== undefined && !INTERNAL_KEYS.includes(key) && key.length !== 1 && !key.includes('-')
 }
 

--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -9,7 +9,7 @@ const { isUserError } = require('../error')
 const { parseFlags } = require('./flags')
 
 // CLI entry point
-const runCli = async function() {
+const runCli = async function () {
   const flags = parseFlags()
 
   try {
@@ -21,13 +21,13 @@ const runCli = async function() {
 }
 
 // The result is printed as JSON on stdout on success (exit code 0)
-const handleCliSuccess = function(result) {
+const handleCliSuccess = function (result) {
   const resultJson = JSON.stringify(result, null, 2)
   console.log(resultJson)
   exit(0)
 }
 
-const handleCliError = function(error) {
+const handleCliError = function (error) {
   // Errors caused by users do not show stack traces and have exit code 1
   if (isUserError(error)) {
     console.error(error.message)

--- a/packages/config/src/build_dir.js
+++ b/packages/config/src/build_dir.js
@@ -5,7 +5,7 @@ const { resolve } = require('path')
 //  - `build.base`
 //  - `--repositoryRoot`
 //  - the current directory
-const getBuildDir = function(repositoryRoot, { build: { base = repositoryRoot } }) {
+const getBuildDir = function (repositoryRoot, { build: { base = repositoryRoot } }) {
   return resolve(repositoryRoot, base)
 }
 

--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -5,7 +5,7 @@ const { deepMerge } = require('./utils/merge')
 // Merge `config.context.{CONTEXT|BRANCH}.*` to `config.build.*`
 // CONTEXT is the `--context` CLI flag.
 // BRANCH is the `--branch` CLI flag.
-const mergeContext = function({ context: contextProps, ...config }, context, branch) {
+const mergeContext = function ({ context: contextProps, ...config }, context, branch) {
   if (!isPlainObj(contextProps)) {
     return config
   }

--- a/packages/config/src/env.js
+++ b/packages/config/src/env.js
@@ -6,22 +6,19 @@ const deepmerge = require('deepmerge')
 // Find all environment variables starting with `NETLIFY_CONFIG_*` and converts
 // them to camelcase options. For example `NETLIFY_CONFIG_FOO_BAR=1` becomes
 // `{ fooBar: 1 }`
-const addEnvVars = function(config) {
+const addEnvVars = function (config) {
   const envVars = Object.entries(env)
     .filter(isEnvOption)
     .map(([name, value]) => removePrefix(name, value, config))
   return deepmerge.all([...envVars, config])
 }
 
-const isEnvOption = function([name]) {
+const isEnvOption = function ([name]) {
   return name.startsWith(ENV_CONFIG_PREFIX)
 }
 
-const removePrefix = function(name, value, config) {
-  const nameA = name
-    .replace(ENV_CONFIG_PREFIX, '')
-    .toLowerCase()
-    .replace(/_/g, '.')
+const removePrefix = function (name, value, config) {
+  const nameA = name.replace(ENV_CONFIG_PREFIX, '').toLowerCase().replace(/_/g, '.')
   const nameB = fixLegacy(nameA, config)
   const valueA = coerceType(value)
   return set({}, nameB, valueA)
@@ -30,7 +27,7 @@ const removePrefix = function(name, value, config) {
 const ENV_CONFIG_PREFIX = 'NETLIFY_CONFIG_'
 
 // Allow environment variable options for any JSON types, not only strings
-const coerceType = function(value) {
+const coerceType = function (value) {
   try {
     return JSON.parse(value)
   } catch (error) {
@@ -42,7 +39,7 @@ const coerceType = function(value) {
 // both defined. However the buildbot passes the second one as an environment
 // variable. We switch it to the first one if needed to avoid this validation
 // error.
-const fixLegacy = function(name, config) {
+const fixLegacy = function (name, config) {
   if (name === 'build.lifecycle.onbuild' && config && config.build && config.build.command) {
     return 'build.command'
   }

--- a/packages/config/src/error.js
+++ b/packages/config/src/error.js
@@ -1,13 +1,13 @@
 // We distinguish between errors thrown intentionally and uncaught exceptions
 // (such as bugs) with a `type` property.
-const throwError = function(messageOrError, error) {
+const throwError = function (messageOrError, error) {
   const errorA = getError(messageOrError, error)
   errorA.type = USER_ERROR_TYPE
   throw errorA
 }
 
 // Can pass either `message`, `error` or `message, error`
-const getError = function(messageOrError, error) {
+const getError = function (messageOrError, error) {
   if (messageOrError instanceof Error) {
     return messageOrError
   }
@@ -21,7 +21,7 @@ const getError = function(messageOrError, error) {
 }
 
 // Check `error.type`
-const isUserError = function(error) {
+const isUserError = function (error) {
   return error instanceof Error && error.type === USER_ERROR_TYPE
 }
 

--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -1,14 +1,14 @@
 const { resolve } = require('path')
 
 // Make configuration paths relative to `buildDir`
-const handleFiles = function({ build, ...config }, buildDir) {
+const handleFiles = function ({ build, ...config }, buildDir) {
   const buildA = PROP_NAMES.reduce((build, propName) => normalizePath(build, propName, buildDir), build)
   return { ...config, build: buildA }
 }
 
 const PROP_NAMES = ['publish', 'functions']
 
-const normalizePath = function(build, propName, buildDir) {
+const normalizePath = function (build, propName, buildDir) {
   const path = build[propName]
 
   if (path === undefined) {

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -16,7 +16,7 @@ const { deepMerge } = require('./utils/merge')
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function({ cachedConfig, ...opts } = {}) {
+const resolveConfig = async function ({ cachedConfig, ...opts } = {}) {
   // Performance optimization when @netlify/config caller has already previously
   // called it and cached the result.
   // This is used by the buildbot which:
@@ -52,7 +52,7 @@ const resolveConfig = async function({ cachedConfig, ...opts } = {}) {
 
 // Load a configuration file passed as a JSON object.
 // The logic is much simpler: it does not normalize nor validate it.
-const getConfig = function(config, name) {
+const getConfig = function (config, name) {
   if (config === undefined) {
     return {}
   }
@@ -67,7 +67,7 @@ const getConfig = function(config, name) {
 // Try to load the configuration file in two passes.
 // The first pass uses the `defaultConfig`'s `build.base` (if defined).
 // The second pass uses the `build.base` from the first pass (if defined).
-const loadConfig = async function({
+const loadConfig = async function ({
   configOpt,
   cwd,
   context,
@@ -110,7 +110,7 @@ const loadConfig = async function({
 }
 
 // Load configuration file and normalize it, merge contexts, etc.
-const getFullConfig = async function({ configOpt, cwd, context, repositoryRoot, branch, defaultConfig, base }) {
+const getFullConfig = async function ({ configOpt, cwd, context, repositoryRoot, branch, defaultConfig, base }) {
   const configPath = await getConfigPath({ configOpt, cwd, repositoryRoot, base })
 
   try {

--- a/packages/config/src/normalize/events.js
+++ b/packages/config/src/normalize/events.js
@@ -81,7 +81,7 @@ const LEGACY_EVENTS = {
 }
 
 // `build.lifecycle.onEvent` can also be spelled `build.lifecycle.onevent`
-const normalizeEventHandler = function(eventHandler) {
+const normalizeEventHandler = function (eventHandler) {
   const normalizedEventHandler = EVENT_HANDLER_CASES[eventHandler.toLowerCase()]
   if (normalizedEventHandler === undefined) {
     return eventHandler
@@ -90,12 +90,12 @@ const normalizeEventHandler = function(eventHandler) {
   return normalizedEventHandler
 }
 
-const getEventHandlerCases = function() {
+const getEventHandlerCases = function () {
   const events = [...EVENTS, ...Object.keys(LEGACY_EVENTS)].map(getEventHandlerCase)
   return Object.assign({}, ...events)
 }
 
-const getEventHandlerCase = function(event) {
+const getEventHandlerCase = function (event) {
   return { [event.toLowerCase()]: event }
 }
 

--- a/packages/config/src/normalize/main.js
+++ b/packages/config/src/normalize/main.js
@@ -7,7 +7,7 @@ const { removeFalsy } = require('../utils/remove_falsy')
 const { LEGACY_EVENTS, normalizeEventHandler } = require('./events')
 
 // Normalize configuration object
-const normalizeConfig = function(config) {
+const normalizeConfig = function (config) {
   const { build, plugins, ...configA } = deepMerge(DEFAULT_CONFIG, config)
   const buildA = normalizeBuild(build)
   const pluginsA = plugins.map(normalizePlugin)
@@ -20,7 +20,7 @@ const DEFAULT_CONFIG = {
 }
 
 // Normalize `build` property
-const normalizeBuild = function({ command, lifecycle, ...build }) {
+const normalizeBuild = function ({ command, lifecycle, ...build }) {
   const lifecycleA = normalizeOnBuild(command, lifecycle)
   const lifecycleB = mapObj(lifecycleA, normalizeEvent)
   const lifecycleC = filterObj(lifecycleB, hasCommand)
@@ -28,7 +28,7 @@ const normalizeBuild = function({ command, lifecycle, ...build }) {
 }
 
 // `build.lifecycle.onBuild` was previously called `build.command`
-const normalizeOnBuild = function(command, { onBuild = command, ...lifecycle }) {
+const normalizeOnBuild = function (command, { onBuild = command, ...lifecycle }) {
   if (onBuild === undefined) {
     return lifecycle
   }
@@ -36,21 +36,21 @@ const normalizeOnBuild = function(command, { onBuild = command, ...lifecycle }) 
   return { ...lifecycle, onBuild }
 }
 
-const normalizeEvent = function(event, bashCommand) {
+const normalizeEvent = function (event, bashCommand) {
   const eventA = normalizeEventHandler(event)
   const eventB = LEGACY_EVENTS[eventA] === undefined ? eventA : LEGACY_EVENTS[eventA]
   return [eventB, bashCommand]
 }
 
 // Remove empty commands
-const hasCommand = function(event, bashCommand) {
+const hasCommand = function (event, bashCommand) {
   return bashCommand.trim() !== ''
 }
 
 // `plugins[*].package` was previously called `plugins[*].type`
 // Same with `plugins[*].config` renamed to `plugins[*].inputs`
 // TODO: remove after the Beta release since it's legacy
-const normalizePlugin = function({ type, package = type, config, inputs = config, ...plugin }) {
+const normalizePlugin = function ({ type, package = type, config, inputs = config, ...plugin }) {
   return removeFalsy({ ...plugin, package, inputs })
 }
 

--- a/packages/config/src/options/branch.js
+++ b/packages/config/src/options/branch.js
@@ -9,7 +9,7 @@ const execa = require('execa')
 //   - `BRANCH` environment variable
 //   - Running `git`
 //   - 'master' (fallback)
-const getBranch = async function({ branch, repositoryRoot }) {
+const getBranch = async function ({ branch, repositoryRoot }) {
   if (branch !== undefined) {
     return branch
   }
@@ -26,7 +26,7 @@ const getBranch = async function({ branch, repositoryRoot }) {
   return FALLBACK_BRANCH
 }
 
-const getGitBranch = async function(repositoryRoot) {
+const getGitBranch = async function (repositoryRoot) {
   try {
     const { stdout } = await execa.command('git rev-parse --abbrev-ref HEAD', { cwd: repositoryRoot })
     return stdout

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -13,7 +13,7 @@ const { getRepositoryRoot } = require('./repository_root')
 const { getBranch } = require('./branch')
 
 // Normalize options and assign default values
-const normalizeOpts = async function(opts) {
+const normalizeOpts = async function (opts) {
   const optsA = removeFalsy(opts)
   const optsB = { ...DEFAULT_CONFIG_OPTS, ...DEFAULT_OPTS, ...optsA }
 
@@ -50,13 +50,13 @@ const DEFAULT_CONFIG_OPTS =
     : {}
 
 // Verify that options point to existing paths
-const checkPaths = async function(opts) {
+const checkPaths = async function (opts) {
   await Promise.all(PATH_NAMES.map(pathName => checkPath(opts, pathName)))
 }
 
 const PATH_NAMES = ['cwd', 'repositoryRoot']
 
-const checkPath = async function(opts, pathName) {
+const checkPath = async function (opts, pathName) {
   const path = opts[pathName]
   if (!(await pathExists(path))) {
     throwError(`Option '${pathName}' points to a non-existing file`)

--- a/packages/config/src/options/repository_root.js
+++ b/packages/config/src/options/repository_root.js
@@ -6,7 +6,7 @@ const findUp = require('find-up')
 //  - `repositoryRoot` option
 //  - find a `.git` directory up from `cwd`
 //  - `cwd` (fallback)
-const getRepositoryRoot = async function({ repositoryRoot, cwd }) {
+const getRepositoryRoot = async function ({ repositoryRoot, cwd }) {
   if (repositoryRoot !== undefined) {
     return repositoryRoot
   }

--- a/packages/config/src/parse/main.js
+++ b/packages/config/src/parse/main.js
@@ -11,7 +11,7 @@ const { PARSERS } = require('./parsers')
 const pReadFile = promisify(readFile)
 
 // Load the configuration file and parse it (YAML/JSON/TOML)
-const parseConfig = async function(configPath) {
+const parseConfig = async function (configPath) {
   if (configPath === undefined) {
     return {}
   }
@@ -31,7 +31,7 @@ const parseConfig = async function(configPath) {
 }
 
 // Reach the configuration file's raw content
-const readConfig = async function(configPath) {
+const readConfig = async function (configPath) {
   try {
     return await pReadFile(configPath, 'utf8')
   } catch (error) {
@@ -40,7 +40,7 @@ const readConfig = async function(configPath) {
 }
 
 // Retrieve the syntax-specific function to parse the raw content
-const getParser = function(configPath) {
+const getParser = function (configPath) {
   const extension = extname(configPath).replace('.', '')
   const parser = PARSERS[extension]
 

--- a/packages/config/src/parse/parsers.js
+++ b/packages/config/src/parse/parsers.js
@@ -1,15 +1,15 @@
 const { load: loadYaml, JSON_SCHEMA } = require('js-yaml')
 const { parse: loadToml } = require('toml')
 
-const parseYaml = function(configString) {
+const parseYaml = function (configString) {
   return loadYaml(configString, { schema: JSON_SCHEMA, json: true })
 }
 
-const parseToml = function(configString) {
+const parseToml = function (configString) {
   return loadToml(configString)
 }
 
-const parseJson = function(configString) {
+const parseJson = function (configString) {
   return JSON.parse(configString)
 }
 

--- a/packages/config/src/path.js
+++ b/packages/config/src/path.js
@@ -11,7 +11,7 @@ const { throwError } = require('./error')
 //  - a `netlify.*` file in the `repositoryRoot/{base}`
 //  - a `netlify.*` file in the `repositoryRoot`
 //  - a `netlify.*` file in the current directory or any parent
-const getConfigPath = async function({ configOpt, cwd, repositoryRoot, base }) {
+const getConfigPath = async function ({ configOpt, cwd, repositoryRoot, base }) {
   if (configOpt !== undefined) {
     return resolve(cwd, configOpt)
   }
@@ -33,7 +33,7 @@ const getConfigPath = async function({ configOpt, cwd, repositoryRoot, base }) {
   return configPathB
 }
 
-const searchConfigFile = async function(cwd) {
+const searchConfigFile = async function (cwd) {
   const paths = FILENAMES.map(filename => resolve(cwd, filename))
   const pathsA = await pFilter(paths, pathExists)
 

--- a/packages/config/src/utils/is-netlify-ci.js
+++ b/packages/config/src/utils/is-netlify-ci.js
@@ -3,7 +3,7 @@ const {
 } = require('process')
 
 // Check if inside Netlify Build CI
-const isNetlifyCI = function() {
+const isNetlifyCI = function () {
   return Boolean(NETLIFY)
 }
 

--- a/packages/config/src/utils/merge.js
+++ b/packages/config/src/utils/merge.js
@@ -2,14 +2,14 @@ const deepmerge = require('deepmerge')
 const isPlainObj = require('is-plain-obj')
 
 // Deep merge utility for configuration objects
-const deepMerge = function(...values) {
+const deepMerge = function (...values) {
   const objects = values.filter(isPlainObj)
   return deepmerge.all(objects, { arrayMerge })
 }
 
 // By default `deepmerge` concatenates arrays. We use the `arrayMerge` option
 // to remove this behavior.
-const arrayMerge = function(arrayA, arrayB) {
+const arrayMerge = function (arrayA, arrayB) {
   return arrayB
 }
 

--- a/packages/config/src/utils/remove_falsy.js
+++ b/packages/config/src/utils/remove_falsy.js
@@ -1,11 +1,11 @@
 const filterObj = require('filter-obj')
 
 // Remove falsy values from object
-const removeFalsy = function(obj) {
+const removeFalsy = function (obj) {
   return filterObj(obj, isDefined)
 }
 
-const isDefined = function(key, value) {
+const isDefined = function (key, value) {
   return value !== undefined && value !== ''
 }
 

--- a/packages/config/src/validate/context.js
+++ b/packages/config/src/validate/context.js
@@ -1,11 +1,11 @@
 // `context.{context}.*` properties have the same validation as `build.*`
 // They need separate ones though since their property name is different and
 // so is their `example`.
-const addContextValidations = function(validations) {
+const addContextValidations = function (validations) {
   return validations.flatMap(validation => addContextValidation({ validation }))
 }
 
-const addContextValidation = function({ validation, validation: { property, example } }) {
+const addContextValidation = function ({ validation, validation: { property, example } }) {
   if (!property.startsWith(BUILD_PREFIX)) {
     return [validation]
   }
@@ -19,7 +19,7 @@ const BUILD_PREFIX = 'build.'
 const CONTEXT_PREFIX = 'context.*.'
 
 // Wrap `example` to return { context: { CONTEXT: ... } } instead of { build: ... }
-const getValidationExample = function(example, ...args) {
+const getValidationExample = function (example, ...args) {
   const { build } = example(...args)
   const context = args[3][1]
   return { context: { [context]: build } }

--- a/packages/config/src/validate/example.js
+++ b/packages/config/src/validate/example.js
@@ -3,7 +3,7 @@ const indentString = require('indent-string')
 const { red, green } = require('chalk')
 
 // Print invalid value and example netlify.yml
-const getExample = function({ value, parent, key, prevPath, example }) {
+const getExample = function ({ value, parent, key, prevPath, example }) {
   const exampleA = typeof example === 'function' ? example(value, key, parent, prevPath) : example
   return `
 ${red.bold('Invalid syntax')}
@@ -15,13 +15,13 @@ ${green.bold('Valid syntax')}
 ${indentString(serializeValue(exampleA), 2)}`
 }
 
-const getInvalidValue = function(value, prevPath) {
+const getInvalidValue = function (value, prevPath) {
   const invalidValue = prevPath.reverse().reduce(setInvalidValuePart, value)
   const invalidValueA = serializeValue(invalidValue)
   return invalidValueA
 }
 
-const setInvalidValuePart = function(value, part) {
+const setInvalidValuePart = function (value, part) {
   if (Number.isInteger(part)) {
     return [value]
   }
@@ -30,7 +30,7 @@ const setInvalidValuePart = function(value, part) {
   return value === undefined ? {} : { [part]: value }
 }
 
-const serializeValue = function(value) {
+const serializeValue = function (value) {
   return dump(value, { noRefs: true }).trim()
 }
 

--- a/packages/config/src/validate/helpers.js
+++ b/packages/config/src/validate/helpers.js
@@ -1,10 +1,10 @@
 const { normalize } = require('path')
 
-const isString = function(value) {
+const isString = function (value) {
   return typeof value === 'string'
 }
 
-const validProperties = function(
+const validProperties = function (
   propNames,
   // istanbul ignore next
   legacyPropNames = [],
@@ -17,11 +17,11 @@ ${propNames.map(propName => `  - ${propName}`).join('\n')}`,
   }
 }
 
-const checkValidProperty = function(value, propNames, mapper) {
+const checkValidProperty = function (value, propNames, mapper) {
   return Object.keys(value).every(propName => propNames.includes(mapper(propName)))
 }
 
-const deprecatedProperties = function(properties, getExample, mapper) {
+const deprecatedProperties = function (properties, getExample, mapper) {
   return {
     check(value, key) {
       return findDeprecatedProperty(properties, mapper(key)) === undefined
@@ -37,7 +37,7 @@ const deprecatedProperties = function(properties, getExample, mapper) {
   }
 }
 
-const findDeprecatedProperty = function(properties, key) {
+const findDeprecatedProperty = function (properties, key) {
   const newPropName = properties[key]
   if (newPropName === undefined) {
     return
@@ -45,13 +45,13 @@ const findDeprecatedProperty = function(properties, key) {
   return newPropName
 }
 
-const identity = function(value) {
+const identity = function (value) {
   return value
 }
 
 // Ensure paths specified by users in the configuration file are not targetting
 // files outside the repository root directory.
-const isInsideRoot = function(path) {
+const isInsideRoot = function (path) {
   return !normalize(path).startsWith('..')
 }
 
@@ -61,7 +61,7 @@ const insideRootCheck = {
 }
 
 // Used in examples to show how to fix the above check
-const removeParentDots = function(path) {
+const removeParentDots = function (path) {
   return normalize(path).replace(PARENT_DOTS_REGEXP, '')
 }
 

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -7,7 +7,7 @@ const { getExample } = require('./example')
 
 // Validate the configuration file.
 // Performed before normalization.
-const validateConfig = function(config) {
+const validateConfig = function (config) {
   try {
     VALIDATIONS.forEach(({ property, ...validation }) => {
       validateProperty(config, { ...validation, nextPath: property.split('.') })
@@ -18,7 +18,7 @@ const validateConfig = function(config) {
 }
 
 // Validate a single property in the configuration file.
-const validateProperty = function(
+const validateProperty = function (
   parent,
   {
     nextPath: [propName, nextPropName, ...nextPath],
@@ -61,7 +61,7 @@ const validateProperty = function(
   reportError({ prevPath, propPath, message, example, warn, value, key, parent })
 }
 
-const reportError = function({ prevPath, propPath, message, example, warn, value, key, parent }) {
+const reportError = function ({ prevPath, propPath, message, example, warn, value, key, parent }) {
   const messageA = typeof message === 'function' ? message(value, key, parent) : message
   const errorMessage = `Configuration property ${cyan.bold(propPath)} ${messageA}
 ${getExample({ value, parent, key, prevPath, example })}`
@@ -74,7 +74,7 @@ ${getExample({ value, parent, key, prevPath, example })}`
 }
 
 // Recurse over children (each part of the `property` array).
-const validateChild = function({ value, nextPropName, prevPath, nextPath, propPath, ...rest }) {
+const validateChild = function ({ value, nextPropName, prevPath, nextPath, propPath, ...rest }) {
   if (value === undefined) {
     return
   }
@@ -95,7 +95,7 @@ const validateChild = function({ value, nextPropName, prevPath, nextPath, propPa
 }
 
 // Can use * to recurse over array|object elements.
-const validateChildProp = function({ childProp, value, nextPath, propPath, prevPath, ...rest }) {
+const validateChildProp = function ({ childProp, value, nextPath, propPath, prevPath, ...rest }) {
   if (Array.isArray(value)) {
     const key = Number(childProp)
     return validateProperty(value, {
@@ -118,7 +118,7 @@ const validateChildProp = function({ childProp, value, nextPath, propPath, prevP
 
 // When `required` is `true`, property must be defined, unless its parent is
 // `undefined`. To make parent required, set its `required` to `true` as well.
-const checkRequired = function({ value, required, propPath, prevPath, example }) {
+const checkRequired = function ({ value, required, propPath, prevPath, example }) {
   // istanbul ignore else
   if (!required) {
     return

--- a/packages/functions-utils/src/main.js
+++ b/packages/functions-utils/src/main.js
@@ -9,11 +9,11 @@ const pStat = promisify(stat)
 
 // Add a Netlify Function file to the `functions` directory so it is processed
 // by `@netlify/plugin-functions-core`
-const functionsUtils = function({ constants: { FUNCTIONS_SRC }, failBuild }) {
+const functionsUtils = function ({ constants: { FUNCTIONS_SRC }, failBuild }) {
   return { add: add.bind(null, FUNCTIONS_SRC, failBuild) }
 }
 
-const add = async function(dist, src, failBuild) {
+const add = async function (dist, src, failBuild) {
   if (src === undefined) {
     failBuild('No function directory was specified')
   }
@@ -31,7 +31,7 @@ const add = async function(dist, src, failBuild) {
   await cpy(srcGlob, dist, { cwd: dirname(src), parents: true, overwrite: false })
 }
 
-const getSrcGlob = async function(src) {
+const getSrcGlob = async function (src) {
   const srcBasename = basename(src)
   const stat = await pStat(src)
 

--- a/packages/git-utils/src/commits.js
+++ b/packages/git-utils/src/commits.js
@@ -3,7 +3,7 @@ const { HEAD } = require('./refs')
 
 // Return information on each commit since the `base` commit, such as SHA,
 // parent commits, author, committer and commit message
-const getCommits = async function(base, cwd) {
+const getCommits = async function (base, cwd) {
   const stdout = await git(['log', `--pretty=format:${JSON.stringify(FORMAT_JSON)}`, `${base}...${HEAD}`], cwd)
   const commits = JSON.parse(`[${stdout.split('\n').join(',')}]`)
   return commits

--- a/packages/git-utils/src/diff.js
+++ b/packages/git-utils/src/diff.js
@@ -3,12 +3,9 @@ const { HEAD } = require('./refs')
 
 // Return the list of modified|created|deleted files according to git, between
 // the `base` commit and the `HEAD`
-const getDiffFiles = async function(base, cwd) {
+const getDiffFiles = async function (base, cwd) {
   const stdout = await git(['diff', '--name-status', '--no-renames', `${base}...${HEAD}`], cwd)
-  const files = stdout
-    .split('\n')
-    .map(getDiffFile)
-    .filter(Boolean)
+  const files = stdout.split('\n').map(getDiffFile).filter(Boolean)
 
   const modifiedFiles = getFilesByType(files, 'M')
   const createdFiles = getFilesByType(files, 'A')
@@ -17,7 +14,7 @@ const getDiffFiles = async function(base, cwd) {
 }
 
 // Parse each `git diff` line
-const getDiffFile = function(line) {
+const getDiffFile = function (line) {
   const result = DIFF_FILE_REGEXP.exec(line)
 
   // Happens for example when `base` is invalid
@@ -31,11 +28,11 @@ const getDiffFile = function(line) {
 
 const DIFF_FILE_REGEXP = /([ADM])\s+(.*)/
 
-const getFilesByType = function(files, type) {
+const getFilesByType = function (files, type) {
   return files.filter(file => file.type === type).map(getFilepath)
 }
 
-const getFilepath = function({ filepath }) {
+const getFilepath = function ({ filepath }) {
   return filepath
 }
 

--- a/packages/git-utils/src/exec.js
+++ b/packages/git-utils/src/exec.js
@@ -2,7 +2,7 @@ const execa = require('execa')
 const moize = require('moize').default
 
 // Fires the `git` binary. Memoized.
-const mGit = async function(args, cwd) {
+const mGit = async function (args, cwd) {
   const { stdout } = await execa('git', args, { cwd })
   return stdout
 }

--- a/packages/git-utils/src/main.js
+++ b/packages/git-utils/src/main.js
@@ -7,7 +7,7 @@ const { getLinesOfCode } = require('./stats')
 const { fileMatch } = require('./match')
 
 // Main entry point to the git utilities
-const getGitUtils = async function(
+const getGitUtils = async function (
   // istanbul ignore next
   { base, cwd = getCwd() } = {},
 ) {
@@ -21,7 +21,7 @@ const getGitUtils = async function(
   }
 }
 
-const getProperties = async function(base, cwd) {
+const getProperties = async function (base, cwd) {
   const [{ modifiedFiles, createdFiles, deletedFiles }, commits, linesOfCode] = await Promise.all([
     getDiffFiles(base, cwd),
     getCommits(base, cwd),
@@ -30,7 +30,7 @@ const getProperties = async function(base, cwd) {
   return { modifiedFiles, createdFiles, deletedFiles, commits, linesOfCode }
 }
 
-const addMethods = function(properties) {
+const addMethods = function (properties) {
   // During initialization, the git utility is not built yet since it is a Proxy
   // and the utility must be sent across processes, i.e. JSON-serializable.
   // Instead we only keep the error stack and build the Proxy now.
@@ -49,7 +49,7 @@ const addMethods = function(properties) {
 // we don't want to report any errors since the user might not use the utility.
 // However we still want to report errors when the user does use the utility.
 // We achieve this by using a Proxy.
-const getFakeGitUtils = function({ error }) {
+const getFakeGitUtils = function ({ error }) {
   return new Proxy(
     // We define those so that `Object.keys()` and similar methods still work
     {

--- a/packages/git-utils/src/match.js
+++ b/packages/git-utils/src/match.js
@@ -3,7 +3,7 @@ const mapObj = require('map-obj')
 
 // Return functions that return modified|created|deleted files filtered by a
 // globbing pattern
-const fileMatch = function({ modifiedFiles, createdFiles, deletedFiles }, ...patterns) {
+const fileMatch = function ({ modifiedFiles, createdFiles, deletedFiles }, ...patterns) {
   const matchFiles = {
     modified: modifiedFiles,
     created: createdFiles,

--- a/packages/git-utils/src/refs.js
+++ b/packages/git-utils/src/refs.js
@@ -9,13 +9,13 @@ const { git } = require('./exec')
 const HEAD = TEST_HEAD === undefined ? 'HEAD' : TEST_HEAD
 
 // Retrieve the `base` commit
-const getBase = async function(base, cwd) {
+const getBase = async function (base, cwd) {
   const refs = getBaseRefs(base)
   const { ref } = await findRef(refs, cwd)
   return ref
 }
 
-const getBaseRefs = function(base) {
+const getBaseRefs = function (base) {
   // istanbul ignore next
   if (base !== undefined) {
     return [base]
@@ -35,7 +35,7 @@ const getBaseRefs = function(base) {
 const DEFAULT_BASE = ['master', `${HEAD}^`, HEAD]
 
 // Use the first commit that exists
-const findRef = async function(refs, cwd) {
+const findRef = async function (refs, cwd) {
   const results = await Promise.all(refs.map(ref => checkRef(ref, cwd)))
   const result = results.find(refExists)
   if (result === undefined) {
@@ -45,7 +45,7 @@ const findRef = async function(refs, cwd) {
   return result
 }
 
-const checkRef = async function(ref, cwd) {
+const checkRef = async function (ref, cwd) {
   try {
     await git(['rev-parse', ref], cwd)
     return { ref }
@@ -54,11 +54,11 @@ const checkRef = async function(ref, cwd) {
   }
 }
 
-const refExists = function({ error }) {
+const refExists = function ({ error }) {
   return error === undefined
 }
 
-const getErrorMessage = function({ ref, error: { message, stderr } }) {
+const getErrorMessage = function ({ ref, error: { message, stderr } }) {
   const messages = [message, stderr].filter(Boolean).join('\n')
   return `Invalid base commit ${ref}\n${messages}`
 }

--- a/packages/git-utils/src/stats.js
+++ b/packages/git-utils/src/stats.js
@@ -3,14 +3,14 @@ const { HEAD } = require('./refs')
 
 // Returns the number of lines of code added, removed or modified since the
 // `base` commit
-const getLinesOfCode = async function(base, cwd) {
+const getLinesOfCode = async function (base, cwd) {
   const stdout = await git(['diff', '--shortstat', `${base}...${HEAD}`], cwd)
   const insertions = parseStdout(stdout, INSERTION_REGEXP)
   const deletions = parseStdout(stdout, DELETION_REGEXP)
   return insertions + deletions
 }
 
-const parseStdout = function(stdout, regexp) {
+const parseStdout = function (stdout, regexp) {
   const result = regexp.exec(stdout)
 
   if (result === null) {

--- a/packages/run-utils/src/main.js
+++ b/packages/run-utils/src/main.js
@@ -1,7 +1,7 @@
 const execa = require('execa')
 
 // Run a command, with arguments being an array
-const run = function(file, args, options) {
+const run = function (file, args, options) {
   const [argsA, optionsA] = parseArgs(args, options)
   const optionsB = { ...DEFAULT_OPTIONS, ...optionsA }
   const childProcess = execa(file, argsA, optionsB)
@@ -10,7 +10,7 @@ const run = function(file, args, options) {
 }
 
 // Run a command, with file + arguments being a single string
-const runCommand = function(command, options) {
+const runCommand = function (command, options) {
   const optionsA = { ...DEFAULT_OPTIONS, ...options }
   const childProcess = execa.command(command, optionsA)
   redirectOutput(childProcess, optionsA)
@@ -18,7 +18,7 @@ const runCommand = function(command, options) {
 }
 
 // Both `args` and `options` are optional
-const parseArgs = function(args, options) {
+const parseArgs = function (args, options) {
   if (Array.isArray(args)) {
     return [args, options]
   }
@@ -34,7 +34,7 @@ const parseArgs = function(args, options) {
 const DEFAULT_OPTIONS = { preferLocal: true }
 
 // Redirect output by default, unless specified otherwise
-const redirectOutput = function(childProcess, { stdio, stdout, stderr }) {
+const redirectOutput = function (childProcess, { stdio, stdout, stderr }) {
   if (stdio !== undefined || stdout !== undefined || stderr !== undefined) {
     return
   }

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -26,7 +26,7 @@ const config = {
           return `- [${name}](./packages/${pkg}) ${description} [npm link](https://www.npmjs.com/package/${name}).`
         })
         .join('\n')
-      return packages
+      return `${packages}\n`
     },
     PLUGINS() {
       const base = path.resolve('packages')


### PR DESCRIPTION
This upgrades Prettier to its new major version. [Prettier release notes](https://prettier.io/blog/2020/03/21/2.0.0.html).

Among the main change it that `function()` is not prettified as `function ()`. This creates most of the changes in this PR diff.