### PR TITLE
Fix performance issue

### DIFF
--- a/packages/build/src/telemetry/track.js
+++ b/packages/build/src/telemetry/track.js
@@ -9,26 +9,24 @@ const { version } = require('../../package.json')
 const REQUEST_FILE = `${__dirname}/request.js`
 
 // Send HTTP request to telemetry.
+// Telemetry should not impact build speed, so we do not wait for the request
+// to complete, by using a child process.
+// We also ignore any errors. Those might happen for example if the current
+// directory was removed by the build command.
 const track = async function({ payload }) {
   if (BUILD_TELEMETRY_DISABLED) {
     return
   }
 
-  const promise = spawnRequest(payload)
-
-  // During tests, we wait for the HTTP request to complete
-  if (TEST_HOST !== undefined) {
-    await promise
-  }
-}
-
-// Telemetry should not impact build speed, so we do not wait for the request
-// to complete, by using a child process.
-// We also ignore any errors. Those might happen for example if the current
-// directory was removed by the build command.
-const spawnRequest = async function(payload) {
   try {
-    await execa('node', [REQUEST_FILE, JSON.stringify(payload)], { detached: true, stdio: 'ignore' })
+    const childProcess = execa('node', [REQUEST_FILE, JSON.stringify(payload)], { detached: true, stdio: 'ignore' })
+
+    // During tests, we wait for the HTTP request to complete
+    if (TEST_HOST === undefined) {
+      childProcess.unref()
+    }
+
+    await childProcess
   } catch (error) {
     return
   }


### PR DESCRIPTION
The child process spawned for the telemetry needs to call `childProcess.unref()`. Otherwise, it will keep the parent process alive, which defeats the point of using a child process for that purpose.

This PR fixes this.