### PR TITLE
Fix `utils.cache.save()` return value

### DIFF
--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -19,7 +19,7 @@ const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, d
 
   const { manifestInfo, identical } = await getManifestInfo({ cachePath, move, ttl, digests })
   if (identical) {
-    return false
+    return true
   }
 
   await del(cachePath, { force: true })

--- a/packages/cache-utils/tests/digests.js
+++ b/packages/cache-utils/tests/digests.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { pWriteFile, createTmpDir, removeFiles } = require('./helpers/main')
+const { pWriteFile, pReadFile, createTmpDir, removeFiles } = require('./helpers/main')
 
 const cacheUtils = require('..')
 
@@ -12,9 +12,10 @@ test('Should allow caching according to a digest file', async t => {
     await Promise.all([pWriteFile(srcFile, 'test'), pWriteFile(digest, 'digest')])
     t.true(await cacheUtils.save(srcDir, { cacheDir, digests: [digest] }))
     await pWriteFile(srcFile, 'newTest')
-    t.false(await cacheUtils.save(srcDir, { cacheDir, digests: [digest] }))
-    await pWriteFile(digest, 'newDigest')
     t.true(await cacheUtils.save(srcDir, { cacheDir, digests: [digest] }))
+    t.true(await cacheUtils.restore(srcDir, { cacheDir, digests: [digest] }))
+    const content = await pReadFile(srcFile, 'utf8')
+    t.is(content, 'test')
   } finally {
     await removeFiles([cacheDir, srcDir])
   }
@@ -29,9 +30,10 @@ test('Should allow caching according to several potential digests files', async 
     await Promise.all([pWriteFile(srcFile, 'test'), pWriteFile(digest, 'digest')])
     t.true(await cacheUtils.save(srcDir, { cacheDir, digests: [digestTwo, digest] }))
     await pWriteFile(srcFile, 'newTest')
-    t.false(await cacheUtils.save(srcDir, { cacheDir, digests: [digestTwo, digest] }))
-    await pWriteFile(digest, 'newDigest')
     t.true(await cacheUtils.save(srcDir, { cacheDir, digests: [digestTwo, digest] }))
+    t.true(await cacheUtils.restore(srcDir, { cacheDir, digests: [digestTwo, digest] }))
+    const content = await pReadFile(srcFile, 'utf8')
+    t.is(content, 'test')
   } finally {
     await removeFiles([cacheDir, srcDir])
   }


### PR DESCRIPTION
`utils.cache.save()` returns a boolean indicating whether the file was found and it was properly cached.

We have a `digests` option as a performance optimization. When a digest file (like `package-lock.json`) in the cache is identical to the local file, we skip caching since the directory to cache is identical. At the moment, when that happens, we return `false`. However we should return `true` since that is just a performance optimization, which should behave just as if the cache actually got cached.

Some tests were adjusted accordingly.