### PR TITLE
Improve npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,19 +7,19 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap",
-    "update-snapshots": "ava -u",
-    "test": "run-s test:* test:dev:*",
-    "test-ci": "run-s test:* test:ci:*",
-    "pre-push": "run-s test:*",
-    "test:toc": "doctoc README.md",
-    "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{packages,scripts}/**/*.js\"",
-    "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{.github,packages,scripts}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
+    "test": "run-s format:* test:dev:*",
+    "test-ci": "run-s format:* test:ci:*",
+    "format": "run-s format:*",
+    "format:toc": "doctoc README.md",
+    "format:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{packages,scripts}/**/*.js\"",
+    "format:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{.github,packages,scripts}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
     "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava"
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
+    "update-snapshots": "ava -u"
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run pre-push"
+      "pre-push": "npm run format"
     }
   },
   "keywords": [


### PR DESCRIPTION
This is a small improvement of npm scripts:
  - rename `pre-push` to `format`
  - distinguish between formatting tasks and automated tests
  - merge some npm scripts
  - re-order some npm scripts