### PR TITLE
Do not allow caching the current directory or any parent

### DIFF
--- a/packages/cache-utils/tests/path.js
+++ b/packages/cache-utils/tests/path.js
@@ -18,3 +18,11 @@ test('Should allow caching files in home directory', async t => {
     await removeFiles([cacheDir, srcDir])
   }
 })
+
+test('Should not allow caching the current directory', async t => {
+  await t.throwsAsync(cacheUtils.save('.'))
+})
+
+test('Should not allow caching a direct parent directory', async t => {
+  await t.throwsAsync(cacheUtils.save('..'))
+})


### PR DESCRIPTION
When the `cache` utility restores previously cached files/directories, those are overwritten. 
Therefore we should forbid caching the repository root directory (which is the current directory from the standpoint of the `cache` utility) or any direct parent of it.
This otherwise creates the [problems experienced](https://github.com/jlengstorf/netlify-plugin-gatsby-cache/issues/8) for example by our Gatsby plugin.

This PR adds validation against this problem and some tests for this new validation.