### PR TITLE
Fix tests failing on Windows

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -1,5 +1,5 @@
 export default {
-  files: ['packages/**/tests/*.js', 'packages/**/tests/**/tests.js', 'packages/**/tests/*.js'],
+  files: ['packages/**/tests/*.js', 'packages/**/tests/**/tests.js'],
   compileEnhancements: false,
   babel: false,
   verbose: true,

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -14,6 +14,7 @@ const list = async function({ cacheDir } = {}) {
   return filesA
 }
 
+// TODO: the returned paths are missing the Windows drive
 const listBase = async function({ name, base }, cacheDir) {
   const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter })
   const filesA = files.map(({ path }) => join(base, path))

--- a/packages/cache-utils/src/path.js
+++ b/packages/cache-utils/src/path.js
@@ -1,5 +1,5 @@
 const { homedir } = require('os')
-const { relative, resolve, normalize } = require('path')
+const { resolve, join, sep } = require('path')
 const { cwd } = require('process')
 
 const { getCacheDir } = require('./dir')
@@ -8,32 +8,50 @@ const { getCacheDir } = require('./dir')
 const parsePath = async function(path, cacheDir) {
   const cacheDirA = await getCacheDir(cacheDir)
 
-  const { name, base, relPath } = findBase(path)
-  const srcPath = resolve(base, relPath)
-  const cachePath = resolve(cacheDirA, name, relPath)
+  const srcPath = resolve(path)
+  const { name, base, relPath } = findBase(srcPath)
+  const cachePath = join(cacheDirA, name, relPath)
   return { srcPath, cachePath, base }
 }
 
 // The cached path is the path relative to the base which can be either the
 // current directory, the home directory or the root directory. Each is tried
 // in order.
-const findBase = function(path) {
-  return BASES.map(({ name, base }) => parseBase(name, base, path)).find(isChildPath)
+const findBase = function(srcPath) {
+  const srcPathA = normalizeWindows(srcPath)
+  return BASES.map(({ name, base }) => parseBase(name, base, srcPathA)).find(Boolean)
 }
 
-const parseBase = function(name, base, path) {
-  const relPath = relative(base, path)
+// Windows drives are problematic:
+//  - they cannot be used in `relPath` since directories cannot be called `C:`
+//    for example.
+//  - they make comparing between drives harder
+// For the moment, we simply strip them. This does mean two files with the same
+// paths but inside different drives would be cached together, which is not
+// correct.
+// This also means `cache.list()` always assumes the source files are on the
+// current drive.
+// TODO: fix it.
+const normalizeWindows = function(srcPath) {
+  return srcPath.replace(WINDOWS_DRIVE_REGEX, '\\')
+}
+
+const WINDOWS_DRIVE_REGEX = /^[a-zA-Z]:\\/
+
+// This logic works when `base` and `path` are on different Windows drives
+const parseBase = function(name, base, srcPath) {
+  if (srcPath === base || !srcPath.startsWith(base)) {
+    return
+  }
+
+  const relPath = srcPath.replace(base, '')
   return { name, base, relPath }
 }
 
 const BASES = [
   { name: 'cwd', base: cwd() },
   { name: 'home', base: homedir() },
-  { name: 'root', base: normalize('/') },
+  { name: 'root', base: sep },
 ]
-
-const isChildPath = function({ relPath }) {
-  return !relPath.startsWith('..') && relPath !== ''
-}
 
 module.exports = { parsePath, BASES }

--- a/packages/cache-utils/tests/dir.js
+++ b/packages/cache-utils/tests/dir.js
@@ -25,7 +25,7 @@ test.serial('Should allow not changing the cache directory', async t => {
 
 // Need to be serial since we change the environment variables
 test.serial('Should allow not changing the cache directory in CI', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   process.env.NETLIFY_BUILD_TEST = '1'
   process.env.NETLIFY = 'true'
   try {
@@ -36,6 +36,6 @@ test.serial('Should allow not changing the cache directory in CI', async t => {
   } finally {
     delete process.env.NETLIFY
     delete process.env.NETLIFY_BUILD_TEST
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })

--- a/packages/cache-utils/tests/has.js
+++ b/packages/cache-utils/tests/has.js
@@ -5,24 +5,28 @@ const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 const cacheUtils = require('..')
 
 test('Should allow checking if one file is cached', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.false(await cacheUtils.has(srcFile, { cacheDir }))
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     t.true(await cacheUtils.has(srcFile, { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 
 test('Should allow checking if several files are cached', async t => {
-  const [cacheDir, srcFile, otherSrcFile] = await Promise.all([createTmpDir(), createTmpFile(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir], [otherSrcFile, otherSrcDir]] = await Promise.all([
+    createTmpDir(),
+    createTmpFile(),
+    createTmpFile(),
+  ])
   try {
     t.false(await cacheUtils.has([srcFile, otherSrcFile], { cacheDir }))
     t.true(await cacheUtils.save([srcFile, otherSrcFile], { cacheDir }))
     t.true(await cacheUtils.has([srcFile, otherSrcFile], { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile, otherSrcFile])
+    await removeFiles([cacheDir, srcDir, otherSrcDir])
   }
 })
 

--- a/packages/cache-utils/tests/hash.js
+++ b/packages/cache-utils/tests/hash.js
@@ -8,14 +8,14 @@ const { pWriteFile, createTmpDir, createTmpFile, removeFiles } = require('./help
 const cacheUtils = require('..')
 
 test('Should not save identically cached file', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     t.false(await cacheUtils.save(srcFile, { cacheDir }))
     await pWriteFile(srcFile, 'test')
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 

--- a/packages/cache-utils/tests/helpers/main.js
+++ b/packages/cache-utils/tests/helpers/main.js
@@ -1,21 +1,25 @@
 const { writeFile, readFile } = require('fs')
 const { promisify } = require('util')
+const { join, basename } = require('path')
 
 const del = require('del')
-const { file: getTmpFile, dir: getTmpDir } = require('tmp-promise')
+const { dir: getTmpDir, tmpName } = require('tmp-promise')
 
 const pSetTimeout = promisify(setTimeout)
 const pWriteFile = promisify(writeFile)
 const pReadFile = promisify(readFile)
 
-const createTmpDir = async function() {
-  const { path } = await getTmpDir({ prefix: PREFIX })
+const createTmpDir = async function(opts) {
+  const { path } = await getTmpDir({ ...opts, prefix: PREFIX })
   return path
 }
 
 const createTmpFile = async function(opts) {
-  const { path } = await getTmpFile({ ...opts, prefix: PREFIX })
-  return path
+  const tmpDir = await createTmpDir(opts)
+  const filename = basename(await tmpName())
+  const tmpFile = join(tmpDir, filename)
+  await pWriteFile(tmpFile, '')
+  return [tmpFile, tmpDir]
 }
 
 const PREFIX = 'test-cache-utils-'

--- a/packages/cache-utils/tests/list.js
+++ b/packages/cache-utils/tests/list.js
@@ -5,13 +5,13 @@ const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 const cacheUtils = require('..')
 
 test('Should allow listing cached files', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.deepEqual(await cacheUtils.list({ cacheDir }), [])
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
-    t.deepEqual(await cacheUtils.list({ cacheDir }), [srcFile])
+    t.deepEqual(await cacheUtils.list({ cacheDir }), [srcFile.replace(/^[a-zA-Z]:\\/, '\\')])
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 

--- a/packages/cache-utils/tests/move.js
+++ b/packages/cache-utils/tests/move.js
@@ -6,13 +6,13 @@ const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 const cacheUtils = require('..')
 
 test('Should allow moving files instead of copying them', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, move: true }))
     t.false(await pathExists(srcFile))
     t.true(await cacheUtils.restore(srcFile, { cacheDir, move: true }))
     t.true(await pathExists(srcFile))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })

--- a/packages/cache-utils/tests/path.js
+++ b/packages/cache-utils/tests/path.js
@@ -8,13 +8,13 @@ const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 const cacheUtils = require('..')
 
 test('Should allow caching files in home directory', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile({ dir: homedir() })])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile({ dir: homedir() })])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     await removeFiles(srcFile)
     t.true(await cacheUtils.restore(srcFile, { cacheDir }))
     t.true(await pathExists(srcFile))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })

--- a/packages/cache-utils/tests/remove.js
+++ b/packages/cache-utils/tests/remove.js
@@ -5,24 +5,28 @@ const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 const cacheUtils = require('..')
 
 test('Should allow removing one cached file', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     t.true(await cacheUtils.remove(srcFile, { cacheDir }))
     t.false(await cacheUtils.restore(srcFile, { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 
 test('Should allow removing several cached files', async t => {
-  const [cacheDir, srcFile, otherSrcFile] = await Promise.all([createTmpDir(), createTmpFile(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir], [otherSrcFile, otherSrcDir]] = await Promise.all([
+    createTmpDir(),
+    createTmpFile(),
+    createTmpFile(),
+  ])
   try {
     t.true(await cacheUtils.save([srcFile, otherSrcFile], { cacheDir }))
     t.true(await cacheUtils.remove([srcFile, otherSrcFile], { cacheDir }))
     t.false(await cacheUtils.restore([srcFile, otherSrcFile], { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile, otherSrcFile])
+    await removeFiles([cacheDir, srcDir, otherSrcDir])
   }
 })
 

--- a/packages/cache-utils/tests/save_restore.js
+++ b/packages/cache-utils/tests/save_restore.js
@@ -10,26 +10,30 @@ test('Should expose several methods', async t => {
 })
 
 test('Should cache and restore one file', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     await removeFiles(srcFile)
     t.true(await cacheUtils.restore(srcFile, { cacheDir }))
     t.true(await pathExists(srcFile))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 
 test('Should cache and restore several files', async t => {
-  const [cacheDir, srcFile, otherSrcFile] = await Promise.all([createTmpDir(), createTmpFile(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir], [otherSrcFile, otherSrcDir]] = await Promise.all([
+    createTmpDir(),
+    createTmpFile(),
+    createTmpFile(),
+  ])
   try {
     t.true(await cacheUtils.save([srcFile, otherSrcFile], { cacheDir }))
     await removeFiles(srcFile)
     t.true(await cacheUtils.restore([srcFile, otherSrcFile], { cacheDir }))
     t.deepEqual(await Promise.all([pathExists(srcFile), pathExists(otherSrcFile)]), [true, true])
   } finally {
-    await removeFiles([cacheDir, srcFile, otherSrcFile])
+    await removeFiles([cacheDir, srcDir, otherSrcDir])
   }
 })
 
@@ -48,7 +52,7 @@ test('Should cache and restore one directory', async t => {
 })
 
 test('Should keep file contents when caching files', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     await pWriteFile(srcFile, 'test')
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
@@ -57,12 +61,12 @@ test('Should keep file contents when caching files', async t => {
     t.true(await pathExists(srcFile))
     t.is(await pReadFile(srcFile, 'utf8'), 'test')
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 
 test('Should overwrite files on restore', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     await pWriteFile(srcFile, 'test')
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
@@ -71,7 +75,7 @@ test('Should overwrite files on restore', async t => {
     t.true(await pathExists(srcFile))
     t.is(await pReadFile(srcFile, 'utf8'), 'test')
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 

--- a/packages/cache-utils/tests/ttl.js
+++ b/packages/cache-utils/tests/ttl.js
@@ -6,35 +6,35 @@ const cacheUtils = require('..')
 
 // Relies on timing
 test.serial('Should allow a TTL on cached files', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, ttl: 1 }))
     await pSetTimeout(2e3)
     t.false(await cacheUtils.has(srcFile, { cacheDir }))
     t.false(await cacheUtils.restore(srcFile, { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 
 test.serial('Should skip TTL when the value is invalid', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, ttl: '1' }))
     await pSetTimeout(2e3)
     t.true(await cacheUtils.has(srcFile, { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })
 
 test.serial('Should skip TTL when the value is negative', async t => {
-  const [cacheDir, srcFile] = await Promise.all([createTmpDir(), createTmpFile()])
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, ttl: -1 }))
     await pSetTimeout(2e3)
     t.true(await cacheUtils.has(srcFile, { cacheDir }))
   } finally {
-    await removeFiles([cacheDir, srcFile])
+    await removeFiles([cacheDir, srcDir])
   }
 })


### PR DESCRIPTION
Creating a regular file (non-directory) in the temporary directory on Windows fails (as opposed to Unix) with an `EPERM` error:

```js
const { tmpdir } = require('os')
const { writeFile } = require('fs')
const { join } = require('path')

const filePath = join(os.tmpdir(), 'test.js')
// This fails on Windows
writeFile(filePath, 'hello', console.log)
```

The tests of the `cache` utility currently rely on the pattern above, which makes them fail on Windows. This PR fixes that by creating the temporary file inside a subdirectory instead.

Since the subdirectory should be cleaned up after the test, the test helper must return it, together with the path to the test file (which is used in the test itself).