### PR TITLE
Remove Codecov token from GitHub action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Tests
         run: npm run test-ci
       - name: Codecov test coverage
-        run: bash scripts/coverage.sh "${{ secrets.CODECOV_TOKEN }}" "${{ matrix.os }}" "${{ matrix.node }}"
+        run: bash scripts/coverage.sh "${{ matrix.os }}" "${{ matrix.node }}"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 # Upload test coverage to Codecov
 
-token="$1"
-
-os="$2"
+os="$1"
 os="${os/-latest/}"
 
-node="$3"
+node="$2"
 node="node_${node//./_}"
 
 curl -s https://codecov.io/bash | \
-  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t "$token" -F "$os" -F "$node"
+  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -F "$os" -F "$node"


### PR DESCRIPTION
The Codecov access token is not needed in public repositories to upload test coverage maps. This PR fixes that.