### PR TITLE
Rename error `context` to `group`

### DIFF
--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -27,8 +27,8 @@ const getTypeInfo = function(errorProps) {
 //        Used when `error.stack` is not being correct due to the error being
 //        passed between different processes.
 // Related to Bugsnag:
-//  - `context`: main title shown in Bugsnag. Also used to group errors together
-//    in Bugsnag, combined with `error.message`.
+//  - `group`: main title shown in Bugsnag. Also used to group
+//    errors together in Bugsnag, combined with `error.message`.
 //  - `severity`: Bugsnag error severity:
 //      - `info`: user error
 //      - `warning`: plugin author error, or possible system error
@@ -37,7 +37,7 @@ const TYPES = {
   // User configuration error (`@netlify/config`)
   resolveConfig: {
     header: 'Configuration error',
-    context: 'Configuration user error',
+    group: 'Configuration user error',
     stackType: 'none',
     severity: 'info',
   },
@@ -45,7 +45,7 @@ const TYPES = {
   // User misconfigured a plugin
   pluginInput: {
     header: ({ location: { package, input } }) => `Invalid input "${input}" for plugin "${package}"`,
-    context: ({ location: { package, input } }) => `Plugin "${package}" invalid input "${input}"`,
+    group: ({ location: { package, input } }) => `Plugin "${package}" invalid input "${input}"`,
     stackType: 'none',
     getLocation: getBuildFailLocation,
     severity: 'info',
@@ -54,7 +54,7 @@ const TYPES = {
   // `build.command` non-0 exit code
   buildCommand: {
     header: 'Build failed',
-    context: ({ location: { buildCommand } }) => buildCommand,
+    group: ({ location: { buildCommand } }) => buildCommand,
     stackType: 'message',
     getLocation: getBuildCommandLocation,
     severity: 'info',
@@ -63,7 +63,7 @@ const TYPES = {
   // Plugin called `utils.build.failBuild()`
   failBuild: {
     header: 'Build failed',
-    context: ({ location: { package } }) => `Plugin "${package}" user error`,
+    group: ({ location: { package } }) => `Plugin "${package}" user error`,
     stackType: 'stack',
     getLocation: getBuildFailLocation,
     severity: 'info',
@@ -72,7 +72,7 @@ const TYPES = {
   // Plugin called `utils.build.failPlugin()`
   failPlugin: {
     header: ({ location: { package } }) => `Plugin "${package}" failed`,
-    context: ({ location: { package } }) => `Plugin "${package}" user error`,
+    group: ({ location: { package } }) => `Plugin "${package}" user error`,
     stackType: 'stack',
     getLocation: getBuildFailLocation,
     severity: 'info',
@@ -81,7 +81,7 @@ const TYPES = {
   // Plugin called `utils.build.cancelBuild()`
   cancelBuild: {
     header: ({ location: { package } }) => `Build canceled by ${package}`,
-    context: ({ location: { package } }) => `Plugin "${package}" canceled build`,
+    group: ({ location: { package } }) => `Plugin "${package}" canceled build`,
     stackType: 'stack',
     getLocation: getBuildFailLocation,
     isSuccess: true,
@@ -92,7 +92,7 @@ const TYPES = {
   // Plugin has an invalid shape
   pluginValidation: {
     header: ({ location: { package } }) => `Plugin "${package}" internal error`,
-    context: ({ location: { package } }) => `Plugin "${package}" internal error`,
+    group: ({ location: { package } }) => `Plugin "${package}" internal error`,
     stackType: 'none',
     getLocation: getBuildFailLocation,
     severity: 'warning',
@@ -101,7 +101,7 @@ const TYPES = {
   // Plugin threw an uncaught exception
   pluginInternal: {
     header: ({ location: { package } }) => `Plugin "${package}" internal error`,
-    context: ({ location: { package } }) => `Plugin "${package}" internal error`,
+    group: ({ location: { package } }) => `Plugin "${package}" internal error`,
     stackType: 'stack',
     showErrorProps: true,
     rawStack: true,
@@ -112,7 +112,7 @@ const TYPES = {
   // Bug while orchestrating child processes
   ipc: {
     header: ({ location: { package } }) => `Plugin "${package}" internal error`,
-    context: ({ location: { package } }) => `Plugin "${package}" internal error`,
+    group: ({ location: { package } }) => `Plugin "${package}" internal error`,
     stackType: 'none',
     getLocation: getBuildFailLocation,
     severity: 'warning',
@@ -121,7 +121,7 @@ const TYPES = {
   // Error while installing user packages (missing plugins, local plugins or functions dependencies)
   dependencies: {
     header: 'Dependencies error',
-    context: 'Packages installation',
+    group: 'Packages installation',
     stackType: 'none',
     severity: 'warning',
   },
@@ -129,7 +129,7 @@ const TYPES = {
   // Request error when `@netlify/build` was calling Netlify API
   api: {
     header: 'API error',
-    context: ({ location: { endpoint } }) => `API request "${endpoint}"`,
+    group: ({ location: { endpoint } }) => `API request "${endpoint}"`,
     stackType: 'message',
     showErrorProps: true,
     getLocation: getApiLocation,
@@ -139,7 +139,7 @@ const TYPES = {
   // `@netlify/build` threw an uncaught exception
   exception: {
     header: 'Core internal error',
-    context: 'Core internal error',
+    group: 'Core internal error',
     stackType: 'stack',
     showErrorProps: true,
     rawStack: true,


### PR DESCRIPTION
Related to #1223

Bugsnag has the concept of `context`, to group errors together.
Netlify also has a concept named `context`: build contexts.
To prevent confusions, this PR renames error `context` to groups instead.