### PR TITLE
Move CLI flags normalization

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -12,28 +12,39 @@ const { removeFalsy } = require('../utils/remove_falsy')
 
 const { getConstants } = require('./constants')
 
-// Retrieve configuration object
-const loadConfig = async function(flags) {
+// Normalize CLI flags
+const normalizeFlags = function(flags) {
   const flagsA = removeFalsy(flags)
   logFlags(flagsA)
 
   const flagsB = { ...DEFAULT_FLAGS, ...flagsA }
-  const {
-    config,
-    defaultConfig,
-    cachedConfig,
-    cwd,
-    repositoryRoot,
-    dry,
-    nodePath,
-    token,
-    siteId,
-    context,
-    branch,
-    baseRelDir,
-    mode,
-  } = removeFalsy(flagsB)
+  const flagsC = removeFalsy(flagsB)
+  return flagsC
+}
 
+// Default values of CLI flags
+const DEFAULT_FLAGS = {
+  nodePath: execPath,
+  token: NETLIFY_AUTH_TOKEN,
+  mode: 'require',
+}
+
+// Retrieve configuration object
+const loadConfig = async function({
+  config,
+  defaultConfig,
+  cachedConfig,
+  cwd,
+  repositoryRoot,
+  dry,
+  nodePath,
+  token,
+  siteId,
+  context,
+  branch,
+  baseRelDir,
+  mode,
+}) {
   const {
     configPath,
     buildDir,
@@ -78,13 +89,6 @@ const loadConfig = async function(flags) {
   }
 }
 
-// Default values of CLI flags
-const DEFAULT_FLAGS = {
-  nodePath: execPath,
-  token: NETLIFY_AUTH_TOKEN,
-  mode: 'require',
-}
-
 // Retrieve configuration file and related information
 // (path, build directory, etc.)
 const resolveFullConfig = async function({
@@ -123,4 +127,4 @@ const resolveFullConfig = async function({
   }
 }
 
-module.exports = { loadConfig }
+module.exports = { normalizeFlags, loadConfig }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -21,7 +21,7 @@ const { startPlugins, stopPlugins } = require('../plugins/spawn')
 const { trackBuildComplete } = require('../telemetry/complete')
 
 const { getCommands, runCommands } = require('./commands')
-const { loadConfig } = require('./config')
+const { normalizeFlags, loadConfig } = require('./config')
 const { doDryRun } = require('./dry')
 
 /**
@@ -35,11 +35,13 @@ const { doDryRun } = require('./dry')
  * @param  {boolean} [flags.dry] - printing commands without executing them
  */
 const build = async function(flags) {
+  const buildTimer = startTimer()
+
+  logBuildStart()
+
+  const flagsA = normalizeFlags(flags)
+
   try {
-    const buildTimer = startTimer()
-
-    logBuildStart()
-
     const {
       netlifyConfig,
       configPath,
@@ -53,7 +55,7 @@ const build = async function(flags) {
       context,
       branch,
       mode,
-    } = await loadConfig(flags)
+    } = await loadConfig(flagsA)
 
     try {
       const pluginsOptions = await getPluginsOptions({ netlifyConfig, buildDir, constants, mode })


### PR DESCRIPTION
At the very beginning of a build, we normalize CLI flags: assign default values, remove `undefined` values, etc.

This PR puts that logic into its own function and moves it outside of the `try`/`catch` block. This is because an incoming PR will add error monitoring, and error monitoring behavior depends on some of those flags, so must be called later. Note that there is a top-level `try`/`catch` block above this, so errors will still always be caught.