### PR TITLE
Use a brighter color for deprecation warning

### DIFF
--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -121,7 +121,7 @@ const logInstallFunctionDependencies = function() {
 const logDeprecatedFunctionsInstall = function(functionsSrc) {
   logErrorSubHeader('Missing plugin')
   logMessage(
-    THEME.errorLine(`Please use the plugin "@netlify/plugin-functions-install-core" to install dependencies from the "package.json" inside your "${functionsSrc}" directory.
+    THEME.errorSubHeader(`Please use the plugin "@netlify/plugin-functions-install-core" to install dependencies from the "package.json" inside your "${functionsSrc}" directory.
 Example "netlify.toml":
 
   [build]


### PR DESCRIPTION
This uses a brighter color for a deprecation warning (`red.bright` instead of just `red`).