### PR TITLE
Fix duplicated paths bug

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -44,21 +44,18 @@ const loadConfig = async function(flags) {
     branch,
     baseRelDir,
   })
-
-  const { buildDir: buildDirA, netlifyConfig: netlifyConfigA } = fixDuplicatePaths(buildDir, netlifyConfig)
-
-  logBuildDir(buildDirA)
+  logBuildDir(buildDir)
   logConfigPath(configPath)
-  logConfig(netlifyConfigA)
+  logConfig(netlifyConfig)
   logContext(contextA)
 
   const api = getApiClient(token)
   const siteInfo = await getSiteInfo(api, siteId)
-  const constants = await getConstants({ configPath, buildDir: buildDirA, netlifyConfig: netlifyConfigA, siteInfo })
+  const constants = await getConstants({ configPath, buildDir, netlifyConfig, siteInfo })
   return {
-    netlifyConfig: netlifyConfigA,
+    netlifyConfig,
     configPath,
-    buildDir: buildDirA,
+    buildDir,
     nodePath,
     api,
     token,
@@ -68,34 +65,6 @@ const loadConfig = async function(flags) {
     context: contextA,
     branch: branchA,
   }
-}
-
-// TODO: temporary hotfix
-const fixDuplicatePaths = function(buildDir, { build, ...netlifyConfig }) {
-  const buildDirA = fixDuplicatePath(buildDir)
-  const buildA = fixDuplicatePathObject(build, 'base')
-  const buildB = fixDuplicatePathObject(buildA, 'functions')
-  const buildC = fixDuplicatePathObject(buildB, 'publish')
-  const netlifyConfigA = { ...netlifyConfig, build: buildC }
-  return { buildDir: buildDirA, netlifyConfig: netlifyConfigA }
-}
-
-const fixDuplicatePathObject = function(object, propName) {
-  const path = object[propName]
-  if (path === undefined) {
-    return object
-  }
-
-  const pathA = fixDuplicatePath(path)
-  return { ...object, [propName]: pathA }
-}
-
-const fixDuplicatePath = function(path) {
-  if (!path.startsWith('/opt/build/repo/opt/build/repo')) {
-    return path
-  }
-
-  return path.replace('/opt/build/repo', '')
 }
 
 // Default values of CLI flags


### PR DESCRIPTION
This bug is combination of several problems. 
Some of those problems are related to the buildbot transitioning from an "old" version (without `@netlify/config`) to a "new" one (with `@netlify/config`), and failure from `@netlify/config` to provide correct backward compatibility between both.

## Base directory UI setting

The "Base directory" UI setting is currently communicated by the "old" buildbot to Netlify Build by changing the current directory to it before calling `@netlify/build`. However the "new" buildbot is using the `--defaultConfig` CLI flag instead. 

To be able to support both, `@netlify/config` sets a `--defaultConfig` CLI flag value of `{ build: { base: getCwd() } }`. The "old" buildbot uses this, therefore getting the correct "Base directory" UI setting. The "new" buildbot does not use it since it overrides it with its own `--defaultConfig`.

This is a workaround that will be removed once the "new" buildbot (see #992).

That workaround is only applied in production CI, not in local builds.

## Absolute paths

Configuration file properties starting with `/` should be handled as relative paths, not absolute. This was just fixed today by #1049.

## Problem

The base directory workaround above uses the current directory absolute path. This means the `--defaultConfig` is `{ build: { base: '/opt/build/repo' } }` (if no UI setting is used). Since that path starts with a `/`, it is understood to be relative to the repository root, which is the same path. This results in `/opt/build/repo/opt/build/repo` being set as `build.base`.

`build.base` is then used to compute the build directory, which is prepended to both `build.publish` and `build.functions`.

## Quick workaround

Since this bug was impacting live users (only the ones with Netlify Beta enabled), a quick workaround was implemented until the bug was fully understood. 

That workaround checks if any configuration file path is repeating `/opt/build/repo` and fixes the path accordingly.

## Real solution

In the case above, the current directory should be set as a relative path to the repository root, instead of an absolute path.

This PR implements that fix and removes the quick workaround described above.

## Debugging issues

This goes beyond the scope of this PR, but I encountered several debugging issues that I wanted to list. I will fill issues so that we can be more reactive in the future with similar bugs:
  - The "Base directory" workaround is only applied in production CI. There are few places in our codebase that have different behavior when run inside the buildbot. Therefore those are not caught in the current automated testing setup. This is not the first bug we've been having that only happens in production builds but not local ones. We need some higher-level automated tests that involve combining the buildbot and `@netlify/build`.
  - The wrong current directory made the build fail when plugin child processes were being spawned. Those child processes use the build directory as `cwd`. In Linux, spawning a child process with a non-existing `cwd` results in an `ENOENT` error. It was hard from the system error message to know that was the problem. At first I thought either the `node` binary itself did not exist (indicating a problem with the `--nodePath` flag) or the plugin file somehow was not on the filesystem in the buildbot. We should set up some validation check to ensure the build directory exists.
  - Thanks to @Benaiah work on the `NETLIFY_BUILD_CLI_VERSION`, it is possible to debug `@netlify/debug` a specific branch using the production CI without actually deploying to production. We should have a similar setup for `@netlify/config`.
  - I was unsure which version of `@netlify/config` was used in builds (it turns out none was). It should be printed in build logs.