### PR TITLE
Fix `Cannot read property 'replace' of undefined`

### DIFF
--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -60,7 +60,7 @@ const getGroup = function(group, errorInfo) {
 }
 
 const getGroupingHash = function(group, error, type) {
-  const message = error instanceof Error ? error.message : String(error)
+  const message = error instanceof Error && typeof error.message === 'string' ? error.message : String(error)
   const messageA = normalizeGroupingMessage(message, type)
   return `${group}\n${messageA}`
 }


### PR DESCRIPTION
This fixes the following error message:

```
TypeError: Cannot read property 'replace' of undefined
at normalizeMessage (/opt/buildhome/.netlify-build-nvm/versions/node/v12.16.2/lib/node_modules/@netlify/build/src/error/monitor/normalize.js:33:18)
at Array.reduce (<anonymous>)
at normalizeGroupingMessage (/opt/buildhome/.netlify-build-nvm/versions/node/v12.16.2/lib/node_modules/@netlify/build/src/error/monitor/normalize.js:6:28)
at getGroupingHash (/opt/buildhome/.netlify-build-nvm/versions/node/v12.16.2/lib/node_modules/@netlify/build/src/error/monitor/report.js:56:20)
at reportBuildError (/opt/buildhome/.netlify-build-nvm/versions/node/v12.16.2/lib/node_modules/@netlify/build/src/error/monitor/report.js:24:24)
at build (/opt/buildhome/.netlify-build-nvm/versions/node/v12.16.2/lib/node_modules/@netlify/build/src/core/main.js:99:11)
at processTicksAndRejections (internal/process/task_queues.js:97:5)
```