### PR TITLE
Improve documentation for `utils.build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ module.exports = {
     try {
       badMethod()
     } catch (error) {
-      utils.build.failBuild('Failure message')
+      return utils.build.failBuild('Failure message')
     }
   },
 }
@@ -269,8 +269,6 @@ The following methods are available depending on the error's type:
 - `utils.build.failPlugin('message')`: fails the plugin but not the build.
 - `utils.build.cancelBuild('message')`: cancels the build - the dashboard would show “Cancelled” for that build. Use
   this to indicate that the build is being cancelled as planned.
-
-This works inside `async` event handlers as well.
 
 `utils.build.failBuild()`, `utils.build.failPlugin()` and `utils.build.cancelBuild()` can specify an options object with
 the following properties:
@@ -286,7 +284,7 @@ module.exports = {
     try {
       badMethod()
     } catch (error) {
-      utils.build.failBuild('Failure message', { error })
+      return utils.build.failBuild('Failure message', { error })
     }
   },
 }


### PR DESCRIPTION
The methods in `utils.build.*` interrupt the current function. Under the hood, they actually throw an error. Although not strictly necessary, we should recommend prepending `return` to those methods since it makes it clear that the control flow is being interrupted both to human readers and to linters.

This PR updates the documentation accordingly.

It also removes a sentence about those methods working with `async` event handlers. Since we support `async` event handlers, users will probably assume our utilities work with them, so there's no need to specify it.