### PR TITLE
Simplify some code related to `loadedFrom`

### DIFF
--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -43,20 +43,7 @@ const isUserPlugin = function({ package }) {
 }
 
 const normalizePluginOptions = function({ package, pluginPath, loadedFrom, origin, inputs = {} }) {
-  const loadedFromA = getLoadedFrom(loadedFrom, package)
-  return { package, pluginPath, loadedFrom: loadedFromA, origin, inputs }
-}
-
-const getLoadedFrom = function(loadedFrom, package) {
-  if (loadedFrom !== undefined) {
-    return loadedFrom
-  }
-
-  if (package.startsWith('.') || package.startsWith('/')) {
-    return 'local'
-  }
-
-  return 'external'
+  return { package, pluginPath, loadedFrom, origin, inputs }
 }
 
 // Retrieve plugin's main file path.

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -28,20 +28,20 @@ const resolvePluginsPath = async function({ pluginsOptions, buildDir, mode }) {
 
 const resolvePluginPath = async function({
   pluginOptions,
-  pluginOptions: { package, pluginPath, loadedFrom },
+  pluginOptions: { package, loadedFrom },
   buildDir,
   autoPluginsDir,
   mode,
 }) {
   // Core plugins
-  if (pluginPath !== undefined) {
+  if (loadedFrom !== undefined) {
     return pluginOptions
   }
 
   // Local plugins
-  if (loadedFrom === 'local') {
+  if (package.startsWith('.') || package.startsWith('/')) {
     const localPath = resolve(buildDir, package)
-    return { ...pluginOptions, pluginPath: localPath }
+    return { ...pluginOptions, pluginPath: localPath, loadedFrom: 'local' }
   }
 
   // Plugin already installed in the project, most likely either local plugins,


### PR DESCRIPTION
This is a small refactoring to simplify the code related to `loadedFrom: local` (local plugins). It does not change behavior.