### PR TITLE
Improve `@netlify/build` return value

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -17,7 +17,7 @@ const runCli = async function() {
     return printFeatures()
   }
 
-  const success = await build(flagsA)
+  const { success } = await build(flagsA)
   process.exitCode = success ? 0 : 1
 }
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -86,7 +86,7 @@ const build = async function(flags) {
       })
 
       if (dry) {
-        return true
+        return { success: true }
       }
 
       await reportStatuses({ statuses, api, mode, netlifyConfig, errorMonitor })
@@ -98,7 +98,7 @@ const build = async function(flags) {
       logBuildSuccess()
       const duration = endTimer(buildTimer, 'Netlify Build')
       await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, mode })
-      return true
+      return { success: true }
     } catch (error) {
       await maybeCancelBuild(error, api)
       await logOldCliVersionError(mode)
@@ -110,7 +110,7 @@ const build = async function(flags) {
     removeErrorColors(error)
     await reportBuildError(error, errorMonitor)
     logBuildError(error)
-    return false
+    return { success: false }
   }
 }
 


### PR DESCRIPTION
This PR changes the programmatic return value of `@netlify/build` from a boolean to an object. This allows for more flexibility if we need to add more information in the return value.

This is required by an upcoming PR which will add more information in the return value.