### PR TITLE
Refactor test utilities

### DIFF
--- a/packages/build/tests/core/config/tests.js
+++ b/packages/build/tests/core/config/tests.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 
-const { runFixture, runFixtureConfig, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../../helpers/main')
+const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
+const { runFixture: runFixtureConfig, getJsonOpt, escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 
 test('--cwd', async t => {
   await runFixture(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty` })

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -1,0 +1,203 @@
+require('log-process-errors/build/register/ava')
+
+const {
+  env: { PRINT },
+} = require('process')
+const { normalize } = require('path')
+
+const {
+  meta: { file: testFile },
+} = require('ava')
+const execa = require('execa')
+const { magentaBright } = require('chalk')
+const cpy = require('cpy')
+
+const { normalizeOutput } = require('./normalize')
+const { createRepoDir, removeDir } = require('./dir')
+
+const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
+
+// Run a CLI using a fixture directory, then snapshot the output.
+// Options:
+//  - `flags` {string[]}: CLI flags
+//  - `repositoryRoot` {string}: `--repositoryRoot` CLI flag
+//  - `env` {object}: environment variable
+//  - `normalize` {boolean}: whether to normalize output
+//  - `snapshot` {boolean}: whether to create a snapshot
+//  - `copyRoot` {object}: copy the fixture directory to a temporary directory
+//    This is useful so that no parent has a `.git` or `package.json`.
+//  - `copyRoot.git` {boolean}: whether the copied directory should have a `.git`
+//    Default: true
+//  - `copyRoot.branch` {string}: create a git branch after copy
+const runFixtureCommon = async function(
+  t,
+  fixtureName,
+  {
+    flags = '',
+    env: envOption,
+    normalize,
+    snapshot = true,
+    repositoryRoot = `${FIXTURES_DIR}/${fixtureName}`,
+    copyRoot,
+    binaryPath,
+  } = {},
+) {
+  const isPrint = PRINT === '1'
+  const FORCE_COLOR = isPrint ? '1' : ''
+  const commandEnv = { FORCE_COLOR, NETLIFY_BUILD_TEST: '1', ...envOption }
+  const copyRootDir = await getCopyRootDir({ copyRoot })
+  const repositoryRootFlag = getRepositoryRootFlag({ fixtureName, copyRoot, copyRootDir, repositoryRoot })
+  const { stdout, stderr, all, exitCode } = await runCommand({
+    binaryPath,
+    repositoryRootFlag,
+    flags,
+    isPrint,
+    snapshot,
+    commandEnv,
+    fixtureName,
+    copyRoot,
+    copyRootDir,
+  })
+
+  doTestAction({ t, stdout, stderr, all, isPrint, normalize, snapshot })
+
+  return { stdout, stderr, exitCode }
+}
+
+// 10 minutes timeout
+const TIMEOUT = 6e5
+
+// The `repositoryRoot` flag can be overriden, but defaults to the fixture
+// directory
+const getRepositoryRootFlag = function({ fixtureName, copyRoot: { cwd } = {}, copyRootDir, repositoryRoot }) {
+  if (fixtureName === '') {
+    return ''
+  }
+
+  if (copyRootDir === undefined) {
+    return `--repositoryRoot=${normalize(repositoryRoot)}`
+  }
+
+  if (cwd) {
+    return `--cwd=${normalize(copyRootDir)}`
+  }
+
+  return `--repositoryRoot=${normalize(copyRootDir)}`
+}
+
+const getCopyRootDir = function({ copyRoot, copyRoot: { git } = {} }) {
+  if (copyRoot === undefined) {
+    return
+  }
+
+  return createRepoDir({ git })
+}
+
+const runCommand = async function({
+  binaryPath,
+  repositoryRootFlag,
+  flags,
+  isPrint,
+  snapshot,
+  commandEnv,
+  fixtureName,
+  copyRoot,
+  copyRoot: { branch } = {},
+  copyRootDir,
+}) {
+  if (copyRoot === undefined) {
+    return execCommand({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv })
+  }
+
+  try {
+    await cpy('**', copyRootDir, { cwd: `${FIXTURES_DIR}/${fixtureName}`, parents: true })
+
+    if (branch !== undefined) {
+      await execa.command(`git checkout -b ${branch}`, { cwd: copyRootDir })
+    }
+
+    return await execCommand({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv })
+  } finally {
+    await removeDir(copyRootDir)
+  }
+}
+
+const execCommand = function({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv }) {
+  return execa.command(`${binaryPath} ${repositoryRootFlag} ${flags}`, {
+    all: isPrint && snapshot,
+    reject: false,
+    env: commandEnv,
+    timeout: TIMEOUT,
+  })
+}
+
+// The `PRINT` environment variable can be set to `1` to run the test in print
+// mode. Print mode is a debugging mode which shows the test output but does
+// not create nor compare its snapshot.
+const doTestAction = function({ t, stdout, stderr, all, isPrint, normalize = !isPrint, snapshot }) {
+  if (!snapshot) {
+    return
+  }
+
+  if (isPrint) {
+    const allA = normalizeOutputString(all, normalize)
+    return printOutput(t, allA)
+  }
+
+  const stdoutA = normalizeOutputString(stdout, normalize)
+  const stderrA = normalizeOutputString(stderr, normalize)
+  // stdout and stderr can be intertwined in a time-sensitive / race-condition
+  // manner otherwise
+  const allB = [stdoutA, stderrA].filter(Boolean).join('\n\n')
+
+  if (shouldIgnoreSnapshot(allB)) {
+    t.pass()
+    return
+  }
+
+  t.snapshot(allB)
+}
+
+const normalizeOutputString = function(outputString, normalize) {
+  if (!normalize) {
+    return outputString
+  }
+
+  return normalizeOutput(outputString)
+}
+
+const printOutput = function(t, all) {
+  console.log(`
+${magentaBright.bold(`${LINE}
+  ${t.title}
+${LINE}`)}
+
+${all}`)
+  t.pass()
+}
+
+const LINE = '='.repeat(50)
+
+const shouldIgnoreSnapshot = function(all) {
+  return IGNORE_REGEXPS.some(regExp => regExp.test(all))
+}
+
+const IGNORE_REGEXPS = [
+  // Some tests send network requests, which can sometimes fail
+  /getaddrinfo EAI_AGAIN/,
+]
+
+// Get an CLI flag whose value is a JSON object, to be passed to `execa.command()`
+// Used for example by --defaultConfig and --cachedConfig.
+const getJsonOpt = function(object) {
+  return escapeExecaOpt(JSON.stringify(object))
+}
+
+// Escape CLI flag value that might contain a space
+const escapeExecaOpt = function(string) {
+  return string.replace(EXECA_COMMAND_REGEXP, '\\ ')
+}
+
+const EXECA_COMMAND_REGEXP = / /g
+
+module.exports = { runFixtureCommon, FIXTURES_DIR, getJsonOpt, escapeExecaOpt }

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -1,243 +1,31 @@
-require('log-process-errors/build/register/ava')
+const { env } = require('process')
+const { delimiter } = require('path')
 
-const {
-  env,
-  env: { PRINT },
-} = require('process')
-const { normalize, delimiter } = require('path')
-
-const {
-  meta: { file: testFile },
-} = require('ava')
-const execa = require('execa')
 const { getBinPath } = require('get-bin-path')
-const { magentaBright } = require('chalk')
 const pathKey = require('path-key')
-const cpy = require('cpy')
 
-const PROJECTS_DIR = `${__dirname}/../../..`
-const BUILD_BIN_DIR = `${PROJECTS_DIR}/build/node_modules/.bin`
+const { runFixtureCommon, FIXTURES_DIR } = require('./common')
 
-const { normalizeOutput } = require('./normalize')
-const { createRepoDir, removeDir } = require('./dir')
+const ROOT_DIR = `${__dirname}/../..`
+const BUILD_BIN_DIR = `${ROOT_DIR}/node_modules/.bin`
 
-const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
-
-// Run the @netlify/build CLI using a fixture directory, then snapshot the output.
-// Options:
-//  - `flags` {string[]}: CLI flags
-//  - `repositoryRoot` {string}: `--repositoryRoot` CLI flag
-//  - `env` {object}: environment variable
-//  - `normalize` {boolean}: whether to normalize output
-//  - `snapshot` {boolean}: whether to create a snapshot
-//  - `copyRoot` {object}: copy the fixture directory to a temporary directory
-//    This is useful so that no parent has a `.git` or `package.json`.
-//  - `copyRoot.git` {boolean}: whether the copied directory should have a `.git`
-//    Default: true
-//  - `copyRoot.branch` {string}: create a git branch after copy
-//  - `copyRoot.cwd` {boolean}: whether the current directory should be changed
-//    to the temporary directory. Default: false
-const runFixture = async function(
-  t,
-  fixtureName,
-  {
-    type = 'build',
-    flags = '',
-    env: envOption,
-    normalize,
-    snapshot = true,
-    repositoryRoot = `${FIXTURES_DIR}/${fixtureName}`,
-    copyRoot,
-  } = {},
-) {
-  const isPrint = PRINT === '1'
-  const FORCE_COLOR = isPrint ? '1' : ''
-  const commandEnv = { ...DEFAULT_ENV[type], FORCE_COLOR, NETLIFY_BUILD_TEST: '1', ...envOption }
-  const copyRootDir = await getCopyRootDir({ copyRoot })
-  const repositoryRootFlag = getRepositoryRootFlag({ fixtureName, copyRoot, copyRootDir, repositoryRoot })
-  const binaryPath = await BINARY_PATH[type]
-  const { stdout, stderr, all, exitCode } = await runCommand({
-    binaryPath,
-    repositoryRootFlag,
-    flags,
-    isPrint,
-    snapshot,
-    commandEnv,
-    fixtureName,
-    copyRoot,
-    copyRootDir,
-  })
-
-  doTestAction({ t, type, stdout, stderr, all, isPrint, normalize, snapshot })
-
-  return { stdout, stderr, exitCode }
-}
-
-// Same with @netlify/config
-const runFixtureConfig = function(t, fixtureName, opts) {
-  return runFixture(t, fixtureName, { ...opts, type: 'config' })
-}
-
-// Each project has its own binary entry point
-const BUILD_BINARY_PATH = getBinPath({ cwd: `${PROJECTS_DIR}/build` })
-const CONFIG_BINARY_PATH = getBinPath({ cwd: `${PROJECTS_DIR}/config` })
-const BINARY_PATH = {
-  build: BUILD_BINARY_PATH,
-  config: CONFIG_BINARY_PATH,
-}
-
-// Each project has its own set of default environment variables
-const DEFAULT_ENV = {
-  build: {
-    NETLIFY_BUILD_DEBUG: '1',
-    // Workarounds to mock caching logic
-    TEST_CACHE_PATH: 'none',
-    // Ensure local tokens aren't used during development
-    NETLIFY_AUTH_TOKEN: '',
-    // Allows executing any locally installed Node modules inside tests,
-    // regardless of the current directory
-    [pathKey()]: `${env[pathKey()]}${delimiter}${BUILD_BIN_DIR}`,
-  },
-  config: {
-    // Make snapshot consistent regardless of the actual current git branch
-    BRANCH: 'branch',
-  },
-}
-
-// 10 minutes timeout
-const TIMEOUT = 6e5
-
-// The `repositoryRoot` flag can be overriden, but defaults to the fixture
-// directory
-const getRepositoryRootFlag = function({ fixtureName, copyRoot: { cwd } = {}, copyRootDir, repositoryRoot }) {
-  if (fixtureName === '') {
-    return ''
-  }
-
-  if (copyRootDir === undefined) {
-    return `--repositoryRoot=${normalize(repositoryRoot)}`
-  }
-
-  if (cwd) {
-    return `--cwd=${normalize(copyRootDir)}`
-  }
-
-  return `--repositoryRoot=${normalize(copyRootDir)}`
-}
-
-const getCopyRootDir = function({ copyRoot, copyRoot: { git } = {} }) {
-  if (copyRoot === undefined) {
-    return
-  }
-
-  return createRepoDir({ git })
-}
-
-const runCommand = async function({
-  binaryPath,
-  repositoryRootFlag,
-  flags,
-  isPrint,
-  snapshot,
-  commandEnv,
-  fixtureName,
-  copyRoot,
-  copyRoot: { branch } = {},
-  copyRootDir,
-}) {
-  if (copyRoot === undefined) {
-    return execCommand({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv })
-  }
-
-  try {
-    await cpy('**', copyRootDir, { cwd: `${FIXTURES_DIR}/${fixtureName}`, parents: true })
-
-    if (branch !== undefined) {
-      await execa.command(`git checkout -b ${branch}`, { cwd: copyRootDir })
-    }
-
-    return await execCommand({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv })
-  } finally {
-    await removeDir(copyRootDir)
-  }
-}
-
-const execCommand = function({ binaryPath, repositoryRootFlag, flags, isPrint, snapshot, commandEnv }) {
-  return execa.command(`${binaryPath} ${repositoryRootFlag} ${flags}`, {
-    all: isPrint && snapshot,
-    reject: false,
-    env: commandEnv,
-    timeout: TIMEOUT,
+const runFixture = async function(t, fixtureName, { env: envOption, ...opts } = {}) {
+  return runFixtureCommon(t, fixtureName, {
+    ...opts,
+    binaryPath: await BINARY_PATH,
+    env: {
+      NETLIFY_BUILD_DEBUG: '1',
+      // Workarounds to mock caching logic
+      TEST_CACHE_PATH: 'none',
+      // Ensure local tokens aren't used during development
+      NETLIFY_AUTH_TOKEN: '',
+      // Allows executing any locally installed Node modules inside tests,
+      // regardless of the current directory
+      [pathKey()]: `${env[pathKey()]}${delimiter}${BUILD_BIN_DIR}`,
+      ...envOption,
+    },
   })
 }
+const BINARY_PATH = getBinPath({ cwd: ROOT_DIR })
 
-// The `PRINT` environment variable can be set to `1` to run the test in print
-// mode. Print mode is a debugging mode which shows the test output but does
-// not create nor compare its snapshot.
-const doTestAction = function({ t, type, stdout, stderr, all, isPrint, normalize = !isPrint, snapshot }) {
-  if (!snapshot) {
-    return
-  }
-
-  if (isPrint) {
-    const allA = normalizeOutputString(all, type, normalize)
-    return printOutput(t, allA)
-  }
-
-  const stdoutA = normalizeOutputString(stdout, type, normalize)
-  const stderrA = normalizeOutputString(stderr, type, normalize)
-  // stdout and stderr can be intertwined in a time-sensitive / race-condition
-  // manner otherwise
-  const allB = [stdoutA, stderrA].filter(Boolean).join('\n\n')
-
-  if (shouldIgnoreSnapshot(allB)) {
-    t.pass()
-    return
-  }
-
-  t.snapshot(allB)
-}
-
-const normalizeOutputString = function(outputString, type, normalize) {
-  if (!normalize) {
-    return outputString
-  }
-
-  return normalizeOutput(outputString, type)
-}
-
-const printOutput = function(t, all) {
-  console.log(`
-${magentaBright.bold(`${LINE}
-  ${t.title}
-${LINE}`)}
-
-${all}`)
-  t.pass()
-}
-
-const LINE = '='.repeat(50)
-
-const shouldIgnoreSnapshot = function(all) {
-  return IGNORE_REGEXPS.some(regExp => regExp.test(all))
-}
-
-const IGNORE_REGEXPS = [
-  // Some tests send network requests, which can sometimes fail
-  /getaddrinfo EAI_AGAIN/,
-]
-
-// Get an CLI flag whose value is a JSON object, to be passed to `execa.command()`
-// Used for example by --defaultConfig and --cachedConfig.
-const getJsonOpt = function(object) {
-  return escapeExecaOpt(JSON.stringify(object))
-}
-
-// Escape CLI flag value that might contain a space
-const escapeExecaOpt = function(string) {
-  return string.replace(EXECA_COMMAND_REGEXP, '\\ ')
-}
-
-const EXECA_COMMAND_REGEXP = / /g
-
-module.exports = { runFixture, runFixtureConfig, FIXTURES_DIR, getJsonOpt, escapeExecaOpt }
+module.exports = { runFixture, FIXTURES_DIR }

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -2,16 +2,16 @@ const stripAnsi = require('strip-ansi')
 const { tick, pointer, arrowDown } = require('figures')
 
 // Normalize log output so it can be snapshot consistently across test runs
-const normalizeOutput = function(output, type) {
+const normalizeOutput = function(output) {
   const outputA = stripAnsi(output)
-  return NORMALIZE_REGEXPS[type].reduce(replaceOutput, outputA)
+  return NORMALIZE_REGEXPS.reduce(replaceOutput, outputA)
 }
 
 const replaceOutput = function(output, [regExp, replacement]) {
   return output.replace(regExp, replacement)
 }
 
-const MAIN_NORMALIZE_REGEXPS = [
+const NORMALIZE_REGEXPS = [
   // Zero width space characters due to a bug in buildbot:
   // https://github.com/netlify/buildbot/issues/595
   [/\u{200b}/gu, ''],
@@ -61,11 +61,5 @@ const MAIN_NORMALIZE_REGEXPS = [
   // HTTP errors are shown differently in Node 8
   [/ \.\.\.:443/g, ''],
 ]
-
-// Some projects require different sets of normalization regExps
-const NORMALIZE_REGEXPS = {
-  build: MAIN_NORMALIZE_REGEXPS,
-  config: MAIN_NORMALIZE_REGEXPS,
-}
 
 module.exports = { normalizeOutput }

--- a/packages/config/package-lock.json
+++ b/packages/config/package-lock.json
@@ -459,6 +459,12 @@
       "integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
       "dev": true
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -1657,6 +1663,74 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "get-bin-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/get-bin-path/-/get-bin-path-4.0.0.tgz",
+      "integrity": "sha512-SS6vz9L0EQQzzUlbY6cKh0/bkJQ6OixbaYk1zMbKUQ+TutREJlV4+s0YfGqIdbeR1BfzE5PUJI2NrYYfi8aDuw==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.3.4",
+        "is-plain-obj": "^2.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2163,6 +2237,12 @@
       "requires": {
         "package-json": "^6.3.0"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "ava": "^2.4.0",
+    "get-bin-path": "^4.0.0",
     "has-ansi": "^4.0.0"
   },
   "engines": {

--- a/packages/config/tests/base/tests.js
+++ b/packages/config/tests/base/tests.js
@@ -1,14 +1,14 @@
 const test = require('ava')
 
-const { runFixtureConfig, getJsonOpt } = require('../helpers/main')
+const { runFixture, getJsonOpt } = require('../helpers/main')
 
 test('Base from defaultConfig', async t => {
   const defaultConfig = getJsonOpt({ build: { base: 'base' } })
-  await runFixtureConfig(t, 'default_config', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'default_config', { flags: `--defaultConfig=${defaultConfig}` })
 })
 
 test('Base from configuration file property', async t => {
-  const { stdout } = await runFixtureConfig(t, 'prop_config')
+  const { stdout } = await runFixture(t, 'prop_config')
   const {
     buildDir,
     config: {
@@ -21,11 +21,11 @@ test('Base from configuration file property', async t => {
 })
 
 test('Base logic is not recursive', async t => {
-  await runFixtureConfig(t, 'recursive')
+  await runFixture(t, 'recursive')
 })
 
 test('BaseRelDir feature flag', async t => {
-  const { stdout } = await runFixtureConfig(t, 'prop_config', { flags: `--no-baseRelDir` })
+  const { stdout } = await runFixture(t, 'prop_config', { flags: `--no-baseRelDir` })
   const {
     buildDir,
     config: {

--- a/packages/config/tests/cli/tests.js
+++ b/packages/config/tests/cli/tests.js
@@ -1,23 +1,23 @@
 const test = require('ava')
 
-const { runFixtureConfig } = require('../helpers/main')
+const { runFixture } = require('../helpers/main')
 
 test('--help', async t => {
-  await runFixtureConfig(t, '', { flags: '--help' })
+  await runFixture(t, '', { flags: '--help' })
 })
 
 test('--version', async t => {
-  await runFixtureConfig(t, '', { flags: '--version' })
+  await runFixture(t, '', { flags: '--version' })
 })
 
 test('Success', async t => {
-  await runFixtureConfig(t, 'empty')
+  await runFixture(t, 'empty')
 })
 
 test('User error', async t => {
-  await runFixtureConfig(t, 'empty', { flags: '--config=/invalid' })
+  await runFixture(t, 'empty', { flags: '--config=/invalid' })
 })
 
 test('CLI flags', async t => {
-  await runFixtureConfig(t, 'empty', { flags: '--branch=test' })
+  await runFixture(t, 'empty', { flags: '--branch=test' })
 })

--- a/packages/config/tests/context/tests.js
+++ b/packages/config/tests/context/tests.js
@@ -1,43 +1,43 @@
 const test = require('ava')
 
-const { runFixtureConfig } = require('../helpers/main')
+const { runFixture } = require('../helpers/main')
 
 test('Context with context CLI flag', async t => {
-  await runFixtureConfig(t, 'context_flag', { flags: '--context=testContext' })
+  await runFixture(t, 'context_flag', { flags: '--context=testContext' })
 })
 
 test('Context environment variable', async t => {
-  await runFixtureConfig(t, 'context_flag', { env: { CONTEXT: 'testContext' } })
+  await runFixture(t, 'context_flag', { env: { CONTEXT: 'testContext' } })
 })
 
 test('Context default value', async t => {
-  await runFixtureConfig(t, 'context_default')
+  await runFixture(t, 'context_default')
 })
 
 test('Context with branch CLI flag', async t => {
-  await runFixtureConfig(t, 'branch', { flags: '--branch=testBranch' })
+  await runFixture(t, 'branch', { flags: '--branch=testBranch' })
 })
 
 test('Context with branch environment variable', async t => {
-  await runFixtureConfig(t, 'branch', { env: { BRANCH: 'testBranch' } })
+  await runFixture(t, 'branch', { env: { BRANCH: 'testBranch' } })
 })
 
 test('Context with branch git', async t => {
-  await runFixtureConfig(t, 'branch', { copyRoot: { branch: 'testBranch' }, env: { BRANCH: '' } })
+  await runFixture(t, 'branch', { copyRoot: { branch: 'testBranch' }, env: { BRANCH: '' } })
 })
 
 test('Context with branch fallback', async t => {
-  await runFixtureConfig(t, 'branch_fallback', { copyRoot: { git: false }, env: { BRANCH: '' } })
+  await runFixture(t, 'branch_fallback', { copyRoot: { git: false }, env: { BRANCH: '' } })
 })
 
 test('Context deep merge', async t => {
-  await runFixtureConfig(t, 'deep_merge')
+  await runFixture(t, 'deep_merge')
 })
 
 test('Context array merge', async t => {
-  await runFixtureConfig(t, 'array_merge')
+  await runFixture(t, 'array_merge')
 })
 
 test('Context merge priority', async t => {
-  await runFixtureConfig(t, 'priority_merge', { flags: '--branch=testBranch' })
+  await runFixture(t, 'priority_merge', { flags: '--branch=testBranch' })
 })

--- a/packages/config/tests/cwd/tests.js
+++ b/packages/config/tests/cwd/tests.js
@@ -3,34 +3,34 @@ const { relative } = require('path')
 
 const test = require('ava')
 
-const { runFixtureConfig, FIXTURES_DIR } = require('../helpers/main')
+const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
 test('--cwd with no config', async t => {
-  await runFixtureConfig(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty` })
 })
 
 test('--cwd with a relative path config', async t => {
-  await runFixtureConfig(t, '', {
+  await runFixture(t, '', {
     flags: `--cwd=${relative(cwd(), FIXTURES_DIR)} --config=empty/netlify.yml`,
   })
 })
 
 test('build.base current directory', async t => {
-  await runFixtureConfig(t, 'build_base_cwd')
+  await runFixture(t, 'build_base_cwd')
 })
 
 test('--repository-root', async t => {
-  await runFixtureConfig(t, '', { flags: `--repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: `--repository-root=${FIXTURES_DIR}/empty` })
 })
 
 test('No .git', async t => {
-  await runFixtureConfig(t, 'empty', { copyRoot: {}, flags: '--cwd=.' })
+  await runFixture(t, 'empty', { copyRoot: { cwd: true, git: false } })
 })
 
 test('--cwd non-existing', async t => {
-  await runFixtureConfig(t, '', { flags: `--cwd=/invalid --repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: `--cwd=/invalid --repository-root=${FIXTURES_DIR}/empty` })
 })
 
 test('--repositoryRoot non-existing', async t => {
-  await runFixtureConfig(t, '', { flags: `--repositoryRoot=/invalid` })
+  await runFixture(t, '', { flags: `--repositoryRoot=/invalid` })
 })

--- a/packages/config/tests/helpers/main.js
+++ b/packages/config/tests/helpers/main.js
@@ -1,6 +1,22 @@
+const { getBinPath } = require('get-bin-path')
+
 // Tests require the full monorepo to be present at the moment
 // TODO: split tests utility into its own package
-const { runFixtureConfig, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../../../build/tests/helpers/main')
-const { removeDir } = require('../../../build/tests/helpers/dir')
+const { runFixtureCommon, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../../../build/tests/helpers/common')
 
-module.exports = { runFixtureConfig, FIXTURES_DIR, removeDir, getJsonOpt, escapeExecaOpt }
+const ROOT_DIR = `${__dirname}/../..`
+
+const runFixture = async function(t, fixtureName, { env, ...opts } = {}) {
+  return runFixtureCommon(t, fixtureName, {
+    ...opts,
+    binaryPath: await BINARY_PATH,
+    env: {
+      // Make snapshot consistent regardless of the actual current git branch
+      BRANCH: 'branch',
+      ...env,
+    },
+  })
+}
+const BINARY_PATH = getBinPath({ cwd: ROOT_DIR })
+
+module.exports = { runFixture, FIXTURES_DIR, getJsonOpt, escapeExecaOpt }

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -4,14 +4,14 @@ const { relative } = require('path')
 const test = require('ava')
 
 const resolveConfig = require('../..')
-const { runFixtureConfig, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../helpers/main')
+const { runFixture, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../helpers/main')
 
 test('Empty configuration', async t => {
-  await runFixtureConfig(t, 'empty')
+  await runFixture(t, 'empty')
 })
 
 test('Can define configuration as environment variables', async t => {
-  await runFixtureConfig(t, 'empty', {
+  await runFixture(t, 'empty', {
     env: {
       NETLIFY_CONFIG_BUILD_LIFECYCLE_ONBUILD: 'echo onBuild',
       NETLIFY_CONFIG_BUILD_LIFECYCLE_ONPOSTBUILD: 'echo onPostBuild',
@@ -21,47 +21,47 @@ test('Can define configuration as environment variables', async t => {
 })
 
 test('No --config but none found', async t => {
-  await runFixtureConfig(t, 'none', { copyRoot: {} })
+  await runFixture(t, 'none', { copyRoot: {} })
 })
 
 test('Several configuration files', async t => {
-  await runFixtureConfig(t, 'several')
+  await runFixture(t, 'several')
 })
 
 test('--config with an absolute path', async t => {
-  await runFixtureConfig(t, '', { flags: `--config=${FIXTURES_DIR}/empty/netlify.yml` })
+  await runFixture(t, '', { flags: `--config=${FIXTURES_DIR}/empty/netlify.yml` })
 })
 
 test('--config with a relative path', async t => {
-  await runFixtureConfig(t, '', { flags: `--config=${relative(cwd(), FIXTURES_DIR)}/empty/netlify.yml` })
+  await runFixture(t, '', { flags: `--config=${relative(cwd(), FIXTURES_DIR)}/empty/netlify.yml` })
 })
 
 test('--config with an invalid relative path', async t => {
-  await runFixtureConfig(t, '', { flags: '--config=/invalid' })
+  await runFixture(t, '', { flags: '--config=/invalid' })
 })
 
 test('--defaultConfig merge', async t => {
   const defaultConfig = getJsonOpt({ build: { lifecycle: { onInit: 'echo onInit' } } })
-  await runFixtureConfig(t, 'default_merge', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'default_merge', { flags: `--defaultConfig=${defaultConfig}` })
 })
 
 test('--defaultConfig priority', async t => {
   const defaultConfig = getJsonOpt({ build: { lifecycle: { onBuild: 'echo onBuild' } } })
-  await runFixtureConfig(t, 'default_priority', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'default_priority', { flags: `--defaultConfig=${defaultConfig}` })
 })
 
 test('--defaultConfig with an invalid relative path', async t => {
-  await runFixtureConfig(t, '', { flags: '--defaultConfig={{}' })
+  await runFixture(t, '', { flags: '--defaultConfig={{}' })
 })
 
 test('--cachedConfig', async t => {
-  const { stdout } = await runFixtureConfig(t, 'cached_config', { snapshot: false })
+  const { stdout } = await runFixture(t, 'cached_config', { snapshot: false })
   const cachedConfig = escapeExecaOpt(stdout)
-  await runFixtureConfig(t, 'cached_config', { flags: `--cachedConfig=${cachedConfig}` })
+  await runFixture(t, 'cached_config', { flags: `--cachedConfig=${cachedConfig}` })
 })
 
 test('--cachedConfig with an invalid path', async t => {
-  await runFixtureConfig(t, '', { flags: '--cachedConfig={{}' })
+  await runFixture(t, '', { flags: '--cachedConfig={{}' })
 })
 
 test('Programmatic', async t => {

--- a/packages/config/tests/normalize/tests.js
+++ b/packages/config/tests/normalize/tests.js
@@ -1,43 +1,43 @@
 const test = require('ava')
 
-const { runFixtureConfig } = require('../helpers/main')
+const { runFixture } = require('../helpers/main')
 
 test('Multiline commands', async t => {
-  await runFixtureConfig(t, 'multiline')
+  await runFixture(t, 'multiline')
 })
 
 test('build.command', async t => {
-  await runFixtureConfig(t, 'command')
+  await runFixture(t, 'command')
 })
 
 test('build.command and build.lifecycle.onbuild', async t => {
-  await runFixtureConfig(t, 'command_lifecycle')
+  await runFixture(t, 'command_lifecycle')
 })
 
 test('build.lifecycle.build', async t => {
-  await runFixtureConfig(t, 'old_lifecycle')
+  await runFixture(t, 'old_lifecycle')
 })
 
 test('build.lifecycle.onbuild case', async t => {
-  await runFixtureConfig(t, 'case')
+  await runFixture(t, 'case')
 })
 
 test('build.lifecycle.prebuild case', async t => {
-  await runFixtureConfig(t, 'old_case')
+  await runFixture(t, 'old_case')
 })
 
 test('build.lifecycle.finally', async t => {
-  await runFixtureConfig(t, 'finally')
+  await runFixture(t, 'finally')
 })
 
 test('build.lifecycle empty', async t => {
-  await runFixtureConfig(t, 'lifecycle_empty')
+  await runFixture(t, 'lifecycle_empty')
 })
 
 test('plugins[*].type', async t => {
-  await runFixtureConfig(t, 'type')
+  await runFixture(t, 'type')
 })
 
 test('plugins[*].config', async t => {
-  await runFixtureConfig(t, 'config')
+  await runFixture(t, 'config')
 })

--- a/packages/config/tests/parse/tests.js
+++ b/packages/config/tests/parse/tests.js
@@ -2,40 +2,40 @@ const { platform, version } = require('process')
 
 const test = require('ava')
 
-const { runFixtureConfig, FIXTURES_DIR } = require('../helpers/main')
+const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
 test('Configuration file - netlify.yaml', async t => {
-  await runFixtureConfig(t, 'yaml')
+  await runFixture(t, 'yaml')
 })
 
 test('Configuration file - netlify.yml', async t => {
-  await runFixtureConfig(t, 'yml')
+  await runFixture(t, 'yml')
 })
 
 test('Configuration file - netlify.json', async t => {
-  await runFixtureConfig(t, 'json')
+  await runFixture(t, 'json')
 })
 
 test('Configuration file - netlify.toml', async t => {
-  await runFixtureConfig(t, 'toml')
+  await runFixture(t, 'toml')
 })
 
 test('Configuration file - invalid format', async t => {
-  await runFixtureConfig(t, '', { flags: `--config=${FIXTURES_DIR}/invalid/netlify.invalid` })
+  await runFixture(t, '', { flags: `--config=${FIXTURES_DIR}/invalid/netlify.invalid` })
 })
 
 test('Configuration file - advanced YAML', async t => {
-  await runFixtureConfig(t, 'advanced_yaml')
+  await runFixture(t, 'advanced_yaml')
 })
 
 // Windows directory permissions work differently than Unix.
 // Node 10 also changed errors there, so Node 8 shows different error messages.
 if (platform !== 'win32' && !version.startsWith('v8.')) {
   test('Configuration file - read permission error', async t => {
-    await runFixtureConfig(t, '', { flags: `--config=${FIXTURES_DIR}/read_error/netlify.yml` })
+    await runFixture(t, '', { flags: `--config=${FIXTURES_DIR}/read_error/netlify.yml` })
   })
 }
 
 test('Configuration file - parsing error', async t => {
-  await runFixtureConfig(t, 'parse_error')
+  await runFixture(t, 'parse_error')
 })

--- a/packages/config/tests/validate/tests.js
+++ b/packages/config/tests/validate/tests.js
@@ -1,115 +1,115 @@
 const test = require('ava')
 const hasAnsi = require('has-ansi')
 
-const { runFixtureConfig } = require('../helpers/main')
+const { runFixture } = require('../helpers/main')
 
 test('plugins: not array', async t => {
-  await runFixtureConfig(t, 'plugins_not_array')
+  await runFixture(t, 'plugins_not_array')
 })
 
 test('plugins: not array of objects', async t => {
-  await runFixtureConfig(t, 'plugins_not_objects')
+  await runFixture(t, 'plugins_not_objects')
 })
 
 test('plugins.any: unknown property', async t => {
-  await runFixtureConfig(t, 'plugins_unknown')
+  await runFixture(t, 'plugins_unknown')
 })
 
 test('plugins.any.id backward compatibility', async t => {
-  await runFixtureConfig(t, 'plugins_id_compat')
+  await runFixture(t, 'plugins_id_compat')
 })
 
 test('plugins.any.type renamed', async t => {
-  await runFixtureConfig(t, 'plugins_type_renamed')
+  await runFixture(t, 'plugins_type_renamed')
 })
 
 test('plugins.any.package: required', async t => {
-  await runFixtureConfig(t, 'plugins_package_required')
+  await runFixture(t, 'plugins_package_required')
 })
 
 test('plugins.any.package: string', async t => {
-  await runFixtureConfig(t, 'plugins_package_string')
+  await runFixture(t, 'plugins_package_string')
 })
 
 test('plugins.any.config: renamed', async t => {
-  await runFixtureConfig(t, 'plugins_config_renamed')
+  await runFixture(t, 'plugins_config_renamed')
 })
 
 test('plugins.any.inputs: object', async t => {
-  await runFixtureConfig(t, 'plugins_inputs_object')
+  await runFixture(t, 'plugins_inputs_object')
 })
 
 test('build: object', async t => {
-  await runFixtureConfig(t, 'build_object')
+  await runFixture(t, 'build_object')
 })
 
 test('build.publish: string', async t => {
-  await runFixtureConfig(t, 'build_publish_string')
+  await runFixture(t, 'build_publish_string')
 })
 
 test('build.publish: parent directory', async t => {
-  await runFixtureConfig(t, 'build_publish_parent')
+  await runFixture(t, 'build_publish_parent')
 })
 
 test('build.functions: string', async t => {
-  await runFixtureConfig(t, 'build_functions_string')
+  await runFixture(t, 'build_functions_string')
 })
 
 test('build.functions: parent directory', async t => {
-  await runFixtureConfig(t, 'build_functions_parent')
+  await runFixture(t, 'build_functions_parent')
 })
 
 test('build.base: string', async t => {
-  await runFixtureConfig(t, 'build_base_string')
+  await runFixture(t, 'build_base_string')
 })
 
 test('build.base: parent directory', async t => {
-  await runFixtureConfig(t, 'build_base_parent')
+  await runFixture(t, 'build_base_parent')
 })
 
 test('build.command: string', async t => {
-  await runFixtureConfig(t, 'build_command_string')
+  await runFixture(t, 'build_command_string')
 })
 
 test('build.command: with environment variable lifecycle', async t => {
-  await runFixtureConfig(t, 'build_command_lifecycle_envvar', {
+  await runFixture(t, 'build_command_lifecycle_envvar', {
     env: { NETLIFY_CONFIG_BUILD_LIFECYCLE_ONBUILD: 'echo onBuild' },
   })
 })
 
 test('build.lifecycle: object', async t => {
-  await runFixtureConfig(t, 'build_lifecycle_object')
+  await runFixture(t, 'build_lifecycle_object')
 })
 
 test('build.lifecycle: event names', async t => {
-  await runFixtureConfig(t, 'build_lifecycle_events')
+  await runFixture(t, 'build_lifecycle_events')
 })
 
 test('build.lifecycle: string', async t => {
-  await runFixtureConfig(t, 'build_lifecycle_events_string')
+  await runFixture(t, 'build_lifecycle_events_string')
 })
 
 test('build.lifecycle: array', async t => {
-  await runFixtureConfig(t, 'build_lifecycle_events_array')
+  await runFixture(t, 'build_lifecycle_events_array')
 })
 
 test('build.context: property', async t => {
-  await runFixtureConfig(t, 'build_context_property')
+  await runFixture(t, 'build_context_property')
 })
 
 test('build.context: nested property', async t => {
-  await runFixtureConfig(t, 'build_context_nested_property')
+  await runFixture(t, 'build_context_nested_property')
 })
 
 test('build.context: object', async t => {
-  await runFixtureConfig(t, 'build_context_object')
+  await runFixture(t, 'build_context_object')
 })
 
 test('build.context.CONTEXT: object', async t => {
-  await runFixtureConfig(t, 'build_context_nested_object')
+  await runFixture(t, 'build_context_nested_object')
 })
 
 test('Colors', async t => {
-  const { stderr } = await runFixtureConfig(t, 'build_object', { snapshot: false, normalize: false })
+  const { stderr } = await runFixture(t, 'build_object', { snapshot: false, normalize: false })
   t.true(hasAnsi(stderr))
 })


### PR DESCRIPTION
Both `@netlify/build` and `@netlify/config` use the same test setup, based on snapshot testing. The only difference are that they: 
  - use different entry points / binaries
  - inject different environment variables

This PR refactors the setup by putting all common test setup under a specific `tests/helpers/common.js` file, then putting what's specific in each project in a `tests/helpers/main.js` file inside each project.

This PR only moves lines around and renames variables, it does not change any testing behavior.