### PR TITLE
Do not report plugin `package.json` twice on build errors

### DIFF
--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -78,9 +78,9 @@ const getPluginMetadata = function(plugin) {
     return {}
   }
 
-  const { packageJson } = plugin
+  const { packageJson, ...pluginA } = plugin
   const homepage = getHomepage(packageJson)
-  return { plugin: { ...plugin, homepage }, packageJson }
+  return { plugin: { ...pluginA, homepage }, packageJson }
 }
 
 const getApp = function() {


### PR DESCRIPTION
On build errors, we report the plugin's `package.json`. However we report it in two different places. This PR removes the redundancy.