### PR TITLE
Document NETLIFY_BUILD_CLI_VERSION

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,9 @@ This is a monorepo. Below are a list of packages included.
 
 See our [testing documentation](packages/build/tests/README.md) to learn about our integration tests setup.
 
+To test a beta release of `@netlify/build` in a site on Netlify, set the environment variable
+`NETLIFY_BUILD_CLI_VERSION` to the NPM tag you wish to use.
+
 ## Requirements
 
 Linting is performed with ESLint using the [following configuration](.eslintrc.json).


### PR DESCRIPTION
**Which problem is this pull request solving?**

Testing beta versions of `@netlify/build` in production is supported, but not documented.

**List other issues or pull requests related to this problem**

https://github.com/netlify/buildbot/issues/503

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
