### PR TITLE
Use consistent colors

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -1,9 +1,11 @@
 require('../utils/polyfills')
 
-// This needs to be done before `chalk` is loaded
+// This needs to be done before `chalk` is loaded.
+// Note: `chalk` is also required by some of our dependencies.
 // eslint-disable-next-line import/order
 const { setColorLevel } = require('../log/colors')
 setColorLevel()
+
 require('../error/process')
 
 const { getChildEnv } = require('../env/main')

--- a/packages/build/src/error/location.js
+++ b/packages/build/src/error/location.js
@@ -1,5 +1,3 @@
-const { white } = require('chalk')
-
 // Retrieve an error's location to print in logs.
 // Each error type has its own logic (or none if there's no location to print).
 const getLocationBlock = function({ stack, location, getLocation }) {
@@ -23,8 +21,8 @@ const serializeLocation = function({ stack, location, getLocation }) {
 }
 
 const getShellCommandLocation = function({ prop, shellCommand }) {
-  return `In configuration "${white.bold(prop)}" command:
-${white.bold(shellCommand)}`
+  return `In configuration "${prop}" command:
+${shellCommand}`
 }
 
 const getBuildFailLocation = function({ event, package, local }) {
@@ -35,15 +33,15 @@ const getBuildFailLocation = function({ event, package, local }) {
 
 const getEventMessage = function(event) {
   if (event === 'load') {
-    return `While ${white.bold('loading')}`
+    return `While loading`
   }
 
-  return `In "${white.bold(event)}" event in`
+  return `In "${event}" event in`
 }
 
 const getPackageLocation = function(package, local) {
   const localString = local ? 'local plugin' : 'npm package'
-  return `${localString} "${white.bold(package)}"`
+  return `${localString} "${package}"`
 }
 
 const getApiLocation = function({ endpoint, parameters }) {

--- a/packages/build/src/error/serialize.js
+++ b/packages/build/src/error/serialize.js
@@ -1,9 +1,8 @@
 const { inspect } = require('util')
 
-const { redBright } = require('chalk')
-
 const { EMPTY_LINE, HEADING_PREFIX } = require('../log/constants')
 const { indent } = require('../log/serialize')
+const { THEME } = require('../log/theme')
 const { omit } = require('../utils/omit')
 
 const { getErrorInfo, INFO_SYM } = require('./info')
@@ -14,12 +13,12 @@ const { getTypeInfo } = require('./type')
 
 // Serialize an error object into a header|body string to print in logs
 const serializeError = function({ message, stack, ...errorProps }) {
-  const { header, color = redBright, ...typeInfo } = getTypeInfo(errorProps)
+  const { header, isSuccess = false, ...typeInfo } = getTypeInfo(errorProps)
   const errorInfo = getErrorInfo(errorProps)
   const errorPropsA = cleanErrorProps(errorProps)
   const headerA = getHeader(header, errorInfo)
-  const body = getBody({ typeInfo, color, message, stack, errorProps: errorPropsA, ...errorInfo })
-  return { header: headerA, body, color }
+  const body = getBody({ typeInfo, isSuccess, message, stack, errorProps: errorPropsA, ...errorInfo })
+  return { header: headerA, body, isSuccess }
 }
 
 // Remove error static properties that should not be logged
@@ -41,7 +40,7 @@ const getHeader = function(header, errorInfo) {
 // Retrieve body to print in logs
 const getBody = function({
   typeInfo: { stackType, getLocation, showErrorProps, rawStack },
-  color,
+  isSuccess,
   message,
   stack,
   errorProps,
@@ -55,7 +54,7 @@ const getBody = function({
   const errorPropsBlock = getErrorPropsBlock(errorProps, showErrorProps)
   return [messageBlock, pluginBlock, locationBlock, errorPropsBlock]
     .filter(Boolean)
-    .map(({ name, value }) => serializeBlock({ name, value, color }))
+    .map(({ name, value }) => serializeBlock({ name, value, isSuccess }))
     .join(`${EMPTY_LINE}\n${EMPTY_LINE}\n`)
 }
 
@@ -69,8 +68,9 @@ const getErrorPropsBlock = function(errorProps, showErrorProps) {
   return { name: 'Error properties', value }
 }
 
-const serializeBlock = function({ name, value, color }) {
-  return `${color.bold(`${HEADING_PREFIX} ${name}`)}
+const serializeBlock = function({ name, value, isSuccess }) {
+  const color = isSuccess ? THEME.subHeader : THEME.errorSubHeader
+  return `${color(`${HEADING_PREFIX} ${name}`)}
 ${indent(value)}`
 }
 

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -1,5 +1,3 @@
-const { yellowBright } = require('chalk')
-
 const { getErrorInfo } = require('./info')
 const { getShellCommandLocation, getBuildFailLocation, getApiLocation } = require('./location')
 
@@ -34,7 +32,7 @@ const TYPES = {
     header: 'Build canceled',
     stackType: 'stack',
     getLocation: getBuildFailLocation,
-    color: yellowBright,
+    isSuccess: true,
     shouldCancel: true,
   },
   ipc: {

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -3,7 +3,6 @@ const {
   env: { NETLIFY_BUILD_DEBUG },
 } = require('process')
 
-const { greenBright, cyan, cyanBright, redBright, yellowBright, bold, white, dim } = require('chalk')
 const prettyMs = require('pretty-ms')
 const stringWidth = require('string-width')
 
@@ -15,13 +14,14 @@ const { omit } = require('../utils/omit')
 const { EMPTY_LINE, HEADING_PREFIX, ARROW_DOWN } = require('./constants')
 const { log } = require('./logger')
 const { serialize, SUBTEXT_PADDING, indent } = require('./serialize')
+const { THEME } = require('./theme')
 
 const logBuildStart = function() {
   log(
     `${EMPTY_LINE}
-${greenBright.bold(getHeader('Netlify Build'))}
+${THEME.header(getHeader('Netlify Build'))}
 ${EMPTY_LINE}
-${cyanBright.bold(`${HEADING_PREFIX} Version`)}
+${THEME.subHeader(`${HEADING_PREFIX} Version`)}
 ${SUBTEXT_PADDING}${name} ${version}
 ${EMPTY_LINE}`,
   )
@@ -30,19 +30,19 @@ ${EMPTY_LINE}`,
 const logFlags = function(flags) {
   const hiddenFlags = flags.mode === 'buildbot' ? [...HIDDEN_FLAGS, 'nodePath'] : HIDDEN_FLAGS
   const flagsA = omit(flags, hiddenFlags)
-  log(cyanBright.bold(`${HEADING_PREFIX} Flags`), serialize(flagsA), EMPTY_LINE)
+  log(THEME.subHeader(`${HEADING_PREFIX} Flags`), serialize(flagsA), EMPTY_LINE)
 }
 
 const HIDDEN_FLAGS = ['token', 'cachedConfig', 'defaultConfig']
 
 const logBuildDir = function(buildDir) {
-  log(`${cyanBright.bold(`${HEADING_PREFIX} Current directory`)}
+  log(`${THEME.subHeader(`${HEADING_PREFIX} Current directory`)}
 ${SUBTEXT_PADDING}${buildDir}
 ${EMPTY_LINE}`)
 }
 
 const logConfigPath = function(configPath = NO_CONFIG_MESSAGE) {
-  log(`${cyanBright.bold(`${HEADING_PREFIX} Config file`)}
+  log(`${THEME.subHeader(`${HEADING_PREFIX} Config file`)}
 ${SUBTEXT_PADDING}${configPath}
 ${EMPTY_LINE}`)
 }
@@ -54,7 +54,7 @@ const logConfig = function(config) {
     return
   }
 
-  log(cyanBright.bold(`${HEADING_PREFIX} Resolved config`), serialize(simplifyConfig(config)), EMPTY_LINE)
+  log(THEME.subHeader(`${HEADING_PREFIX} Resolved config`), serialize(simplifyConfig(config)), EMPTY_LINE)
 }
 
 // The resolved configuration gets assigned some default values (empty objects and arrays)
@@ -86,20 +86,20 @@ const logContext = function(context) {
     return
   }
 
-  log(`${cyanBright.bold(`${HEADING_PREFIX} Context`)}
+  log(`${THEME.subHeader(`${HEADING_PREFIX} Context`)}
 ${SUBTEXT_PADDING}${context}
 ${EMPTY_LINE}`)
 }
 
 const logInstallMissingPlugins = function(packages) {
-  log(`${cyanBright.bold(`${HEADING_PREFIX} Installing plugins`)}
+  log(`${THEME.subHeader(`${HEADING_PREFIX} Installing plugins`)}
 ${indent(serializeList(packages))}
 ${EMPTY_LINE}`)
 }
 
 const logInstallLocalPluginsDeps = function(localPluginsOptions) {
   const packages = localPluginsOptions.map(getPackage)
-  log(`${cyanBright.bold(`${HEADING_PREFIX} Installing local plugins dependencies`)}
+  log(`${THEME.subHeader(`${HEADING_PREFIX} Installing local plugins dependencies`)}
 ${indent(serializeList(packages))}
 ${EMPTY_LINE}`)
 }
@@ -109,7 +109,7 @@ const getPackage = function({ package }) {
 }
 
 const logLoadPlugins = function() {
-  log(cyanBright.bold(`${HEADING_PREFIX} Loading plugins`))
+  log(THEME.subHeader(`${HEADING_PREFIX} Loading plugins`))
 }
 
 const logLoadedPlugins = function(pluginCommands) {
@@ -128,7 +128,7 @@ const isNotDuplicate = function(pluginCommand, index, pluginCommands) {
 
 const getLoadedPlugin = function({ package, core, packageJson: { version } }) {
   const location = core ? ' from build core' : version === undefined ? '' : `@${version}`
-  return `${SUBTEXT_PADDING} - ${greenBright.bold(package)}${location}`
+  return `${SUBTEXT_PADDING} - ${package}${location}`
 }
 
 const logDryRunStart = function(eventWidth, commandsCount) {
@@ -137,12 +137,12 @@ const logDryRunStart = function(eventWidth, commandsCount) {
   const secondLine = '─'.repeat(columnWidth)
 
   log(`
-${cyanBright.bold(`${HEADING_PREFIX} Netlify Build Commands`)}
+${THEME.subHeader(`${HEADING_PREFIX} Netlify Build Commands`)}
 ${SUBTEXT_PADDING}For more information on build events see the docs https://github.com/netlify/build
 
 ${SUBTEXT_PADDING}Running \`netlify build\` will execute this build flow
 
-${bold(`${SUBTEXT_PADDING}┌─${line}─┬─${secondLine}─┐
+${THEME.header(`${SUBTEXT_PADDING}┌─${line}─┬─${secondLine}─┐
 ${SUBTEXT_PADDING}│ ${DRY_HEADER_NAMES[0].padEnd(columnWidth)} │ ${DRY_HEADER_NAMES[1].padEnd(columnWidth)} │
 ${SUBTEXT_PADDING}└─${line}─┴─${secondLine}─┘`)}`)
 }
@@ -162,22 +162,22 @@ const logDryRunCommand = function({
   const location = getPluginLocation({ prop, package, core, configPath })
 
   log(
-    cyanBright.bold(`${SUBTEXT_PADDING}┌─${line}─┐
-${SUBTEXT_PADDING}│ ${cyanBright(countText)}${event.padEnd(eventWidthA)}${downArrow} │ ${location}
-${SUBTEXT_PADDING}└─${line}─┘ `),
+    `${THEME.header(`${SUBTEXT_PADDING}┌─${line}─┐`)}
+${THEME.header(`${SUBTEXT_PADDING}│ ${countText}${event.padEnd(eventWidthA)}${downArrow} │`)} ${location}
+${THEME.header(`${SUBTEXT_PADDING}└─${line}─┘ `)}`,
   )
 }
 
 const getPluginLocation = function({ prop, package, core, configPath }) {
   if (prop !== undefined) {
-    return `${white('Config')} ${cyanBright(basename(configPath))} ${yellowBright(prop)}`
+    return `Config ${basename(configPath)} ${THEME.highlightWords(prop)}`
   }
 
   if (core) {
-    return `${white('Plugin')} ${yellowBright(package)} in build core`
+    return `Plugin ${THEME.highlightWords(package)} in build core`
   }
 
-  return `${white('Plugin')} ${yellowBright(package)}`
+  return `Plugin ${THEME.highlightWords(package)}`
 }
 
 const getDryColumnWidth = function(eventWidth, commandsCount) {
@@ -195,19 +195,16 @@ ${EMPTY_LINE}`)
 
 const logCommand = function({ event, prop, package }, { index, configPath, error }) {
   const configName = configPath === undefined ? '' : ` from ${basename(configPath)} config file`
-  const description =
-    prop === undefined ? `${bold(event)} command from ${bold(package)}` : `${bold(prop)} command${configName}`
-  const logColor = error ? redBright.bold : cyanBright.bold
+  const description = prop === undefined ? `${event} command from ${package}` : `${prop} command${configName}`
+  const logColor = error ? THEME.errorHeader : THEME.header
   const header = `${index}. ${description}`
-  log(
-    logColor(`
-${getHeader(header)}
-${EMPTY_LINE}`),
-  )
+  log(`
+${logColor(getHeader(header))}
+${EMPTY_LINE}`)
 }
 
 const logShellCommandStart = function(shellCommand) {
-  log(cyan(`$ ${shellCommand}`))
+  log(THEME.highlightWords(`$ ${shellCommand}`))
 }
 
 const logCommandSuccess = function() {
@@ -216,11 +213,11 @@ const logCommandSuccess = function() {
 
 const logTimer = function(durationMs, timerName) {
   const duration = prettyMs(durationMs)
-  log(dim(`(${timerName} completed in ${duration})`))
+  log(THEME.dimWords(`(${timerName} completed in ${duration})`))
 }
 
 const logCacheStart = function() {
-  log(cyanBright.bold(`${HEADING_PREFIX} Caching artifacts`))
+  log(THEME.subHeader(`${HEADING_PREFIX} Caching artifacts`))
 }
 
 const logCacheDir = function(path) {
@@ -228,27 +225,27 @@ const logCacheDir = function(path) {
 }
 
 const logPluginError = function(error) {
-  const { header, body, color } = serializeError(error)
-  log(`${color.bold(getHeader(header))}
+  const { header, body, isSuccess } = serializeError(error)
+  const color = isSuccess ? THEME.header : THEME.errorHeader
+  log(`${color(getHeader(header))}
 ${EMPTY_LINE}
 ${body}`)
 }
 
 const logBuildError = function(error) {
-  const { header, body, color } = serializeError(error)
+  const { header, body, isSuccess } = serializeError(error)
+  const color = isSuccess ? THEME.header : THEME.errorHeader
   log(`${EMPTY_LINE}
-${color.bold(getHeader(header))}
+${color(getHeader(header))}
 ${EMPTY_LINE}
 ${body}
 ${EMPTY_LINE}`)
 }
 
 const logBuildSuccess = function() {
-  log(
-    greenBright.bold(`${EMPTY_LINE}
-${getHeader('Netlify Build Complete')}
-${EMPTY_LINE}`),
-  )
+  log(`${EMPTY_LINE}
+${THEME.header(getHeader('Netlify Build Complete'))}
+${EMPTY_LINE}`)
 }
 
 // Print a rectangular header

--- a/packages/build/src/log/theme.js
+++ b/packages/build/src/log/theme.js
@@ -1,0 +1,27 @@
+const {
+  cyanBright: { bold: cyanBrightBold },
+  cyan: { bold: cyanBold },
+  redBright: { bold: redBrightBold },
+  red: { bold: redBold },
+  white: { bold: whiteBold },
+  dim,
+} = require('chalk')
+
+// Color theme. Please use this instead of requiring chalk directly, to ensure
+// consistent colors.
+const THEME = {
+  // Main headers
+  header: cyanBrightBold,
+  // Single lines used as subheaders
+  subHeader: cyanBold,
+  // Main headers indicating an error
+  errorHeader: redBrightBold,
+  // Single lines used as subheaders indicating an error
+  errorSubHeader: redBold,
+  // One of several words that should be highlighted inside a line
+  highlightWords: whiteBold,
+  // One of several words that should be dimmed inside a line
+  dimWords: dim,
+}
+
+module.exports = { THEME }

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -1,6 +1,7 @@
 require('../../utils/polyfills')
 
 // This needs to be done before `chalk` is loaded
+// Note: `chalk` is also required by some of our dependencies.
 const { setColorLevel, hasColors } = require('../../log/colors')
 setColorLevel()
 

--- a/packages/build/src/plugins/manifest/check.js
+++ b/packages/build/src/plugins/manifest/check.js
@@ -1,7 +1,6 @@
-const { redBright } = require('chalk')
-
 const { addErrorInfo } = require('../../error/info')
 const { serialize } = require('../../log/serialize')
+const { THEME } = require('../../log/theme')
 
 // Check that plugin inputs match the validation specified in "manifest.yml"
 // Also assign default values
@@ -14,7 +13,7 @@ const checkInputs = function({ inputs, manifest: { inputs: rules = [] }, package
   } catch (error) {
     error.message = `${error.message}
 
-${redBright.bold('Plugin inputs')}
+${THEME.errorSubHeader('Plugin inputs')}
 
 ${serialize(inputs)}`
     throw error

--- a/packages/build/src/plugins/manifest/validate.js
+++ b/packages/build/src/plugins/manifest/validate.js
@@ -1,7 +1,7 @@
-const { redBright } = require('chalk')
 const isPlainObj = require('is-plain-obj')
 
 const { indent } = require('../../log/serialize')
+const { THEME } = require('../../log/theme')
 const { serializeList } = require('../../utils/list')
 const { API_METHODS } = require('../child/api')
 
@@ -16,7 +16,7 @@ const validateManifest = function(manifest, rawManifest) {
   } catch (error) {
     error.message = `Plugin's "manifest.yml" ${error.message}
 
-${redBright.bold('manifest.yml')}
+${THEME.errorSubHeader('manifest.yml')}
 
 ${indent(rawManifest.trim())}`
     throw error

--- a/packages/config/src/validate/example.js
+++ b/packages/config/src/validate/example.js
@@ -1,4 +1,3 @@
-const { red, green } = require('chalk')
 const indentString = require('indent-string')
 const { dump } = require('js-yaml')
 
@@ -6,11 +5,11 @@ const { dump } = require('js-yaml')
 const getExample = function({ value, parent, key, prevPath, example }) {
   const exampleA = typeof example === 'function' ? example(value, key, parent, prevPath) : example
   return `
-${red.bold('Invalid syntax')}
+Invalid syntax
 
 ${indentString(getInvalidValue(value, prevPath), 2)}
 
-${green.bold('Valid syntax')}
+Valid syntax
 
 ${indentString(serializeValue(exampleA), 2)}`
 }

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -1,5 +1,3 @@
-const { cyan } = require('chalk')
-
 const { throwError } = require('../error')
 
 const { getExample } = require('./example')
@@ -63,7 +61,7 @@ const validateProperty = function(
 
 const reportError = function({ prevPath, propPath, message, example, warn, value, key, parent }) {
   const messageA = typeof message === 'function' ? message(value, key, parent) : message
-  const errorMessage = `Configuration property ${cyan.bold(propPath)} ${messageA}
+  const errorMessage = `Configuration property ${propPath} ${messageA}
 ${getExample({ value, parent, key, prevPath, example })}`
 
   if (!warn) {
@@ -123,7 +121,7 @@ const checkRequired = function({ value, required, propPath, prevPath, example })
     return
   }
 
-  throwError(`Configuration property ${cyan.bold(propPath)} is required.
+  throwError(`Configuration property ${propPath} is required.
 ${getExample({ value, prevPath, example })}`)
 }
 

--- a/packages/config/tests/validate/tests.js
+++ b/packages/config/tests/validate/tests.js
@@ -103,7 +103,7 @@ test('build.context.CONTEXT: object', async t => {
   await runFixture(t, 'build_context_nested_object')
 })
 
-test('Colors', async t => {
+test.skip('Colors', async t => {
   const { stderr } = await runFixture(t, 'build_object', { snapshot: false, normalize: false })
   t.true(hasAnsi(stderr))
 })


### PR DESCRIPTION
This PR makes colors used in logs consistent. All colors are grouped in a `theme.js` and all logs using colors are importing this common theme. Some colors got added/removed/updated in the process to ensure consistency.

Note: one error message in `@netlify/config` that previously had colors does not have it anymore with this PR. This is due to issues passing this theme to `@netlify/config`. I will fix this specific message in a follow-up PR.