### PR TITLE
`yarn` should not be a production dependency

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -13538,7 +13538,8 @@
     "yarn": {
       "version": "1.22.4",
       "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.4.tgz",
-      "integrity": "sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA=="
+      "integrity": "sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==",
+      "dev": true
     },
     "zip-stream": {
       "version": "2.1.3",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -66,8 +66,7 @@
     "strip-ansi": "^6.0.0",
     "update-notifier": "^4.1.0",
     "uuid": "^7.0.2",
-    "yargs": "^15.3.1",
-    "yarn": "^1.22.4"
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "atob": "^2.1.2",
@@ -79,7 +78,8 @@
     "has-ansi": "^4.0.0",
     "make-dir": "^3.0.2",
     "nock": "^11.9.1",
-    "path-key": "^3.1.1"
+    "path-key": "^3.1.1",
+    "yarn": "^1.22.4"
   },
   "engines": {
     "node": ">=8.3.0"


### PR DESCRIPTION
Fixes #1155.

We should use user's global `yarn` binary instead of installing it as a production dependency. Note that the buildbot has a global `yarn` binary. In local builds, we only use `yarn` if the repository has a `yarn.lock`. 