### PR TITLE
Fix Ava configuration

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -1,5 +1,5 @@
 export default {
-  files: ['packages/**/tests/*.js', 'packages/**/tests/**/tests.js'],
+  files: ['packages/**/tests/*.js', 'packages/**/tests/**/tests.js', 'packages/**/tests/*.js'],
   compileEnhancements: false,
   babel: false,
   verbose: true,


### PR DESCRIPTION
There are some pending PRs (#1042, #1043, #1044, #1045) which add some tests files in some of the packages of this monorepo. To support those, the Ava configuration needs to be updated to include those future tests.