### PR TITLE
Add error statuses

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -9,6 +9,7 @@ setColorLevel()
 require('../error/process')
 
 const { getChildEnv } = require('../env/main')
+const { maybeCancelBuild } = require('../error/cancel')
 const { removeErrorColors } = require('../error/colors')
 const { reportBuildError } = require('../error/monitor/report')
 const { startErrorMonitor } = require('../error/monitor/start')
@@ -79,7 +80,6 @@ const build = async function(flags) {
         branch,
         mode,
         errorMonitor,
-        api,
       })
 
       if (dry) {
@@ -97,6 +97,7 @@ const build = async function(flags) {
       await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, mode })
       return true
     } catch (error) {
+      await maybeCancelBuild(error, api)
       await logOldCliVersionError(mode)
       throw error
     }
@@ -122,7 +123,6 @@ const buildRun = async function({
   branch,
   mode,
   errorMonitor,
-  api,
 }) {
   const utilsData = await startUtils(buildDir)
   const childEnv = await getChildEnv({ netlifyConfig, buildDir, context, branch, siteInfo, mode })
@@ -142,7 +142,6 @@ const buildRun = async function({
       dry,
       constants,
       errorMonitor,
-      api,
     })
   } finally {
     await stopPlugins(childProcesses)
@@ -162,7 +161,6 @@ const executeCommands = async function({
   dry,
   constants,
   errorMonitor,
-  api,
 }) {
   const pluginsCommands = await loadPlugins({
     pluginsOptions,
@@ -187,7 +185,6 @@ const executeCommands = async function({
     nodePath,
     childEnv,
     errorMonitor,
-    api,
   })
 }
 

--- a/packages/build/src/error/cancel.js
+++ b/packages/build/src/error/cancel.js
@@ -2,13 +2,21 @@ const {
   env: { DEPLOY_ID },
 } = require('process')
 
+const { getErrorInfo } = require('./info')
+
 // Cancel builds, for example when a plugin uses `utils.build.cancelBuild()`
-const cancelBuild = async function(api) {
+const maybeCancelBuild = async function(error, api) {
   if (api === undefined || !DEPLOY_ID) {
+    return
+  }
+
+  const { type } = getErrorInfo(error)
+
+  if (type !== 'cancelBuild') {
     return
   }
 
   await api.cancelSiteDeploy({ deploy_id: DEPLOY_ID })
 }
 
-module.exports = { cancelBuild }
+module.exports = { maybeCancelBuild }

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -7,13 +7,14 @@ const { getErrorProps } = require('./properties')
 const { getStackInfo } = require('./stack')
 
 // Parse all error information into a normalized sets of properties
-const parseError = function(error) {
+const parseError = function({ error, colors }) {
   const {
     message,
     stack,
     errorProps,
     errorInfo,
     errorInfo: { location = {}, plugin = {} },
+    state,
     title,
     isSuccess,
     stackType,
@@ -28,20 +29,21 @@ const parseError = function(error) {
 
   const pluginInfo = getPluginInfo(plugin, location)
   const locationInfo = getLocationInfo({ stack: stackA, location, locationType })
-  const errorPropsA = getErrorProps(errorProps, showErrorProps)
-  return { title: titleA, message: messageA, pluginInfo, locationInfo, errorProps: errorPropsA, isSuccess }
+  const errorPropsA = getErrorProps({ errorProps, showErrorProps, colors })
+  return { state, title: titleA, message: messageA, pluginInfo, locationInfo, errorProps: errorPropsA, isSuccess }
 }
 
 // Parse error instance into all the basic properties containing information
 const parseErrorInfo = function(error) {
   const { message, stack, ...errorProps } = normalizeError(error)
   const errorInfo = getErrorInfo(errorProps)
-  const { title, isSuccess, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(errorInfo)
+  const { state, title, isSuccess, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(errorInfo)
   return {
     message,
     stack,
     errorProps,
     errorInfo,
+    state,
     title,
     isSuccess,
     stackType,

--- a/packages/build/src/error/parse/properties.js
+++ b/packages/build/src/error/parse/properties.js
@@ -4,14 +4,14 @@ const { omit } = require('../../utils/omit')
 const { INFO_SYM } = require('../info')
 
 // In uncaught exceptions, print error static properties
-const getErrorProps = function(errorProps, showErrorProps) {
+const getErrorProps = function({ errorProps, showErrorProps, colors }) {
   const errorPropsA = omit(errorProps, CLEANED_ERROR_PROPS)
 
   if (!showErrorProps || Object.keys(errorPropsA).length === 0) {
     return
   }
 
-  return inspect(errorPropsA)
+  return inspect(errorPropsA, { colors })
 }
 
 // Remove error static properties that should not be logged

--- a/packages/build/src/error/parse/serialize_log.js
+++ b/packages/build/src/error/parse/serialize_log.js
@@ -4,7 +4,7 @@ const { parseError } = require('./parse')
 
 // Serialize an error object into a title|body string to print in logs
 const serializeLogError = function(error) {
-  const { title, message, pluginInfo, locationInfo, errorProps, isSuccess } = parseError(error)
+  const { title, message, pluginInfo, locationInfo, errorProps, isSuccess } = parseError({ error, colors: true })
   const body = getBody({ message, pluginInfo, locationInfo, errorProps, isSuccess })
   return { title, body, isSuccess }
 }

--- a/packages/build/src/error/parse/serialize_status.js
+++ b/packages/build/src/error/parse/serialize_status.js
@@ -1,0 +1,28 @@
+const { parseError } = require('./parse')
+
+// Serialize an error object to `statuses` properties
+const serializeErrorStatus = function(error) {
+  const { state, title, message, locationInfo, errorProps } = parseError({ error, colors: false })
+  const text = getText({ locationInfo, errorProps })
+  return { state, title, summary: message, text }
+}
+
+const getText = function({ locationInfo, errorProps }) {
+  const parts = [locationInfo, getErrorProps(errorProps)].filter(Boolean)
+
+  if (parts.length === 0) {
+    return
+  }
+
+  return parts.join('\n\n')
+}
+
+const getErrorProps = function(errorProps) {
+  if (errorProps === undefined) {
+    return
+  }
+
+  return `Error properties:\n${errorProps}`
+}
+
+module.exports = { serializeErrorStatus }

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -1,7 +1,7 @@
 // Retrieve error-type specific information
 const getTypeInfo = function({ type }) {
   const typeA = TYPES[type] === undefined ? DEFAULT_TYPE : type
-  return { type: typeA, ...TYPES[typeA] }
+  return { type: typeA, state: DEFAULT_STATE, ...TYPES[typeA] }
 }
 
 // List of error types, and their related properties
@@ -20,6 +20,8 @@ const getTypeInfo = function({ type }) {
 //      - `message`: printed as is, but taken from `error.message`.
 //        Used when `error.stack` is not being correct due to the error being
 //        passed between different processes.
+// Related to error statuses:
+//  - `state`: error status state. Defaults to `failed_build`
 // Related to Bugsnag:
 //  - `group`: main title shown in Bugsnag. Also used to group errors together
 //    in Bugsnag, combined with `error.message`.
@@ -67,6 +69,7 @@ const TYPES = {
     stackType: 'stack',
     locationType: 'buildFail',
     severity: 'info',
+    state: 'failed_plugin',
   },
 
   // Plugin called `utils.build.cancelBuild()`
@@ -76,6 +79,7 @@ const TYPES = {
     locationType: 'buildFail',
     isSuccess: true,
     severity: 'info',
+    state: 'canceled_plugin',
   },
 
   // Plugin has an invalid shape
@@ -129,7 +133,11 @@ const TYPES = {
     severity: 'error',
   },
 }
+
 // When no error type matches, it's an uncaught exception, i.e. a bug
 const DEFAULT_TYPE = 'exception'
+
+// When no `state` is provided
+const DEFAULT_STATE = 'failed_build'
 
 module.exports = { getTypeInfo }


### PR DESCRIPTION
Part of #1223.

This creates statuses for every plugin that errors. Those statuses are meant to be shown in the UI deploy summary.

The statuses are created using the same logic as the one used to print errors in build logs, with few differences to make them fit better in the UI deploy summary context.

Note that this PR does not have tests yet: in a follow-up PR, I will add the `statuses` API call, which will make testing this PR much easier. I will add some tests then. The currently existing tests are passing though, so this should not break anything in the meantime.