### PR TITLE
Rename `header` to `title`

### DIFF
--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -17,7 +17,7 @@ const reportBuildError = async function(error, errorMonitor) {
     return
   }
 
-  const { type, severity, header, group = header } = getTypeInfo(error)
+  const { type, severity, title, group = title } = getTypeInfo(error)
   const errorInfo = getErrorInfo(error)
   const severityA = getSeverity(severity, errorInfo)
   const groupA = getGroup(group, errorInfo)

--- a/packages/build/src/error/parse.js
+++ b/packages/build/src/error/parse.js
@@ -13,7 +13,7 @@ const parseError = function(error) {
     errorProps,
     errorInfo,
     errorInfo: { location = {}, plugin = {} },
-    header,
+    title,
     isSuccess,
     stackType,
     getLocation,
@@ -21,27 +21,27 @@ const parseError = function(error) {
     rawStack,
   } = parseErrorInfo(error)
 
-  const headerA = getHeader(header, errorInfo)
+  const titleA = getTitle(title, errorInfo)
 
   const { message: messageA, stack: stackA } = getStackInfo({ message, stack, stackType, rawStack, isSuccess })
 
   const pluginInfo = getPluginInfo(plugin, location)
   const locationInfo = getLocationInfo({ stack: stackA, location, getLocation })
   const errorPropsA = getErrorProps(errorProps, showErrorProps)
-  return { header: headerA, message: messageA, pluginInfo, locationInfo, errorProps: errorPropsA, isSuccess }
+  return { title: titleA, message: messageA, pluginInfo, locationInfo, errorProps: errorPropsA, isSuccess }
 }
 
 // Parse error instance into all the basic properties containing information
 const parseErrorInfo = function(error) {
   const { message, stack, ...errorProps } = normalizeError(error)
-  const { header, isSuccess, stackType, getLocation, showErrorProps, rawStack } = getTypeInfo(errorProps)
+  const { title, isSuccess, stackType, getLocation, showErrorProps, rawStack } = getTypeInfo(errorProps)
   const errorInfo = getErrorInfo(errorProps)
   return {
     message,
     stack,
     errorProps,
     errorInfo,
-    header,
+    title,
     isSuccess,
     stackType,
     getLocation,
@@ -58,13 +58,13 @@ const normalizeError = function(error) {
   return new Error(String(error))
 }
 
-// Retrieve header to print in logs
-const getHeader = function(header, errorInfo) {
-  if (typeof header !== 'function') {
-    return header
+// Retrieve title to print in logs
+const getTitle = function(title, errorInfo) {
+  if (typeof title !== 'function') {
+    return title
   }
 
-  return header(errorInfo)
+  return title(errorInfo)
 }
 
 module.exports = { parseError }

--- a/packages/build/src/error/serialize_log.js
+++ b/packages/build/src/error/serialize_log.js
@@ -2,11 +2,11 @@ const { THEME } = require('../log/theme')
 
 const { parseError } = require('./parse')
 
-// Serialize an error object into a header|body string to print in logs
+// Serialize an error object into a title|body string to print in logs
 const serializeLogError = function(error) {
-  const { header, message, pluginInfo, locationInfo, errorProps, isSuccess } = parseError(error)
+  const { title, message, pluginInfo, locationInfo, errorProps, isSuccess } = parseError(error)
   const body = getBody({ message, pluginInfo, locationInfo, errorProps, isSuccess })
-  return { header, body, isSuccess }
+  return { title, body, isSuccess }
 }
 
 const getBody = function({ message, pluginInfo, locationInfo, errorProps, isSuccess }) {

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -12,7 +12,7 @@ const getTypeInfo = function(errorProps) {
 // Related to error handling:
 //  - `shouldCancel`: `true` when the build should be canceled
 // Related to build error logs:
-//  - `header`: main title shown in build error logs
+//  - `title`: main title shown in build error logs
 //  - `getLocation()`: retrieve a human-friendly location of the error, printed
 //    in build error logs
 //  - `isSuccess`: `true` when this should not be reported as an error
@@ -29,7 +29,7 @@ const getTypeInfo = function(errorProps) {
 // Related to Bugsnag:
 //  - `group`: main title shown in Bugsnag. Also used to group errors together
 //    in Bugsnag, combined with `error.message`.
-//    Defaults to `header`.
+//    Defaults to `title`.
 //  - `severity`: Bugsnag error severity:
 //      - `info`: user error
 //      - `warning`: plugin author error, or possible system error
@@ -37,14 +37,14 @@ const getTypeInfo = function(errorProps) {
 const TYPES = {
   // User configuration error (`@netlify/config`)
   resolveConfig: {
-    header: 'Configuration error',
+    title: 'Configuration error',
     stackType: 'none',
     severity: 'info',
   },
 
   // User misconfigured a plugin
   pluginInput: {
-    header: ({ location: { package, input } }) => `Plugin "${package}" invalid input "${input}"`,
+    title: ({ location: { package, input } }) => `Plugin "${package}" invalid input "${input}"`,
     stackType: 'none',
     getLocation: getBuildFailLocation,
     severity: 'info',
@@ -52,7 +52,7 @@ const TYPES = {
 
   // `build.command` non-0 exit code
   buildCommand: {
-    header: '"build.command" failed',
+    title: '"build.command" failed',
     group: ({ location: { buildCommand } }) => buildCommand,
     stackType: 'message',
     getLocation: getBuildCommandLocation,
@@ -61,7 +61,7 @@ const TYPES = {
 
   // Plugin called `utils.build.failBuild()`
   failBuild: {
-    header: ({ location: { package } }) => `Plugin "${package}" failed`,
+    title: ({ location: { package } }) => `Plugin "${package}" failed`,
     stackType: 'stack',
     getLocation: getBuildFailLocation,
     severity: 'info',
@@ -69,7 +69,7 @@ const TYPES = {
 
   // Plugin called `utils.build.failPlugin()`
   failPlugin: {
-    header: ({ location: { package } }) => `Plugin "${package}" failed`,
+    title: ({ location: { package } }) => `Plugin "${package}" failed`,
     stackType: 'stack',
     getLocation: getBuildFailLocation,
     severity: 'info',
@@ -77,7 +77,7 @@ const TYPES = {
 
   // Plugin called `utils.build.cancelBuild()`
   cancelBuild: {
-    header: ({ location: { package } }) => `Build canceled by ${package}`,
+    title: ({ location: { package } }) => `Build canceled by ${package}`,
     stackType: 'stack',
     getLocation: getBuildFailLocation,
     isSuccess: true,
@@ -87,7 +87,7 @@ const TYPES = {
 
   // Plugin has an invalid shape
   pluginValidation: {
-    header: ({ location: { package } }) => `Plugin "${package}" internal error`,
+    title: ({ location: { package } }) => `Plugin "${package}" internal error`,
     stackType: 'none',
     getLocation: getBuildFailLocation,
     severity: 'warning',
@@ -95,7 +95,7 @@ const TYPES = {
 
   // Plugin threw an uncaught exception
   pluginInternal: {
-    header: ({ location: { package } }) => `Plugin "${package}" internal error`,
+    title: ({ location: { package } }) => `Plugin "${package}" internal error`,
     stackType: 'stack',
     showErrorProps: true,
     rawStack: true,
@@ -105,7 +105,7 @@ const TYPES = {
 
   // Bug while orchestrating child processes
   ipc: {
-    header: ({ location: { package } }) => `Plugin "${package}" internal error`,
+    title: ({ location: { package } }) => `Plugin "${package}" internal error`,
     stackType: 'none',
     getLocation: getBuildFailLocation,
     severity: 'warning',
@@ -113,14 +113,14 @@ const TYPES = {
 
   // Error while installing user packages (missing plugins, local plugins or functions dependencies)
   dependencies: {
-    header: 'Dependencies installation error',
+    title: 'Dependencies installation error',
     stackType: 'none',
     severity: 'warning',
   },
 
   // Request error when `@netlify/build` was calling Netlify API
   api: {
-    header: ({ location: { endpoint } }) => `API error on "${endpoint}"`,
+    title: ({ location: { endpoint } }) => `API error on "${endpoint}"`,
     stackType: 'message',
     showErrorProps: true,
     getLocation: getApiLocation,
@@ -129,7 +129,7 @@ const TYPES = {
 
   // `@netlify/build` threw an uncaught exception
   exception: {
-    header: 'Core internal error',
+    title: 'Core internal error',
     stackType: 'stack',
     showErrorProps: true,
     rawStack: true,

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -239,15 +239,15 @@ const logCacheDir = function(path) {
 }
 
 const logPluginError = function(error) {
-  const { header, body } = serializeLogError(error)
-  logErrorHeader(header)
+  const { title, body } = serializeLogError(error)
+  logErrorHeader(title)
   logMessage(`\n${body}`)
 }
 
 const logBuildError = function(error) {
-  const { header, body, isSuccess } = serializeLogError(error)
+  const { title, body, isSuccess } = serializeLogError(error)
   const logFunction = isSuccess ? logHeader : logErrorHeader
-  logFunction(header)
+  logFunction(title)
   logMessage(`\n${body}\n`)
 }
 


### PR DESCRIPTION
Each error type has its own `header` shown in the terminal.
Since we will re-use this for statuses `title` (#1223), this PR renames `header` to `title` instead.