### PR TITLE
Fix outdated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Now, let's run the build!
 netlify build
 ```
 
-This will execute our `onPreBuild` function and the `npm run build` command.
+This will execute our `onPreBuild` function.
 
 ### Adding inputs to plugins
 


### PR DESCRIPTION
The `README.md` mentions that builds will run `npm run build` but this is incorrect. 

Probably, a `package.json` was previously documented there with a `build.command` `npm run build`.

This PR removes that statement.