### PR TITLE
Improve error handling grouping

### DIFF
--- a/packages/build/src/error/monitor/normalize.js
+++ b/packages/build/src/error/monitor/normalize.js
@@ -41,6 +41,8 @@ const NORMALIZE_REGEXPS = [
   [/version "[^"]+"/g, 'version "1.0.0"'],
   // Cypress plugin prints the user's platform
   [/^Platform: .*/gm, ''],
+  // URLs
+  [/https?:[\w.+_~!$&'()*,;=:@/?#]+/, 'https://domain.com'],
 ]
 
 module.exports = { normalizeGroupingMessage }


### PR DESCRIPTION
`error.message` is used to group errors in Bugsnag. 
It the `error.message` contains a URL with a unique ID, this creates unique errors where it should not. For example [this](https://app.bugsnag.com/netlify/netlify-build/errors/5eace62e94aa900018d973bf) and [that](https://app.bugsnag.com/netlify/netlify-build/errors/5eadea5f7211110018923c09).

This PR fixes this by replacing any URLs by always the same string.