### PR TITLE
Remove `istanbul ignore next` comments

### DIFF
--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -23,7 +23,6 @@ const getColorLevel = function() {
   }
 
   // In unit tests when using `PRINT` mode
-  // istanbul ignore next
   if (env.PRINT === '1') {
     return '1'
   }
@@ -37,13 +36,11 @@ const getColorLevel = function() {
   // we disable colors because ANSI sequences are a problem most of the time in
   // that case
   // We cannot test this since unit tests are never in an interactive terminal
-  // istanbul ignore else
   if (!isTTY) {
     return '0'
   }
 
   // Node <9.9.0 does not have `getColorDepth()`. Default to 16 colors then.
-  // istanbul ignore next
   if (getColorDepth === undefined) {
     return '1'
   }
@@ -51,7 +48,6 @@ const getColorLevel = function() {
   // Guess how many colors are supported, mostly based on environment variables
   // This allows using 256 colors or 16 million colors on terminals that
   // support it
-  // istanbul ignore next
   return DEPTH_TO_LEVEL[getColorDepth()]
 }
 

--- a/packages/build/src/log/redact.js
+++ b/packages/build/src/log/redact.js
@@ -5,7 +5,6 @@ const redactString = function(string) {
   return redactEnv.redact(string, secrets)
 }
 
-// istanbul ignore next
 const redactStream = function(stream) {
   return stream.pipe(replaceStream(secrets, '[secure]'))
 }

--- a/packages/build/src/log/stream.js
+++ b/packages/build/src/log/stream.js
@@ -43,7 +43,6 @@ const unpipeOutput = async function(childProcess) {
 // parent process.stdout|stderr yet.
 // TODO: find a more reliable way
 const waitForFlush = async function(stream) {
-  // istanbul ignore next
   while (stream._readableState.paused) {
     await pSetTimeout(1e3)
     stream.resume()

--- a/packages/build/src/plugins_core/cache/plugin.js
+++ b/packages/build/src/plugins_core/cache/plugin.js
@@ -26,7 +26,6 @@ const saveCache = async function(path, digests, cache) {
 
   const success = await cache.save(path, { move: isNetlifyCI(), digests })
 
-  // istanbul ignore else
   if (success) {
     logCacheDir(path)
   }

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -11,8 +11,7 @@ const CORE_PLUGINS = [
   // TODO: run only inside tests until integrated in the buildbot
   ...(TEST_CACHE_PATH !== undefined && TEST_CACHE_PATH !== 'none'
     ? [{ package: '@netlify/plugin-cache-core', location: CACHE_PLUGIN, core: true }]
-    : // istanbul ignore next
-      []),
+    : []),
 ]
 
 module.exports = { CORE_PLUGINS }

--- a/packages/cache-utils/src/dir.js
+++ b/packages/cache-utils/src/dir.js
@@ -13,7 +13,6 @@ const getCacheDir = function() {
     return LOCAL_CACHE_DIR
   }
 
-  // istanbul ignore next
   // Do not use in tests since /opt might not be writable by current user
   if (platform === 'linux' && TEST_CACHE_PATH === undefined) {
     return CI_CACHE_DIR

--- a/packages/cache-utils/src/hash.js
+++ b/packages/cache-utils/src/hash.js
@@ -109,7 +109,6 @@ const computeHash = async function(hashInfos) {
 
 // When hashing a directory, sort its files by path so the hash is stable.
 // The hashes are often already sorted, which is why we skip test coverage.
-// istanbul ignore next
 const comparePath = function(hashInfoA, hashInfoB) {
   if (hashInfoA.path > hashInfoB.path) {
     return 1

--- a/packages/config/src/validate/example.js
+++ b/packages/config/src/validate/example.js
@@ -26,7 +26,6 @@ const setInvalidValuePart = function(value, part) {
     return [value]
   }
 
-  // istanbul ignore next
   return value === undefined ? {} : { [part]: value }
 }
 

--- a/packages/config/src/validate/helpers.js
+++ b/packages/config/src/validate/helpers.js
@@ -4,12 +4,7 @@ const isString = function(value) {
   return typeof value === 'string'
 }
 
-const validProperties = function(
-  propNames,
-  // istanbul ignore next
-  legacyPropNames = [],
-  mapper = identity,
-) {
+const validProperties = function(propNames, legacyPropNames = [], mapper = identity) {
   return {
     check: value => checkValidProperty(value, [...propNames, ...legacyPropNames], mapper),
     message: `has unknown properties. Valid properties are:

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -119,13 +119,10 @@ const validateChildProp = function({ childProp, value, nextPath, propPath, prevP
 // When `required` is `true`, property must be defined, unless its parent is
 // `undefined`. To make parent required, set its `required` to `true` as well.
 const checkRequired = function({ value, required, propPath, prevPath, example }) {
-  // istanbul ignore else
   if (!required) {
     return
   }
 
-  // Not used yet
-  // istanbul ignore next
   throwError(`Configuration property ${cyan.bold(propPath)} is required.
 ${getExample({ value, prevPath, example })}`)
 }

--- a/packages/git-utils/src/main.js
+++ b/packages/git-utils/src/main.js
@@ -7,10 +7,7 @@ const { getLinesOfCode } = require('./stats')
 const { fileMatch } = require('./match')
 
 // Main entry point to the git utilities
-const getGitUtils = async function(
-  // istanbul ignore next
-  { base, cwd = getCwd() } = {},
-) {
+const getGitUtils = async function({ base, cwd = getCwd() } = {}) {
   try {
     const baseA = await getBase(base, cwd)
     const properties = await getProperties(baseA, cwd)

--- a/packages/git-utils/src/refs.js
+++ b/packages/git-utils/src/refs.js
@@ -5,7 +5,6 @@ const {
 const { git } = require('./exec')
 
 // `TEST_HEAD` is only used in unit tests
-// istanbul ignore next
 const HEAD = TEST_HEAD === undefined ? 'HEAD' : TEST_HEAD
 
 // Retrieve the `base` commit
@@ -16,17 +15,14 @@ const getBase = async function(base, cwd) {
 }
 
 const getBaseRefs = function(base) {
-  // istanbul ignore next
   if (base !== undefined) {
     return [base]
   }
 
-  // istanbul ignore else
   if (CACHED_COMMIT_REF) {
     return [CACHED_COMMIT_REF]
   }
 
-  // istanbul ignore next
   return DEFAULT_BASE
 }
 


### PR DESCRIPTION
This PR removes all `// istanbul ignore next` comments.

We use test coverage as a way to check which lines of codes are not tested. Using those comments defeats that purpose. Using those comments is only useful when test coverage is enforced to a specific threshold (which we don't do).

Let's be brave and see our true test coverage percentage :)