### PR TITLE
Simplify code related to automatic installs

### DIFF
--- a/packages/build/src/install/main.js
+++ b/packages/build/src/install/main.js
@@ -12,7 +12,7 @@ const installDependencies = function({ packageRoot, isLocal }) {
 }
 
 // Add new Node.js dependencies
-const addDependencies = function({ packageRoot, isLocal, packages }) {
+const addLatestDependencies = function({ packageRoot, isLocal, packages }) {
   return runCommand({ packageRoot, packages, isLocal, type: 'add' })
 }
 
@@ -31,14 +31,19 @@ const runCommand = async function({ packageRoot, packages, isLocal, type }) {
 
 // Retrieve the shell command to install or add dependencies
 const getCommand = async function({ packageRoot, type, isLocal }) {
-  const manager = await getManager(packageRoot)
+  const manager = await getManager(type, packageRoot)
   const command = COMMANDS[manager][type]
   const commandA = await fixNpmCiCompat(command)
   const commandB = addYarnCustomCache(commandA, manager, isLocal)
   return commandB
 }
 
-const getManager = async function(packageRoot) {
+const getManager = async function(type, packageRoot) {
+  // `addLatestDependencies()` is only supported with npm at the moment
+  if (type === 'add') {
+    return 'npm'
+  }
+
   if (await pathExists(`${packageRoot}/yarn.lock`)) {
     return 'yarn'
   }
@@ -52,7 +57,6 @@ const COMMANDS = {
     install: 'npm install --no-progress --no-audit --no-fund',
   },
   yarn: {
-    add: 'yarn add --no-progress --non-interactive --ignore-workspace-root-check',
     install: 'yarn install --no-progress --non-interactive',
   },
 }
@@ -100,4 +104,4 @@ const isNotNpmLogMessage = function(line) {
 }
 const NPM_LOG_MESSAGES = ['complete log of this run', '-debug.log']
 
-module.exports = { installDependencies, addDependencies }
+module.exports = { installDependencies, addLatestDependencies }

--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -6,7 +6,7 @@ const pathExists = require('path-exists')
 
 const { logInstallMissingPlugins } = require('../log/main')
 
-const { addDependencies } = require('./main')
+const { addLatestDependencies } = require('./main')
 
 const pWriteFile = promisify(writeFile)
 
@@ -34,7 +34,7 @@ const installMissingPlugins = async function({ pluginsOptions, autoPluginsDir, m
   logInstallMissingPlugins(packages)
 
   await createAutoPluginsDir(autoPluginsDir)
-  await addDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
+  await addLatestDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
 }
 
 const getMissingPlugins = function(pluginsOptions) {


### PR DESCRIPTION
We have some logic to add dependencies with either npm or Yarn.

However this currently is only used with npm, with automatic installs. Even if users use Yarn in their projects, automatically installed plugins will use npm to match the behavior from the `build-image` and make the logic more resilient.

Also, the latest version of dependencies is always installed in that case.

This PR does some refactoring simplifying that code taking into account the above. It does not change any behavior.