### PR TITLE
Add documentation about the Node.js environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ A plugin consists of two files:
 The plugin defined above will log out `Hello world from onPreBuild event!` right before the site's build commands are
 run.
 
+The `index.js` file runs in a regular Node.js environment and can use any
+[Node.js core methods](https://nodejs.org/api/) and [modules](https://www.npmjs.com/).
+[Environment variables](https://docs.netlify.com/configure-builds/environment-variables/) can be accessed with
+[`process.env`](https://nodejs.org/api/process.html#process_process_env).
+
 Save the `index.js` file locally to a `./plugins/netlify-plugin-hello-world`. This will allow us to use the plugin in
 the next step.
 


### PR DESCRIPTION
Fixes #1094.

This adds more documentation about the Node.js environment in which Build plugins run.