### PR TITLE
Fix duration color

### DIFF
--- a/packages/build/src/log/theme.js
+++ b/packages/build/src/log/theme.js
@@ -4,7 +4,7 @@ const {
   redBright: { bold: redBrightBold },
   red: { bold: redBold },
   white: { bold: whiteBold },
-  dim,
+  gray,
 } = require('chalk')
 
 // Color theme. Please use this instead of requiring chalk directly, to ensure
@@ -21,7 +21,7 @@ const THEME = {
   // One of several words that should be highlighted inside a line
   highlightWords: whiteBold,
   // One of several words that should be dimmed inside a line
-  dimWords: dim,
+  dimWords: gray,
 }
 
 module.exports = { THEME }


### PR DESCRIPTION
We currently color duration timing with `chalk.dim()`. However this works locally (by making it gray) but not in production CI.

This PR fixes this by using `chalk.gray()` instead.