### PR TITLE
Fix `resolve`

### DIFF
--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -52,7 +52,7 @@ const resolvePluginPath = async function({
   }
 
   // Cached in the build image
-  const buildImagePath = await tryBuildImagePath(package, mode)
+  const buildImagePath = await tryBuildImagePath(package, mode, buildDir)
   if (buildImagePath !== undefined) {
     return { ...pluginOptions, pluginPath: buildImagePath, loadedFrom: 'image_cache' }
   }
@@ -69,7 +69,7 @@ const resolvePluginPath = async function({
 
 // In production, we pre-install most Build plugins to that directory, for
 // performance reasons
-const tryBuildImagePath = async function(package, mode) {
+const tryBuildImagePath = async function(package, mode, buildDir) {
   if (mode !== 'buildbot') {
     return
   }
@@ -80,7 +80,7 @@ const tryBuildImagePath = async function(package, mode) {
     return
   }
 
-  return resolvePath(buildImagePath)
+  return resolvePath(buildImagePath, buildDir)
 }
 
 const getBuildImagePluginsDir = function() {

--- a/packages/build/src/utils/resolve.js
+++ b/packages/build/src/utils/resolve.js
@@ -1,10 +1,30 @@
-const resolve = require('resolve')
+const { version: nodeVersion } = require('process')
 
-// Like `require.resolve()` but works with a custom base directory.
+const resolve = require('resolve')
+const { gte: gteVersion } = require('semver')
+
+// This throws if the package cannot be found
+// We try not to use `resolve` because it gives unhelpful error messages.
+//   https://github.com/browserify/resolve/issues/223
+// Ideally we would use async I/O but that is not an option with
+// `require.resolve()`
+const resolvePath = function(path, basedir) {
+  if (gteVersion(nodeVersion, REQUEST_RESOLVE_MIN_VERSION)) {
+    return require.resolve(path, { paths: [basedir] })
+  }
+
+  return resolvePathFallback(path, basedir)
+}
+
+// `require.resolve()` option `paths` was introduced in Node 8.9.0
+const REQUEST_RESOLVE_MIN_VERSION = '8.9.0'
+
+// Like `require.resolve()` but works with Node <8.9.0
+// TODO: remove after dropping support for Node <8.9.0
 // We need to use `new Promise()` due to a bug with `utils.promisify()` on
 // `resolve`:
 //   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
-const resolvePath = function(path, basedir) {
+const resolvePathFallback = function(path, basedir) {
   return new Promise((success, reject) => {
     resolve(path, { basedir }, (error, resolvedPath) => {
       if (error) {


### PR DESCRIPTION
Fixes #1250.

The `resolve` library gives very unhelpful error messages. This means when we fail to find a plugin, the build error logs are confusing.

The `require.resolve()` can be used and does the same thing, but synchronously.