### PR TITLE
Fix `onEnd` and `onError` error handling

### DIFF
--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -64,8 +64,12 @@ const handleEvents = async function(state) {
 }
 
 const handleEvent = async function(callId, eventName, payload, state) {
-  const response = await EVENTS[eventName](payload, state)
-  await sendEventToParent(callId, response)
+  try {
+    const response = await EVENTS[eventName](payload, state)
+    await sendEventToParent(callId, response)
+  } catch (error) {
+    await handleError(error)
+  }
 }
 
 // Initial plugin load


### PR DESCRIPTION
Fixes #1138

Errors inside `onEnd` and `onError` plugin event handlers were not properly handled. This PR fixes this.

The tests were added as `skip()` as part of another PR (#1111).