### PR TITLE
Finish removing `plugins[*].type`

### DIFF
--- a/packages/config/src/validate/validations.js
+++ b/packages/config/src/validate/validations.js
@@ -41,7 +41,7 @@ const RAW_VALIDATIONS = [
 
   {
     property: 'plugins.*',
-    check: ({ package, type }) => package !== undefined || type !== undefined,
+    check: ({ package }) => package !== undefined,
     message: '"package" property is required.',
     example: () => ({ plugins: [{ package: 'netlify-plugin-one' }] }),
   },


### PR DESCRIPTION
Part of #1303.
Follow-up on #1346.

#1346 removed `plugins[*].type`. But there was one place where this attribute was still used. This PR removes it.