### PR TITLE
Run GitHub actions on PRs coming from forks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [push]
+on:
+  # Ensure GitHub actions are not run twice for same commits
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+    types: [opened, synchronize, reopened]
 env:
   CI: 'true'
 jobs:


### PR DESCRIPTION
PRs coming from forks do not currently trigger GitHub actions. This fixes that.