### PR TITLE
Fix wrong usage of `process.exit()`

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { exit } = require('process')
+const process = require('process')
 
 const filterObj = require('filter-obj')
 const yargs = require('yargs')
@@ -18,8 +18,7 @@ const runCli = async function() {
   }
 
   const success = await build(flagsA)
-  const exitCode = success ? 0 : 1
-  exit(exitCode)
+  process.exitCode = success ? 0 : 1
 }
 
 const parseFlags = function() {
@@ -130,7 +129,7 @@ const INTERNAL_KEYS = ['help', 'version', '_', '$0', 'dryRun']
 
 const printFeatures = function() {
   console.log(['', ...FEATURES, ''].join(FEATURES_DELIMITER))
-  exit(0)
+  process.exitCode = 0
 }
 
 const FEATURES = ['cachesave']

--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
-const {
-  exit,
-  env: { NETLIFY_BUILD_TEST },
-} = require('process')
+const process = require('process')
 
 const { stableStringify } = require('fast-safe-stringify')
 
@@ -31,13 +28,13 @@ const handleCliSuccess = function(result, stable) {
   const stringifyFunc = stable ? stableStringify : JSON.stringify
   const resultJson = stringifyFunc(resultA, null, 2)
   console.log(resultJson)
-  exit(0)
+  process.exitCode = 0
 }
 
 // `api` is not JSON-serializable, so we remove it
 // We still indicate it as a boolean in tests
 const serializeApi = function({ api, ...result }) {
-  if (NETLIFY_BUILD_TEST !== '1' || api === undefined) {
+  if (process.env.NETLIFY_BUILD_TEST !== '1' || api === undefined) {
     return result
   }
 
@@ -48,12 +45,13 @@ const handleCliError = function(error) {
   // Errors caused by users do not show stack traces and have exit code 1
   if (isUserError(error)) {
     console.error(error.message)
-    return exit(1)
+    process.exitCode = 1
+    return
   }
 
   // Internal errors / bugs have exit code 2
   console.error(error.stack)
-  exit(2)
+  process.exitCode = 2
 }
 
 runCli()

--- a/packages/config/tests/cli/tests.js
+++ b/packages/config/tests/cli/tests.js
@@ -1,6 +1,12 @@
-const test = require('ava')
+const { writeFile } = require('fs')
+const { promisify } = require('util')
 
-const { runFixture } = require('../helpers/main')
+const test = require('ava')
+const del = require('del')
+
+const { runFixture, FIXTURES_DIR } = require('../helpers/main')
+
+const pWriteFile = promisify(writeFile)
 
 test('--help', async t => {
   await runFixture(t, '', { flags: '--help' })
@@ -29,3 +35,29 @@ test('Stabilitize output with the --stable flag', async t => {
 test('Does not stabilitize output without the --stable flag', async t => {
   await runFixture(t, 'empty', { flags: '--no-stable' })
 })
+
+test('Handles big outputs', async t => {
+  const bigNetlify = `${FIXTURES_DIR}/big/netlify.toml`
+  await del(bigNetlify, { force: true })
+  try {
+    const bigContent = getBigNetlifyContent()
+    await pWriteFile(bigNetlify, bigContent)
+    const { stdout } = await runFixture(t, 'big', { snapshot: false })
+    t.notThrows(() => {
+      JSON.parse(stdout)
+    })
+  } finally {
+    await del(bigNetlify, { force: true })
+  }
+})
+
+const getBigNetlifyContent = function() {
+  const envVars = Array.from({ length: BIG_NUMBER }, getEnvVar).join('\n')
+  return `[build.environment]\n${envVars}`
+}
+
+const BIG_NUMBER = 1e4
+
+const getEnvVar = function(value, index) {
+  return `TEST${index} = ${index}`
+}


### PR DESCRIPTION
Related to https://github.com/netlify/buildbot/issues/772

When the output of `@netlify/config` is over 65536 bytes, it is truncated. This might be due to calling `process.exit()`. `process.exit()` does not wait for I/O to be flushed. This is a problem when using async I/O such as `console.log()` when `stdout` is redirected to a pipe (I/O is sync if redirected to a TTY).

The good pattern [as outlined in Node.js documentation](https://nodejs.org/dist/latest-v14.x/docs/api/process.html#process_process_exit_code) is to use `process.exitCode`.