### PR TITLE
Make `flags` object optional

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -35,7 +35,7 @@ const { doDryRun } = require('./dry')
  * @param  {string} [flags.context] - Build context
  * @param  {boolean} [flags.dry] - printing commands without executing them
  */
-const build = async function(flags) {
+const build = async function(flags = {}) {
   const buildTimer = startTimer()
 
   logBuildStart()


### PR DESCRIPTION
This allows the argument to `@netlify/build` (when run programmatically) to be optional.