### PR TITLE
Remove `omit.js`

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -47,7 +47,6 @@
     "log-process-errors": "^5.0.3",
     "map-obj": "^4.1.0",
     "netlify": "^3.1.0",
-    "omit.js": "^1.0.2",
     "os-name": "^3.1.0",
     "p-event": "^4.1.0",
     "p-filter": "^2.1.0",

--- a/packages/build/src/error/serialize.js
+++ b/packages/build/src/error/serialize.js
@@ -1,10 +1,10 @@
 const { inspect } = require('util')
 
 const { redBright } = require('chalk')
-const omit = require('omit.js')
 
 const { EMPTY_LINE, HEADING_PREFIX } = require('../log/constants')
 const { indent } = require('../log/serialize')
+const { omit } = require('../utils/omit')
 
 const { getErrorInfo, INFO_SYM } = require('./info')
 const { getTypeInfo } = require('./type')

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -6,12 +6,12 @@ const {
 
 const stringWidth = require('string-width')
 const { greenBright, cyanBright, redBright, yellowBright, bold, white } = require('chalk')
-const omit = require('omit.js')
 
 const { version } = require('../../package.json')
 const { serializeError } = require('../error/serialize')
 const isNetlifyCI = require('../utils/is-netlify-ci')
 const { serializeList } = require('../utils/list')
+const { omit } = require('../utils/omit')
 
 const { log } = require('./logger')
 const { serialize, SUBTEXT_PADDING, indent } = require('./serialize')

--- a/packages/build/src/plugins/env.js
+++ b/packages/build/src/plugins/env.js
@@ -1,7 +1,6 @@
-const omit = require('omit.js')
-
 const isNetlifyCI = require('../utils/is-netlify-ci')
 const { removeFalsy } = require('../utils/remove_falsy')
+const { omit } = require('../utils/omit')
 
 const { getGitEnv } = require('./git')
 

--- a/packages/build/src/utils/omit.js
+++ b/packages/build/src/utils/omit.js
@@ -1,0 +1,8 @@
+const filterObj = require('filter-obj')
+
+// lodash.omit is 1400 lines of codes. filter-obj is much smaller and simpler.
+const omit = function(obj, keys) {
+  return filterObj(obj, key => !keys.includes(key))
+}
+
+module.exports = { omit }

--- a/packages/config/package-lock.json
+++ b/packages/config/package-lock.json
@@ -748,15 +748,6 @@
         "estraverse": "^4.1.1"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1232,7 +1223,8 @@
     "core-js": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.1",
@@ -2624,14 +2616,6 @@
         "symbol-observable": "^1.0.4"
       }
     },
-    "omit.js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.2.tgz",
-      "integrity": "sha512-/QPc6G2NS+8d4L/cQhbk6Yit1WTB6Us2g84A7A/1+w9d/eRGHyEqC5kkQtHVoHZ5NFWGG7tUGgrhVZwgZanKrQ==",
-      "requires": {
-        "babel-runtime": "^6.23.0"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3143,11 +3127,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regexp.prototype.flags": {
       "version": "1.2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -32,7 +32,6 @@
     "is-plain-obj": "^2.1.0",
     "js-yaml": "^3.13.1",
     "map-obj": "^4.1.0",
-    "omit.js": "^1.0.2",
     "p-filter": "^2.1.0",
     "path-exists": "^4.0.0",
     "toml": "^3.0.0",

--- a/packages/config/src/utils/omit.js
+++ b/packages/config/src/utils/omit.js
@@ -1,0 +1,8 @@
+const filterObj = require('filter-obj')
+
+// lodash.omit is 1400 lines of codes. filter-obj is much smaller and simpler.
+const omit = function(obj, keys) {
+  return filterObj(obj, key => !keys.includes(key))
+}
+
+module.exports = { omit }

--- a/packages/config/src/validate/validations.js
+++ b/packages/config/src/validate/validations.js
@@ -1,7 +1,7 @@
 const isPlainObj = require('is-plain-obj')
-const omit = require('omit.js')
 
 const { EVENTS, LEGACY_EVENTS, normalizeEventHandler } = require('../normalize/events')
+const { omit } = require('../utils/omit')
 
 const { isString, validProperties, deprecatedProperties, insideRootCheck, removeParentDots } = require('./helpers')
 const { addContextValidations } = require('./context')


### PR DESCRIPTION
Fixes #1048 

This removes the `omit.js` dependency. Besides not being well maintained, it includes an old version of `core-js` which [prints warning messages on `npm install`](https://github.com/benjycui/omit.js/issues/6).

We do not want to use `lodash.omit` because it is huge ([1500 lines of code](https://unpkg.com/lodash.omit@4.5.0/index.js) compared to [12 lines of code](https://github.com/benjycui/omit.js/blob/master/src/index.js) for `omit.js`). This is because `lodash.omit` comes with all the extraneous features and utility helpers of the whole Lodash ecosystem. Tiny modules are much simpler to debug and less bug-prone.

I could not find any well maintained alternatives on npm except for `filter-obj`, which we already use. However it needs to be wrapped with a tiny utility function to make it more convenient.