### PR TITLE
Fix uncaught exceptions reporting

### DIFF
--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -4,12 +4,8 @@ const { getBuildCommandLocation, getBuildFailLocation, getApiLocation } = requir
 // Retrieve error-type specific information
 const getTypeInfo = function(errorProps) {
   const { type } = getErrorInfo(errorProps)
-
-  if (TYPES[type] === undefined) {
-    return { type, ...TYPES[DEFAULT_TYPE] }
-  }
-
-  return { type, ...TYPES[type] }
+  const typeA = TYPES[type] === undefined ? DEFAULT_TYPE : type
+  return { type: typeA, ...TYPES[typeA] }
 }
 
 // List of error types, and their related properties


### PR DESCRIPTION
Uncaught exceptions are [currently reported in Bugsnag](https://app.bugsnag.com/netlify/netlify-build/errors/5ea9c6d063104a0017720495) as `<UnknownErrorClass>` instead of `exception` due to a bug in the code, which this PR fixes.