### PR TITLE
Fix `build.command` shell on Windows

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -1,3 +1,5 @@
+const { platform } = require('process')
+
 const execa = require('execa')
 const pReduce = require('p-reduce')
 
@@ -197,7 +199,7 @@ const fireBuildCommand = async function({ buildCommand, configPath, buildDir, no
 
   const env = setEnvChanges(envChanges, { ...childEnv })
   const childProcess = execa(buildCommand, {
-    shell: 'bash',
+    shell: SHELL,
     cwd: buildDir,
     preferLocal: true,
     execPath: nodePath,
@@ -216,6 +218,9 @@ const fireBuildCommand = async function({ buildCommand, configPath, buildDir, no
     await stopOutput(childProcess, mode, outputState)
   }
 }
+
+// We use Bash on Unix and `cmd.exe` on Windows
+const SHELL = platform === 'win32' ? true : 'bash'
 
 // Fire a plugin command
 const firePluginCommand = async function({

--- a/packages/build/tests/core/build_command/tests.js
+++ b/packages/build/tests/core/build_command/tests.js
@@ -4,9 +4,11 @@ const test = require('ava')
 
 const { runFixture } = require('../../helpers/main')
 
-test('build.command uses Bash', async t => {
-  await runFixture(t, 'bash')
-})
+if (platform !== 'win32') {
+  test('build.command uses Bash', async t => {
+    await runFixture(t, 'bash')
+  })
+}
 
 test('build.command can execute global binaries', async t => {
   await runFixture(t, 'global_bin')


### PR DESCRIPTION
In the buildbot (which uses Linux), we run `build.command` with Bash. However in local builds (Netlify CLI) on Windows, Bash might not be available. This PR fixes this.