### PR TITLE
Rename `handleError()` to `maybeCancelBuild()`

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -9,7 +9,7 @@ setColorLevel()
 require('../error/process')
 
 const { getChildEnv } = require('../env/main')
-const { handleBuildError } = require('../error/handle')
+const { maybeCancelBuild } = require('../error/cancel')
 const { installLocalPluginsDependencies } = require('../install/local')
 const { logBuildStart, logBuildError, logBuildSuccess } = require('../log/main')
 const { logOldCliVersionError } = require('../log/old_version')
@@ -83,7 +83,7 @@ const build = async function(flags) {
       await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, mode })
       return true
     } catch (error) {
-      await handleBuildError(error, api)
+      await maybeCancelBuild(error, api)
       await logOldCliVersionError(mode)
       throw error
     }

--- a/packages/build/src/error/cancel.js
+++ b/packages/build/src/error/cancel.js
@@ -6,7 +6,7 @@ const { getTypeInfo } = require('./type')
 
 // Handle top-level build errors.
 // Logging is done separately.
-const handleBuildError = async function(error, api) {
+const maybeCancelBuild = async function(error, api) {
   const { shouldCancel } = getTypeInfo(error)
   await cancelBuild(shouldCancel, api)
 }
@@ -20,4 +20,4 @@ const cancelBuild = async function(shouldCancel, api) {
   await api.cancelSiteDeploy({ deploy_id: DEPLOY_ID })
 }
 
-module.exports = { handleBuildError }
+module.exports = { maybeCancelBuild }


### PR DESCRIPTION
When a build fails, we check if the `utils.build.cancelBuild()` caused that failure. If so, we call the API endpoint to cancel the build. This function is currently called `handleError()` which is imprecise. This PR renames it to `maybeCancelBuild()`.