### PR TITLE
Improve normalization of Bugsnag errors

### DIFF
--- a/packages/build/src/error/monitor/normalize.js
+++ b/packages/build/src/error/monitor/normalize.js
@@ -34,8 +34,10 @@ const normalizeMessage = function(message, [regExp, replacement]) {
 }
 
 const NORMALIZE_REGEXPS = [
+  // Base64 URL
+  [/(data:[^;]+;base64),[\w+/-]+/g, 'dataURI'],
   // File paths
-  [/(["'`, ]|^)([^"'`, ]*[/\\][^"'`, ]*)(["'`, ]|$)/gm, '$1/file/path$3'],
+  [/(["'`, ]|^)([^"'`, \n]*[/\\][^"'`, \n]*)(["'`, ]|$)/gm, '$1/file/path$3'],
   // Semantic versions
   [/\d+\.\d+\.\d+(-\d+)?/g, '1.0.0'],
   [/version "[^"]+"/g, 'version "1.0.0"'],


### PR DESCRIPTION
This is a follow-up on #1405, which adds normalization of base64 encoded URIs.