### PR TITLE
Upgrade `minimist`

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -14486,11 +14486,11 @@
       }
     },
     "gonzales-pe": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
-      "integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "^1.2.5"
       }
     },
     "got": {
@@ -15630,9 +15630,9 @@
       }
     },
     "minimist": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-      "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "3.0.2",


### PR DESCRIPTION
Upgrades `minimist` dependency to fix a security vulnerability reported both by GitHub and `npm audit`.