### PR TITLE
Fix test fixture using `onInit()`

### DIFF
--- a/packages/build/tests/error/monitor/fixtures/plugin_homepage/plugin.js
+++ b/packages/build/tests/error/monitor/fixtures/plugin_homepage/plugin.js
@@ -1,5 +1,5 @@
 module.exports = {
-  onInit() {
+  onPreBuild() {
     throw new Error('test')
   },
 }


### PR DESCRIPTION
A test fixture is mistakenly using `onInit()` even though this event handler is deprecated.