### PR TITLE
Add `--bugsnag-key` CLI flag

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -26,6 +26,7 @@ const DEFAULT_FLAGS = () => ({
   mode: 'require',
   deployId: env.DEPLOY_ID,
   debug: Boolean(env.NETLIFY_BUILD_DEBUG),
+  bugsnagKey: env.BUGSNAG_KEY,
 })
 
 // Retrieve configuration object

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -40,8 +40,8 @@ const build = async function(flags = {}) {
 
   logBuildStart()
 
-  const flagsA = normalizeFlags(flags)
-  const errorMonitor = startErrorMonitor(flagsA)
+  const { bugsnagKey, ...flagsA } = normalizeFlags(flags)
+  const errorMonitor = startErrorMonitor({ flags: flagsA, bugsnagKey })
 
   try {
     const {

--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -1,5 +1,3 @@
-const { env } = require('process')
-
 const Bugsnag = require('@bugsnag/js')
 const memoizeOne = require('memoize-one')
 
@@ -9,16 +7,15 @@ const { log } = require('../../log/logger.js')
 const projectRoot = `${__dirname}/../../..`
 
 // Start a client to monitor errors
-const startErrorMonitor = function({ mode }) {
-  const apiKey = env.BUGSNAG_KEY
-  if (!apiKey) {
+const startErrorMonitor = function({ flags: { mode }, bugsnagKey }) {
+  if (!bugsnagKey) {
     return
   }
 
   const releaseStage = getReleaseStage(mode)
   try {
     const errorMonitor = startBugsnag({
-      apiKey,
+      apiKey: bugsnagKey,
       appVersion: `${name} ${version}`,
       appType: name,
       releaseStage,

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -34,7 +34,7 @@ const logFlags = function(flags) {
   logObject(flagsA)
 }
 
-const HIDDEN_FLAGS = ['token', 'deployId', 'cachedConfig', 'defaultConfig', 'debug']
+const HIDDEN_FLAGS = ['token', 'deployId', 'cachedConfig', 'defaultConfig', 'debug', 'bugsnagKey']
 
 const logBuildDir = function(buildDir) {
   logSubHeader('Current directory')

--- a/packages/build/tests/error/monitor/tests.js
+++ b/packages/build/tests/error/monitor/tests.js
@@ -6,88 +6,89 @@ const hasAnsi = require('has-ansi')
 const { getJsonOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
-const env = { BUGSNAG_KEY: '00000000000000000000000000000000' }
+const flags = '--bugsnag-key=00000000000000000000000000000000'
 
 test('Report build.command failure', async t => {
-  await runFixture(t, 'command', { env })
+  await runFixture(t, 'command', { flags })
 })
 
 test('Report configuration user error', async t => {
-  await runFixture(t, 'config', { env })
+  await runFixture(t, 'config', { flags })
 })
 
 test('Report plugin input error', async t => {
-  await runFixture(t, 'plugin_input', { env })
+  await runFixture(t, 'plugin_input', { flags })
 })
 
 test('Report plugin validation error', async t => {
-  await runFixture(t, 'plugin_validation', { env })
+  await runFixture(t, 'plugin_validation', { flags })
 })
 
 test('Report plugin internal error', async t => {
-  await runFixture(t, 'plugin_internal', { env })
+  await runFixture(t, 'plugin_internal', { flags })
 })
 
 test('Report utils.build.failBuild()', async t => {
-  await runFixture(t, 'fail_build', { env })
+  await runFixture(t, 'fail_build', { flags })
 })
 
 test('Report utils.build.failPlugin()', async t => {
-  await runFixture(t, 'fail_plugin', { env })
+  await runFixture(t, 'fail_plugin', { flags })
 })
 
 test('Report utils.build.cancelBuild()', async t => {
-  await runFixture(t, 'cancel_build', { env })
+  await runFixture(t, 'cancel_build', { flags })
 })
 
 test('Report IPC error', async t => {
-  await runFixture(t, 'ipc', { env })
+  await runFixture(t, 'ipc', { flags })
 })
 
 test('Report API error', async t => {
-  await runFixture(t, 'cancel_build', { env, flags: '--token=test --deploy-id=test' })
+  await runFixture(t, 'cancel_build', { flags: `${flags} --token=test --deploy-id=test` })
 })
 
 // Node v8 uses a different error message format
 if (!version.startsWith('v8.')) {
   test('Report dependencies error', async t => {
-    await runFixture(t, 'dependencies', { env })
+    await runFixture(t, 'dependencies', { flags })
   })
 }
 
 test('Report buildbot mode as releaseStage', async t => {
-  await runFixture(t, 'command', { env, flags: '--mode=buildbot' })
+  await runFixture(t, 'command', { flags: `${flags} --mode=buildbot` })
 })
 
 test('Report CLI mode as releaseStage', async t => {
-  await runFixture(t, 'command', { env, flags: '--mode=cli' })
+  await runFixture(t, 'command', { flags: `${flags} --mode=cli` })
 })
 
 test('Report programmatic mode as releaseStage', async t => {
-  await runFixture(t, 'command', { env, flags: '--mode=require' })
+  await runFixture(t, 'command', { flags: `${flags} --mode=require` })
 })
 
 test('Remove colors in error.message', async t => {
-  const { stdout } = await runFixture(t, 'colors', { env, snapshot: false })
+  const { stdout } = await runFixture(t, 'colors', { flags, snapshot: false })
   const lines = stdout.split('\n').filter(line => line.includes('ColorTest'))
   t.true(lines.every(line => !hasAnsi(line)))
 })
 
 test('Report BUILD_ID', async t => {
-  await runFixture(t, 'command', { env: { ...env, BUILD_ID: 'test' } })
+  await runFixture(t, 'command', { flags, env: { BUILD_ID: 'test' } })
 })
 
 test('Report plugin homepage', async t => {
-  await runFixture(t, 'plugin_homepage', { env })
+  await runFixture(t, 'plugin_homepage', { flags })
 })
 
 test('Report plugin origin', async t => {
   const defaultConfig = getJsonOpt({ plugins: [{ package: './plugin.js' }] })
-  await runFixture(t, 'plugin_origin', { env, flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'plugin_origin', { flags: `${flags} --defaultConfig=${defaultConfig}` })
 })
 
 test('Report build logs URLs', async t => {
   await runFixture(t, 'command', {
-    env: { ...env, DEPLOY_ID: 'testDeployId', DEPLOY_URL: 'https://testDeployId--testSiteName.netlify.app' },
+    flags,
+    env: { DEPLOY_ID: 'testDeployId', DEPLOY_URL: 'https://testDeployId--testSiteName.netlify.app' },
   })
 })


### PR DESCRIPTION
There is a `BUGSNAG_KEY` environment variable to set the Bugsnag API key. However environment variables are global, which makes it difficult to run parallel tests in the same process. This PR does not remove that environment variable but adds an additional way to specify it: a `--bugsnag-key` CLI flag, which is test-friendlier.