### PR TITLE
Improve logging of `cancelBuild()`

### DIFF
--- a/packages/build/src/error/cancel.js
+++ b/packages/build/src/error/cancel.js
@@ -3,6 +3,7 @@ const {
 } = require('process')
 
 const { getErrorInfo } = require('./info')
+const { getTypeInfo } = require('./type')
 
 // Cancel builds, for example when a plugin uses `utils.build.cancelBuild()`
 const maybeCancelBuild = async function(error, api) {
@@ -19,4 +20,11 @@ const maybeCancelBuild = async function(error, api) {
   await api.cancelSiteDeploy({ deploy_id: DEPLOY_ID })
 }
 
-module.exports = { maybeCancelBuild }
+// Is an exception but not a build error, e.g. canceled builds
+const isSuccessException = function(error) {
+  const errorInfo = getErrorInfo(error)
+  const { isSuccess } = getTypeInfo(errorInfo)
+  return Boolean(isSuccess)
+}
+
+module.exports = { maybeCancelBuild, isSuccessException }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -6,6 +6,7 @@ const { arrowDown } = require('figures')
 const prettyMs = require('pretty-ms')
 
 const { name, version } = require('../../package.json')
+const { isSuccessException } = require('../error/cancel')
 const { serializeLogError } = require('../error/parse/serialize_log')
 const { omit } = require('../utils/omit')
 
@@ -58,12 +59,13 @@ const logConfig = function(netlifyConfig) {
   logObject(simplifyConfig(netlifyConfig))
 }
 
-const logConfigOnError = function(netlifyConfig) {
+const logConfigOnError = function(error, netlifyConfig) {
   if (netlifyConfig === undefined) {
     return
   }
 
-  logMessage(THEME.errorSubHeader('Resolved config'))
+  const color = isSuccessException(error) ? THEME.subHeader : THEME.errorSubHeader
+  logMessage(color('Resolved config'))
   logObject(simplifyConfig(netlifyConfig))
 }
 
@@ -234,7 +236,7 @@ const logDryRunEnd = function() {
 
 const logCommand = function({ event, package, index, configPath, error }) {
   const description = getCommandDescription({ event, package, configPath })
-  const logHeaderFunc = error ? logErrorHeader : logHeader
+  const logHeaderFunc = error && !isSuccessException(error) ? logErrorHeader : logHeader
   logHeaderFunc(`${index + 1}. ${description}`)
   logMessage('')
 }
@@ -272,7 +274,7 @@ const logPluginError = function(error, netlifyConfig) {
   const { title, body } = serializeLogError(error)
   logErrorHeader(title)
   logMessage(`\n${body}\n`)
-  logConfigOnError(netlifyConfig)
+  logConfigOnError(error, netlifyConfig)
 }
 
 const logBuildError = function(error) {
@@ -280,7 +282,7 @@ const logBuildError = function(error) {
   const logFunction = isSuccess ? logHeader : logErrorHeader
   logFunction(title)
   logMessage(`\n${body}\n`)
-  logConfigOnError(netlifyConfig)
+  logConfigOnError(error, netlifyConfig)
 }
 
 const logBuildSuccess = function() {


### PR DESCRIPTION
Fixes #1333.

When using `cancelBuild()`, the logs should show successful colors (cyan), not error ones (red).