### PR TITLE
Remove colors from `error.message`

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -10,6 +10,7 @@ require('../error/process')
 
 const { getChildEnv } = require('../env/main')
 const { maybeCancelBuild } = require('../error/cancel')
+const { removeErrorColors } = require('../error/colors')
 const { reportBuildError } = require('../error/monitor/report')
 const { startErrorMonitor } = require('../error/monitor/start')
 const { installLocalPluginsDependencies } = require('../install/local')
@@ -94,6 +95,7 @@ const build = async function(flags) {
       throw error
     }
   } catch (error) {
+    removeErrorColors(error)
     await reportBuildError(error, errorMonitor)
     logBuildError(error)
     return false

--- a/packages/build/src/error/colors.js
+++ b/packages/build/src/error/colors.js
@@ -1,0 +1,13 @@
+const stripAnsi = require('strip-ansi')
+
+// Remove ANSI sequences from `error.message`
+const removeErrorColors = function(error) {
+  if (!(error instanceof Error)) {
+    return
+  }
+
+  error.message = stripAnsi(error.message)
+  error.stack = stripAnsi(error.stack)
+}
+
+module.exports = { removeErrorColors }

--- a/packages/build/tests/error/monitor/fixtures/colors/netlify.toml
+++ b/packages/build/tests/error/monitor/fixtures/colors/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin.js"

--- a/packages/build/tests/error/monitor/fixtures/colors/plugin.js
+++ b/packages/build/tests/error/monitor/fixtures/colors/plugin.js
@@ -1,0 +1,7 @@
+const { red } = require('chalk')
+
+module.exports = {
+  onInit() {
+    throw new Error(red('ColorTest'))
+  },
+}

--- a/packages/build/tests/error/monitor/tests.js
+++ b/packages/build/tests/error/monitor/tests.js
@@ -1,6 +1,7 @@
 const { version } = require('process')
 
 const test = require('ava')
+const hasAnsi = require('has-ansi')
 
 const { runFixture } = require('../../helpers/main')
 
@@ -63,4 +64,10 @@ test('Report CLI mode as releaseStage', async t => {
 
 test('Report programmatic mode as releaseStage', async t => {
   await runFixture(t, 'command', { env, flags: '--mode=require' })
+})
+
+test('Remove colors in error.message', async t => {
+  const { stdout } = await runFixture(t, 'colors', { env, snapshot: false })
+  const lines = stdout.split('\n').filter(line => line.includes('ColorTest'))
+  t.true(lines.every(line => !hasAnsi(line)))
 })


### PR DESCRIPTION
This removes colors from any build `error.message` so that:
  - The raw ANSI sequences are not shown in the error monitoring dashboard
  - Those do not clash with our colors theme