### PR TITLE
Refactor `plugin.origin`

### DIFF
--- a/packages/config/src/default_config.js
+++ b/packages/config/src/default_config.js
@@ -2,18 +2,27 @@ const { deepMerge } = require('./utils/merge')
 
 // Merge `--defaultConfig` which is used to retrieve UI build settings and
 // UI-installed plugins.
+const mergeDefaultConfig = function({ plugins: defaultPlugins = [], ...defaultConfig }, { plugins = [], ...config }) {
+  const configA = deepMerge(defaultConfig, config)
+  const pluginsA = mergePlugins(defaultPlugins, plugins)
+  return { ...configA, plugins: pluginsA }
+}
+
 // `defaultConfig` `plugins` are UI-installed plugins. Those are merged by
 // concatenation instead of override.
 // Also, we add the `origin` field of plugins: installed through `ui` or through
 // `config` (`netlify.toml`)
-const mergeDefaultConfig = function({ plugins: defaultPlugins = [], ...defaultConfig }, { plugins = [], ...config }) {
-  const configA = deepMerge(defaultConfig, config)
-  const pluginsA = [...defaultPlugins.map(addUiOrigin), ...plugins]
-  return { ...configA, plugins: pluginsA }
+const mergePlugins = function(defaultPlugins, plugins) {
+  const pluginsA = [...defaultPlugins.map(addUiOrigin), ...plugins.map(addConfigOrigin)]
+  return pluginsA
 }
 
 const addUiOrigin = function(plugin) {
   return { ...plugin, origin: 'ui' }
+}
+
+const addConfigOrigin = function(plugin) {
+  return { ...plugin, origin: 'config' }
 }
 
 module.exports = { mergeDefaultConfig }

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -50,10 +50,8 @@ const removeEmptyCommand = function({ command, ...build }) {
   return { ...build, command }
 }
 
-const normalizePlugin = function({ package, inputs = {}, origin = DEFAULT_ORIGIN, ...plugin }) {
+const normalizePlugin = function({ package, inputs = {}, origin, ...plugin }) {
   return removeFalsy({ ...plugin, package, inputs, origin })
 }
-
-const DEFAULT_ORIGIN = 'config'
 
 module.exports = { normalizeConfig }


### PR DESCRIPTION
This is a small refactoring of how `plugin.origin` is assigned. Its value is `ui` when the plugin has been installed from the UI (`defaultConfig` parameter) and `config` when installed from `netlify.toml` (`config` parameter). This does not change behavior.