### PR TITLE
Add `debug` flag

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -115,6 +115,11 @@ Default: false`,
   - 'require': through require('@netlify/build')`,
     hidden: true,
   },
+  debug: {
+    boolean: true,
+    describe: 'Print debugging information',
+    hidden: true,
+  },
 }
 
 const USAGE = `netlify-build [OPTIONS...]

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -25,6 +25,7 @@ const DEFAULT_FLAGS = () => ({
   token: env.NETLIFY_AUTH_TOKEN,
   mode: 'require',
   deployId: env.DEPLOY_ID,
+  debug: Boolean(env.NETLIFY_BUILD_DEBUG),
 })
 
 // Retrieve configuration object
@@ -43,6 +44,7 @@ const loadConfig = async function({
   branch,
   baseRelDir,
   mode,
+  debug,
 }) {
   const {
     configPath,
@@ -67,7 +69,7 @@ const loadConfig = async function({
   })
   logBuildDir(buildDir)
   logConfigPath(configPath)
-  logConfig(netlifyConfig)
+  logConfig({ netlifyConfig, debug })
   logContext(contextA)
 
   const apiA = addApiErrorHandlers(api)

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -1,7 +1,3 @@
-const {
-  env: { NETLIFY_BUILD_DEBUG },
-} = require('process')
-
 const { arrowDown } = require('figures')
 const filterObj = require('filter-obj')
 const prettyMs = require('pretty-ms')
@@ -38,7 +34,7 @@ const logFlags = function(flags) {
   logObject(flagsA)
 }
 
-const HIDDEN_FLAGS = ['token', 'deployId', 'cachedConfig', 'defaultConfig']
+const HIDDEN_FLAGS = ['token', 'deployId', 'cachedConfig', 'defaultConfig', 'debug']
 
 const logBuildDir = function(buildDir) {
   logSubHeader('Current directory')
@@ -52,8 +48,8 @@ const logConfigPath = function(configPath = NO_CONFIG_MESSAGE) {
 
 const NO_CONFIG_MESSAGE = 'No config file was defined: using default values.'
 
-const logConfig = function(netlifyConfig) {
-  if (!NETLIFY_BUILD_DEBUG) {
+const logConfig = function({ netlifyConfig, debug }) {
+  if (!debug) {
     return
   }
 

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -73,7 +73,7 @@ const getMainFlags = function({ fixtureName, copyRoot, copyRootDir, repositoryRo
   return `${DEFAULT_FLAGS} ${repositoryRootFlag} ${flags}`
 }
 
-const DEFAULT_FLAGS = ''
+const DEFAULT_FLAGS = '--debug'
 
 // The `repositoryRoot` flag can be overriden, but defaults to the fixture
 // directory

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -14,7 +14,6 @@ const runFixture = async function(t, fixtureName, { env: envOption, ...opts } = 
     ...opts,
     binaryPath: await BINARY_PATH,
     env: {
-      NETLIFY_BUILD_DEBUG: '1',
       // Workarounds to mock caching logic
       TEST_CACHE_PATH: 'none',
       // Ensure local tokens aren't used during development


### PR DESCRIPTION
There is a `NETLIFY_BUILD_DEBUG` environment variable which prints additional information in logs. However environment variables are global, which makes it difficult to run parallel tests in the same process. This PR does not remove that environment variables but adds an additional way to specify it: a `--debug` CLI flag, which is test-friendlier.