### PR TITLE
Fix environment variable `CACHED_COMMIT_REF` in the `git` utility

### DIFF
--- a/packages/git-utils/src/refs.js
+++ b/packages/git-utils/src/refs.js
@@ -1,5 +1,6 @@
 const {
-  env: { CACHED_COMMIT_REF, TEST_HEAD },
+  env,
+  env: { TEST_HEAD },
 } = require('process')
 
 const { git } = require('./exec')
@@ -19,8 +20,8 @@ const getBaseRefs = function(base) {
     return [base]
   }
 
-  if (CACHED_COMMIT_REF) {
-    return [CACHED_COMMIT_REF]
+  if (env.CACHED_COMMIT_REF) {
+    return [env.CACHED_COMMIT_REF]
   }
 
   return DEFAULT_BASE


### PR DESCRIPTION
The `CACHED_COMMIT_REF` environment variable is used in the `git` utility. Its value is retrieved at load time. However it should be retrieved at run time instead. This allows for users to modify it dynamically. This will be used for example by the tests added by #1044.