### PR TITLE
Upgrade `log-process-errors`

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -8873,7 +8873,8 @@
     "core-js": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
-      "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
+      "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -10828,15 +10829,15 @@
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "log-process-errors": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/log-process-errors/-/log-process-errors-5.1.1.tgz",
-      "integrity": "sha512-Eb90xoU3AC0XtIiMBF4J8SUNHt8sPZNz6GEsP7kn0gcfCD/tqp21i6yFzpRvOxBaWu6ySgSQNRc8FmEq+OG6Tg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/log-process-errors/-/log-process-errors-5.1.2.tgz",
+      "integrity": "sha512-s4kmYHrzj543xUAIxc/cpmoiGZcbFwKRqqwO49DbgH+hFoSTswi0sYZuJKjUUc73b49MRPQGl0CNl8cx98/Wtg==",
       "requires": {
         "chalk": "^3.0.0-beta.2",
-        "core-js": "^3.3.6",
         "figures": "^3.0.0",
         "filter-obj": "^2.0.1",
         "jest-validate": "^24.9.0",
+        "map-obj": "^4.1.0",
         "moize": "^5.4.4",
         "supports-color": "^7.1.0"
       },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -48,7 +48,7 @@
     "is-plain-obj": "^2.1.0",
     "js-yaml": "^3.13.1",
     "locate-path": "^5.0.0",
-    "log-process-errors": "^5.1.1",
+    "log-process-errors": "^5.1.2",
     "map-obj": "^4.1.0",
     "netlify": "^4.0.5",
     "os-name": "^3.1.0",


### PR DESCRIPTION
Fixes part of #1143.

This upgrades `log-process-errors` to remove one of the dependencies on `core-js`.