### PR TITLE
Disable Codecov PR comments and commit status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
   parsers:
     javascript:
       enable_partials: true
-comment:
-  layout: files,flags
-  require_changes: true
+  status:
+    project: false
+    patch: false
+comment: false


### PR DESCRIPTION
Codecov posts PR comments that are mostly noise. 

Commit status could be useful. Unfortunately at the moment they seem to go randomly up and down. So this PR disables it too.