### PR TITLE
Remove dead code in `.eslintrc.json`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,16 +31,9 @@
   },
   "overrides": [
     {
-      "files": ["**/*.test.js", "scripts/**/*.js"],
+      "files": ["**/*.test.js"],
       "rules": {
         "node/no-unpublished-require": 0,
-        "node/no-missing-require": 0
-      }
-    },
-    {
-      "files": ["packages/build/scaffold/**/*.js"],
-      "rules": {
-        "node/no-extraneous-require": 0,
         "node/no-missing-require": 0
       }
     }


### PR DESCRIPTION
This removes some dead code in `.eslintrc.json`:
  - the `scaffold` directory does not exist anymore
  - the `scripts/docs.js` file does not exist anymore