### PR TITLE
Improve Bugsnag start logic

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -11280,6 +11280,11 @@
       "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
       "dev": true
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "meow": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -51,6 +51,7 @@
     "log-process-errors": "^5.1.2",
     "make-dir": "^3.0.2",
     "map-obj": "^4.1.0",
+    "memoize-one": "^5.1.1",
     "netlify": "^4.2.0",
     "os-name": "^3.1.0",
     "p-event": "^4.1.0",

--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -1,6 +1,7 @@
 const { env } = require('process')
 
 const Bugsnag = require('@bugsnag/js')
+const memoizeOne = require('memoize-one')
 
 const { name, version } = require('../../../package.json')
 const { log } = require('../../log/logger.js')
@@ -16,7 +17,7 @@ const startErrorMonitor = function({ mode }) {
 
   const releaseStage = getReleaseStage(mode)
   try {
-    const errorMonitor = Bugsnag.start({
+    const errorMonitor = startBugsnag({
       apiKey,
       appVersion: `${name} ${version}`,
       appType: name,
@@ -35,6 +36,11 @@ const startErrorMonitor = function({ mode }) {
     return
   }
 }
+
+// Bugsnag.start() caches a global instance and warns on duplicate calls.
+// This ensures the warning message is not shown when calling the main function
+// several times.
+const startBugsnag = memoizeOne(Bugsnag.start.bind(Bugsnag), () => true)
 
 // Based the release stage on the `mode`
 const getReleaseStage = function(mode = DEFAULT_RELEASE_STAGE) {


### PR DESCRIPTION
When `@netlify/build` is run several times for a single process (e.g. during tests), Bugsnag prints a warning because `Bugsnag.start()` return value is a singleton which cannot be instantiated twice.

This PR adds `memoize-one` so that calling `Bugsnag.start()` a second time returns the same return value, but without any warning message printed on console.