### PR TITLE
Fix automatic package installation uncaught exception

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -76,6 +76,15 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -7165,6 +7174,16 @@
         "unixify": "^1.0.0",
         "util.promisify": "^1.0.1",
         "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -11657,6 +11676,14 @@
         "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -12656,9 +12683,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "2.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.1.tgz",
+      "integrity": "sha512-ZGTmuLZAW++TDjgslfUMRZcv7kXHv8z0zwxvuRWOPjnqc56HVsn1lVaqsWOZeQ8MwiilPVJLrcPVKG909QsAfA==",
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -60,7 +60,7 @@
     "pretty-ms": "^6.0.1",
     "read-pkg-up": "^7.0.1",
     "readdirp": "^3.4.0",
-    "resolve": "^1.15.1",
+    "resolve": "^2.0.0-next.1",
     "semver": "^7.1.3",
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",

--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -1,13 +1,9 @@
-const { promisify } = require('util')
-
 const pFilter = require('p-filter')
-const resolve = require('resolve')
 
 const { logInstallMissingPlugins } = require('../log/main')
+const { resolveLocation } = require('../utils/resolve')
 
 const { addDependencies } = require('./main')
-
-const pResolve = promisify(resolve)
 
 // Automatically install plugins if not installed already
 const installMissingPlugins = async function({ pluginsOptions, buildDir, mode }) {
@@ -27,7 +23,7 @@ const isMissingPlugin = async function({ location, core }, buildDir) {
   }
 
   try {
-    await pResolve(location, { basedir: buildDir })
+    await resolveLocation(location, buildDir)
     return false
   } catch (error) {
     return true

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -1,16 +1,12 @@
 const { dirname } = require('path')
-const { promisify } = require('util')
-
-const resolve = require('resolve')
 
 const corePackageJson = require('../../package.json')
 const { installMissingPlugins } = require('../install/missing')
 const { CORE_PLUGINS } = require('../plugins_core/main')
+const { resolveLocation } = require('../utils/resolve')
 
 const { useManifest } = require('./manifest/main')
 const { getPackageJson } = require('./package')
-
-const pResolve = promisify(resolve)
 
 // Load plugin options (specified by user in `config.plugins`)
 const getPluginsOptions = async function({ netlifyConfig: { plugins }, buildDir, constants: { FUNCTIONS_SRC }, mode }) {
@@ -30,7 +26,7 @@ const normalizePluginOptions = function({ package, location = package, core = fa
 // Retrieve plugin's main file path.
 // Then load plugin's `package.json` and `manifest.yml`.
 const loadPluginFiles = async function({ pluginOptions, pluginOptions: { location }, buildDir }) {
-  const pluginPath = await pResolve(location, { basedir: buildDir })
+  const pluginPath = await resolveLocation(location, buildDir)
   const pluginDir = dirname(pluginPath)
   const { packageDir, packageJson } = await getPackageJson({ pluginDir })
   const { manifest, inputs: inputsA } = await useManifest(pluginOptions, { pluginDir, packageDir, packageJson })

--- a/packages/build/src/utils/resolve.js
+++ b/packages/build/src/utils/resolve.js
@@ -1,0 +1,19 @@
+const resolve = require('resolve')
+
+// Like `require.resolve()` but works with a custom base directory.
+// We need to use `new Promise()` due to a bug with `utils.promisify()` on
+// `resolve`:
+//   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
+const resolveLocation = function(location, basedir) {
+  return new Promise((success, reject) => {
+    resolve(location, { basedir }, (error, resolvedLocation) => {
+      if (error) {
+        return reject(error)
+      }
+
+      success(resolvedLocation)
+    })
+  })
+}
+
+module.exports = { resolveLocation }


### PR DESCRIPTION
Fixes #1197.

The `resolve` package uses a callback async signature. Due to [a bug in that package](https://github.com/browserify/resolve/issues/151#issuecomment-368210310), it does not work with `util.promisify`. Instead, `new Promise()` must be used.

This PR also upgrade `resolve` to the next major version, currently in beta, but that version probably solves more problems than it introduces.