### PR TITLE
Fix error normalization

### DIFF
--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -68,7 +68,7 @@ const parseErrorInfo = function(error) {
 }
 
 const normalizeError = function(error) {
-  if (error instanceof Error) {
+  if (error instanceof Error && typeof error.message === 'string' && typeof error.stack === 'string') {
     return error
   }
 


### PR DESCRIPTION
The following error happens in some builds:

```
Cannot read property 'split' of undefined 
    src/error/parse/stack.js:27:24 splitStack
    src/error/parse/stack.js:23:10 splitStackInfo
    src/error/parse/stack.js:5:48 getStackInfo
    src/error/parse/parse.js:30:48 parseError
    src/error/parse/serialize_status.js:5:63 serializeErrorStatus
    src/core/commands.js:289:21 handleCommandError
    src/core/commands.js:160:15 runCommand
    internal/process/task_queues.js:97:5 processTicksAndRejections
    src/core/commands.js:75:104 async pReduce.index
    src/core/commands.js:69:72 async runCommands
```

This happens when an error is thrown that is an `Error` instance but whose `message` or `stack` property is not a `string`. This PR ensures we handle that edge case.