### PR TITLE
Clarify that deploy events are not included

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ after your site build has completed.
 | ⇩ ‏‏‎ ‏‏‎ ‏‏‎ **onError** ‏‏‎ ‏‏‎ ‏‏‎     | Runs on build error                |
 | 🎉 ‏‏‎ **onEnd** ‏‏‎ ‏‏‎ ‏‏‎              | Runs on build error or success     |
 
+_Please keep in mind that these events are for build events only and do not include deploy events, pertinent in cases that you're working with our API._
+
 ### Anatomy of a plugin
 
 A plugin consists of two files:


### PR DESCRIPTION
As per #1285, putting in a small README PR to clarify that the deploy events aren't currently available, open to changes!

- [x ] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x ] The status checks are successful (continuous integration). Those can be seen below.
