### PR TITLE
Small refactoring of `getTypeInfo()`

### DIFF
--- a/packages/build/src/error/cancel.js
+++ b/packages/build/src/error/cancel.js
@@ -2,12 +2,14 @@ const {
   env: { DEPLOY_ID },
 } = require('process')
 
+const { getErrorInfo } = require('./info')
 const { getTypeInfo } = require('./type')
 
 // Handle top-level build errors.
 // Logging is done separately.
 const maybeCancelBuild = async function(error, api) {
-  const { shouldCancel } = getTypeInfo(error)
+  const errorInfo = getErrorInfo(error)
+  const { shouldCancel } = getTypeInfo(errorInfo)
   await cancelBuild(shouldCancel, api)
 }
 

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -17,8 +17,8 @@ const reportBuildError = async function(error, errorMonitor) {
     return
   }
 
-  const { type, severity, title, group = title } = getTypeInfo(error)
   const errorInfo = getErrorInfo(error)
+  const { type, severity, title, group = title } = getTypeInfo(errorInfo)
   const severityA = getSeverity(severity, errorInfo)
   const groupA = getGroup(group, errorInfo)
   const groupingHash = getGroupingHash(groupA, error, type)

--- a/packages/build/src/error/parse.js
+++ b/packages/build/src/error/parse.js
@@ -34,8 +34,8 @@ const parseError = function(error) {
 // Parse error instance into all the basic properties containing information
 const parseErrorInfo = function(error) {
   const { message, stack, ...errorProps } = normalizeError(error)
-  const { title, isSuccess, stackType, getLocation, showErrorProps, rawStack } = getTypeInfo(errorProps)
   const errorInfo = getErrorInfo(errorProps)
+  const { title, isSuccess, stackType, getLocation, showErrorProps, rawStack } = getTypeInfo(errorInfo)
   return {
     message,
     stack,

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -1,9 +1,7 @@
-const { getErrorInfo } = require('./info')
 const { getBuildCommandLocation, getBuildFailLocation, getApiLocation } = require('./location')
 
 // Retrieve error-type specific information
-const getTypeInfo = function(errorProps) {
-  const { type } = getErrorInfo(errorProps)
+const getTypeInfo = function({ type }) {
   const typeA = TYPES[type] === undefined ? DEFAULT_TYPE : type
   return { type: typeA, ...TYPES[typeA] }
 }


### PR DESCRIPTION
Part of #1223.

Errors information is attached to a symbol property. It is retrieve using `getErrorInfo()`.
Also, each error type as a sets of properties retrieved using `getTypeInfo()`.
This PR is a small refactoring to try to decouple those two separate things more.