### PR TITLE
Add `@netlify/plugin-functions-install-core` to tests

### DIFF
--- a/packages/build/tests/install/functions/fixtures/dir/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/dir/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"

--- a/packages/build/tests/install/functions/fixtures/node_modules/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/node_modules/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"

--- a/packages/build/tests/install/functions/fixtures/npm_ci_lock/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/npm_ci_lock/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"

--- a/packages/build/tests/install/functions/fixtures/npm_ci_no_lock/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/npm_ci_no_lock/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"

--- a/packages/build/tests/install/functions/fixtures/npm_lock/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/npm_lock/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"

--- a/packages/build/tests/install/functions/fixtures/yarn_ci_lock/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/yarn_ci_lock/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"

--- a/packages/build/tests/install/functions/fixtures/yarn_lock/netlify.toml
+++ b/packages/build/tests/install/functions/fixtures/yarn_lock/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions"
+
+[[plugins]]
+package = "@netlify/plugin-functions-install-core"


### PR DESCRIPTION
Part of #1220.

#1241 is splitting `@netlify/plugin-functions-core` with `@netlify/plugin-functions-install-core`. This PR adds the later to the test fixtures that need it to keep working properly.

This PR requires #1244 and #1241 to be merged first, which is why CI tests are failing.