### PR TITLE
Add more information about dynamic events

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ are **now in public beta.** Learn how to enable your site to use Netlify Build a
   - [Validating plugin inputs](#validating-plugin-inputs)
   - [Plugin constants](#plugin-constants)
   - [Error reporting](#error-reporting)
+  - [Dynamic events](#dynamic-events)
 - [Publishing a plugin](#publishing-a-plugin)
   - [Sharing with the community](#sharing-with-the-community)
 - [Contributors](#contributors)
@@ -177,25 +178,6 @@ module.exports = {
 }
 ```
 
-Instead of a plugin being a simple object, it can also be a function returning an object:
-
-```js
-// index.js
-
-module.exports = function helloWorldPlugin(inputs) {
-  console.log(inputs.foo) // bar
-  console.log(inputs.fizz) // pop
-
-  return {
-    onPreBuild: ({ inputs, netlifyConfig, constants }) => {
-      console.log('Hello world from onPreBuild event!')
-      console.log(inputs.foo) // bar
-      console.log(inputs.fizz) // pop
-    },
-  }
-}
-```
-
 ### Validating plugin inputs
 
 The plugin inputs can be validated using the `inputs` property in the plugin `manifest.yml` file:
@@ -289,6 +271,31 @@ module.exports = {
       utils.build.failBuild('Failure message', { error })
     }
   },
+}
+```
+
+### Dynamic events
+
+Some plugins trigger different events depending on the user's `inputs`. This can be achieved by returning the plugin
+object from a function instead.
+
+```js
+// index.js
+
+module.exports = function helloWorldPlugin(inputs) {
+  if (inputs.before) {
+    return {
+      onPreBuild: () => {
+        console.log('Hello world from onPreBuild event!')
+      },
+    }
+  } else {
+    return {
+      onPostBuild: () => {
+        console.log('Hello world from onPostBuild event!')
+      },
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Plugins can be top-level functions returning the plugin object.

The only use of this feature (as opposed to using logic at the top-level scope) is when the events that get triggered depend on user inputs. This is rather an edge case.

This PR rework the documentation of this feature to make its purpose clearer.