### PR TITLE
Simplify code related to error logging

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -7,7 +7,7 @@ const { setEnvChanges } = require('../env/changes.js')
 const { addErrorInfo, getErrorInfo } = require('../error/info')
 const { reportBuildError } = require('../error/monitor/report')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
-const { logCommand, logBuildCommandStart, logCommandSuccess, logPluginError } = require('../log/main')
+const { logCommand, logBuildCommandStart, logCommandSuccess, logBuildError } = require('../log/main')
 const { pipeOutput, unpipeOutput } = require('../log/stream')
 const { startTimer, endTimer } = require('../log/timer')
 const { EVENTS } = require('../plugins/events')
@@ -296,7 +296,7 @@ const handleCommandError = async function({ newError, errorMonitor, buildCommand
 }
 
 const handleFailPlugin = async function({ newStatus, package, newError, errorMonitor, netlifyConfig }) {
-  logPluginError(newError, netlifyConfig)
+  logBuildError(newError, netlifyConfig)
   await reportBuildError(newError, errorMonitor)
   return { failedPlugin: [package], newStatus }
 }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -244,15 +244,8 @@ const logCacheDir = function(path) {
   logMessage(`Caching ${path}`)
 }
 
-const logPluginError = function(error, netlifyConfig) {
-  const { title, body } = serializeLogError(error)
-  logErrorHeader(title)
-  logMessage(`\n${body}\n`)
-  logConfigOnError(error, netlifyConfig)
-}
-
-const logBuildError = function(error) {
-  const { title, body, isSuccess, netlifyConfig } = serializeLogError(error)
+const logBuildError = function(error, netlifyConfigArg) {
+  const { title, body, isSuccess, netlifyConfig = netlifyConfigArg } = serializeLogError(error)
   const logFunction = isSuccess ? logHeader : logErrorHeader
   logFunction(title)
   logMessage(`\n${body}\n`)
@@ -285,7 +278,6 @@ module.exports = {
   logTimer,
   logStatuses,
   logCacheDir,
-  logPluginError,
   logBuildError,
   logBuildSuccess,
 }


### PR DESCRIPTION
We have two functions to log errors: one for the errors due to `utils.build.failPlugin()`, one for all the errors. This PR merges those two functions. This is refactoring only.