### PR TITLE
Fix GitHub labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: 'Please replace with a clear and descriptive title'
-labels: bug
+labels: 'type: bug'
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: 'Please replace with a clear and descriptive title'
-labels: enhancement
+labels: 'type: feature'
 assignees: ''
 ---
 


### PR DESCRIPTION
Improve issue templates to match our new company-wise GitHub labels.