### PR TITLE
Fix bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what the bug is.
 - If using the CLI, please enter the following command in a terminal and copy/paste its output:
 
 ```bash
-npx envinfo --system --binaries --npmPackages @netlify/build,@netlify/config,@netlify/git-utils,@netlify/cache-utils,@netlify/functions-utils,@netlify/run-utils,netlify-cli
+npx envinfo --system --binaries --npmPackages @netlify/build,@netlify/config,@netlify/git-utils,@netlify/cache-utils,@netlify/functions-utils,@netlify/run-utils,netlify-cli --npmGlobalPackages @netlify/build,netlify-cli
 ```
 
 **Deploy logs**


### PR DESCRIPTION
The bug report template does not correctly report the version of Netlify CLI used by the user when this is installed as a global binary. This PR fixes this.