### PR TITLE
Fix `cache-utils` missing dependency

### DIFF
--- a/packages/cache-utils/package-lock.json
+++ b/packages/cache-utils/package-lock.json
@@ -92,6 +92,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "array-flat-polyfill": "^1.0.1",
     "cpy": "^8.0.0",
     "del": "^5.1.0",
     "get-stream": "^5.1.0",

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -1,3 +1,5 @@
+require('./utils/polyfills')
+
 const pathExists = require('path-exists')
 const del = require('del')
 

--- a/packages/cache-utils/src/utils/polyfills.js
+++ b/packages/cache-utils/src/utils/polyfills.js
@@ -1,0 +1,3 @@
+// Patches `Array.flat()` and `Array.flatMap()`
+// TODO: remove after dropping Node <12 support
+require('array-flat-polyfill')


### PR DESCRIPTION
One production dependency is missing from the `cache` utility. This was unnoticed until now since it only crashes when both:
  - Node.js version is `<10`
  - the `cache` utility is used directly (not inside Netlify Build)

This PR fixes that.