### PR TITLE
Separate linting and testing in GitHub actions UI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,9 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm install
+      - name: Linting
+        run: npm run format
       - name: Tests
-        run: npm run test-ci
+        run: npm run test:ci
       - name: Codecov test coverage
         run: bash scripts/coverage.sh "${{ secrets.CODECOV_TOKEN }}" "${{ matrix.os }}" "${{ matrix.node }}"

--- a/package.json
+++ b/package.json
@@ -7,14 +7,13 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap",
-    "test": "run-s format:* test:dev:*",
-    "test-ci": "run-s format:* test:ci:*",
+    "test": "npm run format && npm run test:dev",
     "format": "run-s format:*",
     "format:toc": "doctoc README.md",
     "format:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"{packages,scripts}/**/*.js\"",
     "format:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"{.github,packages,scripts}/**/*.{js,md,yml,json}\" \"*.{js,md,yml,json}\"",
-    "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
+    "test:dev": "ava",
+    "test:ci": "nyc -r lcovonly -r text -r json ava",
     "update-snapshots": "ava -u"
   },
   "husky": {


### PR DESCRIPTION
This splits linting and steps into two separate steps in the GitHub actions UI. This makes looking for the logs or the duration of either step easier.