### PR TITLE
Improve documentation of `utils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The `constants` key contains the following values:
 
 ### Utilities
 
-Several utilities are providing with the `utils` argument to event handlers:
+Several utilities are provided with the `utils` argument to event handlers:
 
 - [`build`](#error-reporting): to report errors or cancel builds
 - [`status`](#logging): to display information in the deploy summary
@@ -257,6 +257,16 @@ Several utilities are providing with the `utils` argument to event handlers:
 - [`run`](/packages/run-utils/README.md): to run commands and processes
 - [`git`](/packages/git-utils/README.md): to retrieve git-related information such as the list of
   modified/created/deleted files
+
+```js
+// index.js
+
+module.exports = {
+  onPreBuild: async ({ utils: { build, status, cache, run, git } }) => {
+    await run.command('eslint src/ test/')
+  },
+}
+```
 
 ### Error reporting
 


### PR DESCRIPTION
The documentation of `utils` in the `README` has a typo. 
This PR also adds an example to help developers visualize how to use those `utils`.