### PR TITLE
Improve handling of errors when plugins start

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -174,10 +174,12 @@ const firePluginCommand = async function({ childProcess, event, package, package
   const outputState = startOutput(childProcess, mode)
 
   try {
-    await callChild(childProcess, 'run', { event, error })
-  } catch (error) {
-    addErrorInfo(error, { plugin: { packageJson, package }, location: { event, package, local } })
-    throw error
+    await callChild(
+      childProcess,
+      'run',
+      { event, error },
+      { plugin: { packageJson, package }, location: { event, package, local } },
+    )
   } finally {
     await stopOutput(childProcess, mode, outputState)
   }

--- a/packages/build/src/error/build.js
+++ b/packages/build/src/error/build.js
@@ -2,7 +2,7 @@ const { addErrorInfo } = require('./info')
 
 // Retrieve error information from child process and re-build it in current
 // process. We need this since errors are not JSON-serializable.
-const buildError = function({ type, name, message, stack, ...errorProps }) {
+const buildError = function({ type, plugin, location, name, message, stack, ...errorProps }) {
   const error = new Error('')
 
   assignErrorProps(error, { name, message, stack })
@@ -11,7 +11,7 @@ const buildError = function({ type, name, message, stack, ...errorProps }) {
 
   // Distinguish between utils.build.*() errors and uncaught exceptions / bugs
   if (type !== undefined) {
-    addErrorInfo(error, { type })
+    addErrorInfo(error, { type, plugin, location })
   }
   return error
 }

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -1,6 +1,5 @@
 const groupBy = require('group-by')
 
-const { addErrorInfo } = require('../error/info')
 const { logLoadPlugins, logLoadedPlugins } = require('../log/main')
 
 const { callChild } = require('./ipc')
@@ -38,29 +37,21 @@ const loadPlugin = async function(
 ) {
   const { childProcess } = childProcesses[index]
 
-  try {
-    const { pluginCommands } = await callChild(childProcess, 'load', {
-      pluginPath,
-      manifest,
-      inputs,
-      netlifyConfig,
-      utilsData,
-      token,
-      constants,
-    })
-    const pluginCommandsA = pluginCommands.map(pluginCommand => ({
-      ...pluginCommand,
-      package,
-      core,
-      local,
-      packageJson,
-      childProcess,
-    }))
-    return pluginCommandsA
-  } catch (error) {
-    addErrorInfo(error, { plugin: { package, packageJson }, location: { event: 'load', package, local } })
-    throw error
-  }
+  const { pluginCommands } = await callChild(
+    childProcess,
+    'load',
+    { pluginPath, manifest, inputs, netlifyConfig, utilsData, token, constants },
+    { plugin: { package, packageJson }, location: { event: 'load', package, local } },
+  )
+  const pluginCommandsA = pluginCommands.map(pluginCommand => ({
+    ...pluginCommand,
+    package,
+    core,
+    local,
+    packageJson,
+    childProcess,
+  }))
+  return pluginCommandsA
 }
 
 module.exports = { loadPlugins }

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -3,6 +3,7 @@ const { promisify } = require('util')
 
 const resolve = require('resolve')
 
+const corePackageJson = require('../../package.json')
 const { installMissingPlugins } = require('../install/missing')
 const { CORE_PLUGINS } = require('../plugins_core/main')
 
@@ -36,4 +37,11 @@ const loadPluginFiles = async function({ pluginOptions, pluginOptions: { locatio
   return { ...pluginOptions, pluginPath, packageDir, packageJson, manifest, inputs: inputsA }
 }
 
-module.exports = { getPluginsOptions }
+// Retrieve information about @netlify/build when an error happens there and not
+// in a plugin
+const getCoreInfo = function() {
+  const { name } = corePackageJson
+  return { package: name, packageJson: corePackageJson, local: false }
+}
+
+module.exports = { getPluginsOptions, getCoreInfo }


### PR DESCRIPTION
When plugins start, we first spawn a child process before loading the plugin main JavaScript file. Spawning this child process is supposed to never fail, but it could fail for example if there is a bug in `@netlify/build`. 

This PR adds additional error information if this were to happen. Adding a test for it was difficult since theoretically child processes are not supposed to fail on spawn. However we have many tests covering child process errors in general, and all are passing.