### PR TITLE
Fix `process.cwd()` crash

### DIFF
--- a/packages/build/src/error/clean_stack.js
+++ b/packages/build/src/error/clean_stack.js
@@ -24,7 +24,7 @@ const cleanStacks = function(string, rawStack) {
 }
 
 const cleanStackLine = function(lines, line) {
-  const lineA = line.replace(cwd(), '')
+  const lineA = line.replace(getCwd(), '')
   const lineB = stripAnsi(lineA)
 
   if (!STACK_LINE_REGEXP.test(lineB)) {
@@ -46,6 +46,16 @@ const cleanStackLine = function(lines, line) {
   }
 
   return `${lines}\n${lineC}`
+}
+
+// `process.cwd()` can sometimes fail: directory name too long, current
+// directory has been removed, access denied.
+const getCwd = function() {
+  try {
+    return cwd()
+  } catch (error) {
+    return ''
+  }
 }
 
 // Check if a line is part of a stack trace


### PR DESCRIPTION
`process.cwd()` can crash due to a [range of reasons](https://linux.die.net/man/3/getcwd) including the `build.command` removing the current directory.

`process.cwd()` is currently used in one place: when cleaning up stack traces. This PR adds a `try`/`catch` block.

This error happened [in production](https://app.bugsnag.com/netlify/netlify-build/errors/5ea96cd6c7ea9900180be80c).