### PR TITLE
Improve documentation of local plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ package = "./plugins/netlify-plugin-hello-world"
 
 (Note that each plugin you add to the `netlify.toml` file has its own `[[plugins]]` line.)
 
+Local plugins `package` value must start with `.` or `/`.
+
 Now that the plugin is declared, we can verify it's loading correctly with the `netlify build --dry` command. This
 execute a "dry run" of our build and show us the plugins & commands that will execute for a real build.
 


### PR DESCRIPTION
The following:

```toml
[[plugins]]
package = "hello/world"
```

Could mean two things:
  - local path `./hello/world`
  - GitHub repository `github.com/hello/world`. This is a recognized syntax by `npm install`.

To avoid confusion, and following the same convention as Node.js `require()`, local plugin paths must start with either `.` or `/`.

```toml
[[plugins]]
package = "./hello/world"
```

Some users though might forget the leading `./` (example [error in production](https://app.bugsnag.com/netlify/netlify-build/errors/5ec7075b9039bc0017bd4a4e)). This PR improves the documentation.