### PR TITLE
Improve speed of installation-related tests

### DIFF
--- a/packages/build/tests/install/functions/tests.js
+++ b/packages/build/tests/install/functions/tests.js
@@ -4,48 +4,47 @@ const pathExists = require('path-exists')
 const { removeDir } = require('../../helpers/dir')
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
-// Need to run `npm install` and `yarn` serially to avoid network errors
-test.serial('Functions: install dependencies nested', async t => {
+test('Functions: install dependencies nested', async t => {
   await removeDir([`${FIXTURES_DIR}/dir/.netlify/functions/`, `${FIXTURES_DIR}/dir/functions/function/node_modules/`])
   await runFixture(t, 'dir')
   t.true(await pathExists(`${FIXTURES_DIR}/dir/functions/function/node_modules/`))
   await removeDir([`${FIXTURES_DIR}/dir/.netlify/functions/`, `${FIXTURES_DIR}/dir/functions/function/node_modules/`])
 })
 
-test.serial('Functions: ignore package.json inside node_modules', async t => {
+test('Functions: ignore package.json inside node_modules', async t => {
   await removeDir(`${FIXTURES_DIR}/node_modules/.netlify/functions/`)
   await runFixture(t, 'node_modules')
 })
 
-test.serial('Functions: install dependencies with npm', async t => {
+test('Functions: install dependencies with npm', async t => {
   await removeDir([`${FIXTURES_DIR}/npm/.netlify/functions/`, `${FIXTURES_DIR}/npm/functions/node_modules/`])
   await runFixture(t, 'npm')
   t.true(await pathExists(`${FIXTURES_DIR}/npm/functions/node_modules/`))
   await removeDir([`${FIXTURES_DIR}/npm/.netlify/functions/`, `${FIXTURES_DIR}/npm/functions/node_modules/`])
 })
 
-test.serial('Functions: install dependencies with Yarn locally', async t => {
+test('Functions: install dependencies with Yarn locally', async t => {
   await removeDir([`${FIXTURES_DIR}/yarn/.netlify/functions/`, `${FIXTURES_DIR}/yarn/functions/node_modules/`])
   await runFixture(t, 'yarn')
   t.true(await pathExists(`${FIXTURES_DIR}/yarn/functions/node_modules/`))
   await removeDir([`${FIXTURES_DIR}/yarn/.netlify/functions/`, `${FIXTURES_DIR}/yarn/functions/node_modules/`])
 })
 
-test.serial('Functions: install dependencies with Yarn in CI', async t => {
+test('Functions: install dependencies with Yarn in CI', async t => {
   await removeDir([`${FIXTURES_DIR}/yarn_ci/.netlify/functions/`, `${FIXTURES_DIR}/yarn_ci/functions/node_modules/`])
   await runFixture(t, 'yarn_ci', { flags: '--mode=buildbot' })
   t.true(await pathExists(`${FIXTURES_DIR}/yarn_ci/functions/node_modules/`))
   await removeDir([`${FIXTURES_DIR}/yarn_ci/.netlify/functions/`, `${FIXTURES_DIR}/yarn_ci/functions/node_modules/`])
 })
 
-test.serial('Functions: does not install dependencies unless opting in', async t => {
+test('Functions: does not install dependencies unless opting in', async t => {
   await removeDir([`${FIXTURES_DIR}/optional/.netlify/functions/`, `${FIXTURES_DIR}/optional/functions/node_modules/`])
   await runFixture(t, 'optional')
   t.false(await pathExists(`${FIXTURES_DIR}/optional/functions/node_modules/`))
   await removeDir([`${FIXTURES_DIR}/optional/.netlify/functions/`, `${FIXTURES_DIR}/optional/functions/node_modules/`])
 })
 
-test.serial('Functions: does not print warnings when dependency was mispelled', async t => {
+test('Functions: does not print warnings when dependency was mispelled', async t => {
   await removeDir([
     `${FIXTURES_DIR}/mispelled_dep/.netlify/functions/`,
     `${FIXTURES_DIR}/mispelled_dep/functions/node_modules/`,

--- a/packages/build/tests/install/local/tests.js
+++ b/packages/build/tests/install/local/tests.js
@@ -4,41 +4,40 @@ const pathExists = require('path-exists')
 const { removeDir } = require('../../helpers/dir')
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
-// Need to run `npm install` and `yarn` serially to avoid network errors
-test.serial('Install local plugin dependencies: with npm', async t => {
+test('Install local plugin dependencies: with npm', async t => {
   await removeDir(`${FIXTURES_DIR}/npm/plugin/node_modules`)
   await runFixture(t, 'npm')
   t.true(await pathExists(`${FIXTURES_DIR}/npm/plugin/node_modules`))
   await removeDir(`${FIXTURES_DIR}/npm/plugin/node_modules`)
 })
 
-test.serial('Install local plugin dependencies: with yarn locally', async t => {
+test('Install local plugin dependencies: with yarn locally', async t => {
   await removeDir(`${FIXTURES_DIR}/yarn/plugin/node_modules`)
   await runFixture(t, 'yarn')
   t.true(await pathExists(`${FIXTURES_DIR}/yarn/plugin/node_modules`))
   await removeDir(`${FIXTURES_DIR}/yarn/plugin/node_modules`)
 })
 
-test.serial('Install local plugin dependencies: with yarn in CI', async t => {
+test('Install local plugin dependencies: with yarn in CI', async t => {
   await removeDir(`${FIXTURES_DIR}/yarn_ci/plugin/node_modules`)
   await runFixture(t, 'yarn_ci', { flags: '--mode=buildbot' })
   t.true(await pathExists(`${FIXTURES_DIR}/yarn_ci/plugin/node_modules`))
   await removeDir(`${FIXTURES_DIR}/yarn_ci/plugin/node_modules`)
 })
 
-test.serial('Install local plugin dependencies: propagate errors', async t => {
+test('Install local plugin dependencies: propagate errors', async t => {
   await runFixture(t, 'error')
 })
 
-test.serial('Install local plugin dependencies: already installed', async t => {
+test('Install local plugin dependencies: already installed', async t => {
   await runFixture(t, 'already')
 })
 
-test.serial('Install local plugin dependencies: no package.json', async t => {
+test('Install local plugin dependencies: no package.json', async t => {
   await runFixture(t, 'no_package')
 })
 
-test.serial('Install local plugin dependencies: no root package.json', async t => {
+test('Install local plugin dependencies: no root package.json', async t => {
   await runFixture(t, 'no_root_package', { copyRoot: {} })
 })
 

--- a/packages/build/tests/install/missing/tests.js
+++ b/packages/build/tests/install/missing/tests.js
@@ -2,12 +2,11 @@ const test = require('ava')
 
 const { runFixture } = require('../../helpers/main')
 
-// Need to run `npm install` and `yarn` serially to avoid network errors
-test.serial('Automatically install missing plugins locally', async t => {
+test('Automatically install missing plugins locally', async t => {
   await runFixture(t, 'main', { copyRoot: {} })
 })
 
-test.serial('Automatically install missing plugins in CI', async t => {
+test('Automatically install missing plugins in CI', async t => {
   await runFixture(t, 'main', { copyRoot: {}, flags: '--mode=buildbot' })
 })
 


### PR DESCRIPTION
The tests related to `npm install` are currently run serially because we previously experienced some network errors when run in parallel.

Now that the number of those tests has been reduced, this PR runs them in parallel instead, for improved test speed.