### PR TITLE
Fix uncaught exceptions error name

### DIFF
--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -128,7 +128,7 @@ const TYPES = {
   },
 
   // `@netlify/build` threw an uncaught exception
-  internal: {
+  exception: {
     header: 'Core internal error',
     context: 'Core internal error',
     stackType: 'stack',
@@ -139,6 +139,6 @@ const TYPES = {
   },
 }
 // When no error type matches, it's an uncaught exception, i.e. a bug
-const DEFAULT_TYPE = 'internal'
+const DEFAULT_TYPE = 'exception'
 
 module.exports = { getTypeInfo }


### PR DESCRIPTION
Uncaught exceptions error type is currently `internal`, while plugin uncaught exceptions is `pluginInternal`. 

Unfortunately Bugsnag search filters uses fuzzy matching, which means error types must be completely distinct from each other. Otherwise it is impossible to search only for `internal`.

This PR renames the `internal` error type to `exception`.