### PR TITLE
Add a `cacheDir` option to the `cache` utility

### DIFF
--- a/packages/cache-utils/src/dir.js
+++ b/packages/cache-utils/src/dir.js
@@ -8,7 +8,11 @@ const globalCacheDir = require('global-cache-dir')
 const { isNetlifyCI } = require('./ci')
 
 // Retrieve the cache directory location
-const getCacheDir = function() {
+const getCacheDir = function(cacheDir) {
+  if (cacheDir !== undefined) {
+    return cacheDir
+  }
+
   if (!isNetlifyCI()) {
     return LOCAL_CACHE_DIR
   }

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -7,9 +7,9 @@ const { BASES } = require('./path')
 const { isManifest } = require('./manifest')
 
 // List all cached files
-const list = async function() {
-  const cacheDir = await getCacheDir()
-  const files = await Promise.all(BASES.map(baseInfo => listBase(baseInfo, cacheDir)))
+const list = async function({ cacheDir } = {}) {
+  const cacheDirA = await getCacheDir(cacheDir)
+  const files = await Promise.all(BASES.map(baseInfo => listBase(baseInfo, cacheDirA)))
   const filesA = files.flat()
   return filesA
 }

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -8,8 +8,8 @@ const { getCacheDir } = require('./dir')
 const { list } = require('./list')
 
 // Cache a file
-const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [] } = {}) {
-  const { srcPath, cachePath, base } = await parsePath(path)
+const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [], cacheDir } = {}) {
+  const { srcPath, cachePath, base } = await parsePath(path, cacheDir)
 
   if (!(await pathExists(srcPath))) {
     return false
@@ -28,8 +28,8 @@ const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, d
 }
 
 // Restore a cached file
-const restoreOne = async function(path, { move = DEFAULT_MOVE } = {}) {
-  const { srcPath, cachePath } = await parsePath(path)
+const restoreOne = async function(path, { move = DEFAULT_MOVE, cacheDir } = {}) {
+  const { srcPath, cachePath } = await parsePath(path, cacheDir)
 
   if (!(await pathExists(cachePath))) {
     return false
@@ -46,8 +46,8 @@ const restoreOne = async function(path, { move = DEFAULT_MOVE } = {}) {
 }
 
 // Remove the cache of a file
-const removeOne = async function(path) {
-  const { cachePath } = await parsePath(path)
+const removeOne = async function(path, { cacheDir } = {}) {
+  const { cachePath } = await parsePath(path, cacheDir)
 
   if (!(await pathExists(cachePath))) {
     return false
@@ -60,8 +60,8 @@ const removeOne = async function(path) {
 }
 
 // Check if a file is cached
-const hasOne = async function(path) {
-  const { cachePath } = await parsePath(path)
+const hasOne = async function(path, { cacheDir } = {}) {
+  const { cachePath } = await parsePath(path, cacheDir)
 
   return (await pathExists(cachePath)) && !(await isExpired(cachePath))
 }

--- a/packages/cache-utils/src/path.js
+++ b/packages/cache-utils/src/path.js
@@ -5,12 +5,12 @@ const { cwd } = require('process')
 const { getCacheDir } = require('./dir')
 
 // Find the paths of the file before/after caching
-const parsePath = async function(path) {
-  const cacheDir = await getCacheDir()
+const parsePath = async function(path, cacheDir) {
+  const cacheDirA = await getCacheDir(cacheDir)
 
   const { name, base, relPath } = findBase(path)
   const srcPath = resolve(base, relPath)
-  const cachePath = resolve(cacheDir, name, relPath)
+  const cachePath = resolve(cacheDirA, name, relPath)
   return { srcPath, cachePath, base }
 }
 


### PR DESCRIPTION
In production, the `cache` utility uses the same cache directory that the buildbot uses. Locally it uses `.netlify/cache/` instead. 

This PR adds an undocumented `cacheDir` option which allows us to override that logic and specify the cache directory explicitly. This option will be used in some tests added by #1042.