### PR TITLE
Add comments to error types properties

### DIFF
--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -13,6 +13,30 @@ const getTypeInfo = function(errorProps) {
 }
 
 // List of error types, and their related properties
+// Related to error handling:
+//  - `shouldCancel`: `true` when the build should be canceled
+// Related to build error logs:
+//  - `header`: main title shown in build error logs
+//  - `getLocation()`: retrieve a human-friendly location of the error, printed
+//    in build error logs
+//  - `isSuccess`: `true` when this should not be reported as an error
+//  - `showErrorProps`: `true` when the `Error` instance static properties
+//    should be printed in build error logs. Only useful when the `Error`
+//    instance was not created by us.
+//  - `rawStack`: `true` when the stack trace should be cleaned up
+//  - `stackType`: how the stack trace should appear in build error logs:
+//      - `none`: not printed
+//      - `stack`: printed as is
+//      - `message`: printed as is, but taken from `error.message`.
+//        Used when `error.stack` is not being correct due to the error being
+//        passed between different processes.
+// Related to Bugsnag:
+//  - `context`: main title shown in Bugsnag. Also used to group errors together
+//    in Bugsnag, combined with `error.message`.
+//  - `severity`: Bugsnag error severity:
+//      - `info`: user error
+//      - `warning`: plugin author error, or possible system error
+//      - `error`: likely system error
 const TYPES = {
   // User configuration error (`@netlify/config`)
   resolveConfig: {


### PR DESCRIPTION
We have several error types with a fairly elaborate sets of properties determine how each error type should be both logged and reported to Bugsnag. The goal is to make declarative so that new error types can be added without having to change the core error handling logic.

This PR adds comments explaining what each property means.