### PR TITLE
Add `NETLIFY_BUILD_TEST` environment variable

### DIFF
--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -50,7 +50,7 @@ const runFixture = async function(
 ) {
   const isPrint = PRINT === '1'
   const FORCE_COLOR = isPrint ? '1' : ''
-  const commandEnv = { ...DEFAULT_ENV[type], FORCE_COLOR, ...envOption }
+  const commandEnv = { ...DEFAULT_ENV[type], FORCE_COLOR, NETLIFY_BUILD_TEST: '1', ...envOption }
   const copyRootDir = await getCopyRootDir({ copyRoot })
   const repositoryRootFlag = getRepositoryRootFlag({ fixtureName, copyRootDir, repositoryRoot })
   const binaryPath = await BINARY_PATH[type]

--- a/packages/cache-utils/src/dir.js
+++ b/packages/cache-utils/src/dir.js
@@ -1,7 +1,4 @@
-const {
-  platform,
-  env: { TEST_CACHE_PATH },
-} = require('process')
+const { platform, env } = require('process')
 
 const globalCacheDir = require('global-cache-dir')
 
@@ -15,7 +12,7 @@ const getCacheDir = function() {
 
   // istanbul ignore next
   // Do not use in tests since /opt might not be writable by current user
-  if (platform === 'linux' && TEST_CACHE_PATH === undefined) {
+  if (platform === 'linux' && !env.NETLIFY_BUILD_TEST) {
     return CI_CACHE_DIR
   }
 

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -1,6 +1,7 @@
 const {
   cwd: getCwd,
-  env: { CONTEXT, TEST_CACHE_PATH },
+  env,
+  env: { CONTEXT },
 } = require('process')
 
 const pathExists = require('path-exists')
@@ -43,7 +44,7 @@ const DEFAULT_OPTS = {
 // TODO: remove it once the buildbot starts using `defaultConfig`.
 const DEFAULT_CONFIG_OPTS =
   // Ensure we are not in a local build or running unit tests
-  isNetlifyCI() && !TEST_CACHE_PATH
+  isNetlifyCI() && !env.NETLIFY_BUILD_TEST
     ? {
         defaultConfig: JSON.stringify({ build: { base: getCwd() } }),
       }


### PR DESCRIPTION
We sometimes need to know in our code whether the code is run inside production or inside our tests. We try to avoid this, since integration tests should leave the actual production code intact. However there are currently 2 cases in our codebase where this was difficult.

To detect whether we are running in tests, we've been using the `TEST_CACHE_PATH` environment variable. However this variable is used for a different purpose (testing our cache logic). This PR decouples concerns by adding a new environment variable `NETLIFY_BUILD_TEST` whose sole purpose is to specify that we are currently running tests.