### PR TITLE
Remove backward compatibility for the `--mode` CLI flag

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -1,5 +1,5 @@
 const {
-  env: { NETLIFY_AUTH_TOKEN, NETLIFY },
+  env: { NETLIFY_AUTH_TOKEN },
   execPath,
 } = require('process')
 
@@ -82,7 +82,7 @@ const loadConfig = async function(flags) {
 const DEFAULT_FLAGS = {
   nodePath: execPath,
   token: NETLIFY_AUTH_TOKEN,
-  mode: NETLIFY ? 'buildbot' : 'require',
+  mode: 'require',
 }
 
 // Retrieve configuration file and related information

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -26,6 +26,7 @@ const getColorLevel = function() {
   }
 
   // This also ensure colors are used in the BuildBot
+  // We cannot use the --mode CLI flag since this must be loaded before `chalk`
   if (env.NETLIFY) {
     return '1'
   }

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -1,6 +1,6 @@
 const {
   cwd: getCwd,
-  env: { CONTEXT, NETLIFY },
+  env: { CONTEXT },
 } = require('process')
 
 const { throwError } = require('../error')
@@ -29,7 +29,7 @@ const normalizeOpts = async function(opts) {
 const DEFAULT_OPTS = {
   cwd: getCwd(),
   context: CONTEXT || 'production',
-  mode: NETLIFY ? 'buildbot' : 'require',
+  mode: 'require',
 }
 
 // Verify that options point to existing directories


### PR DESCRIPTION
The `--mode` CLI flag introduced by #1107 is going to be used by the buildbot (https://github.com/netlify/buildbot/pull/672). We had a backward compatibility fix to use the `NETLIFY` environment variable until the buildbot starts passing the `--mode` CLI flag. This fix is not needed anymore, therefore this PR removes it.

Merging this PR requires the buildbot PR being deployed to production first.