### PR TITLE
Improve `util.inspect()` depth when logging error properties

### DIFF
--- a/packages/build/src/error/parse/properties.js
+++ b/packages/build/src/error/parse/properties.js
@@ -11,7 +11,7 @@ const getErrorProps = function({ errorProps, showErrorProps, colors }) {
     return
   }
 
-  return inspect(errorPropsA, { colors })
+  return inspect(errorPropsA, { colors, depth: 5 })
 }
 
 // Remove error static properties that should not be logged


### PR DESCRIPTION
On build errors, if the error has static properties, we print them. We serialize them using `util.inspect()`. However we should increase the maximum depth level, otherwise we get things like:

```
11:25:44 PM:   Error properties
11:25:44 PM:   {
11:25:44 PM:     name: 'JSONHTTPError',
11:25:44 PM:     status: 422,
11:25:44 PM:     json: { errors: { package: [Array] } }
11:25:44 PM:   }
```

(Notice the `[Array]`)

This PR fixes this.