### PR TITLE
Add `testOpts.errorMonitor` flag

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -120,6 +120,10 @@ Default: false`,
     describe: 'Print debugging information',
     hidden: true,
   },
+  testOpts: {
+    describe: 'Options for testing only',
+    hidden: true,
+  },
 }
 
 const USAGE = `netlify-build [OPTIONS...]

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -28,6 +28,9 @@ const DEFAULT_FLAGS = () => ({
   debug: Boolean(env.NETLIFY_BUILD_DEBUG),
   bugsnagKey: env.BUGSNAG_KEY,
   env: {},
+
+  // Flags used only for testing
+  testOpts: {},
 })
 
 // Retrieve configuration object

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -40,7 +40,7 @@ const build = async function(flags = {}) {
 
   logBuildStart()
 
-  const { bugsnagKey, ...flagsA } = normalizeFlags(flags)
+  const { testOpts, bugsnagKey, ...flagsA } = normalizeFlags(flags)
   const errorMonitor = startErrorMonitor({ flags: flagsA, bugsnagKey })
 
   try {
@@ -71,6 +71,7 @@ const build = async function(flags = {}) {
         api,
         errorMonitor,
         deployId,
+        testOpts,
       })
 
       const { commandsCount, error, statuses } = await buildRun({
@@ -87,13 +88,14 @@ const build = async function(flags = {}) {
         api,
         errorMonitor,
         deployId,
+        testOpts,
       })
 
       if (dry) {
         return { success: true }
       }
 
-      await reportStatuses({ statuses, api, mode, netlifyConfig, errorMonitor, deployId })
+      await reportStatuses({ statuses, api, mode, netlifyConfig, errorMonitor, deployId, testOpts })
 
       if (error !== undefined) {
         throw error
@@ -112,7 +114,7 @@ const build = async function(flags = {}) {
     }
   } catch (error) {
     removeErrorColors(error)
-    await reportBuildError(error, errorMonitor)
+    await reportBuildError({ error, errorMonitor, testOpts })
     logBuildError(error)
     return { success: false }
   }
@@ -132,6 +134,7 @@ const buildRun = async function({
   api,
   errorMonitor,
   deployId,
+  testOpts,
 }) {
   const utilsData = await startUtils(buildDir)
   const childProcesses = await startPlugins({ pluginsOptions, buildDir, nodePath, childEnv, mode })
@@ -153,6 +156,7 @@ const buildRun = async function({
       api,
       errorMonitor,
       deployId,
+      testOpts,
     })
   } finally {
     await stopPlugins(childProcesses)
@@ -175,6 +179,7 @@ const executeCommands = async function({
   api,
   errorMonitor,
   deployId,
+  testOpts,
 }) {
   const pluginsCommands = await loadPlugins({
     pluginsOptions,
@@ -187,6 +192,7 @@ const executeCommands = async function({
     api,
     errorMonitor,
     deployId,
+    testOpts,
   })
 
   const { commands, commandsCount } = getCommands(pluginsCommands, netlifyConfig)
@@ -204,6 +210,7 @@ const executeCommands = async function({
     childEnv,
     errorMonitor,
     netlifyConfig,
+    testOpts,
   })
 }
 

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -34,7 +34,7 @@ const logFlags = function(flags) {
   logObject(flagsA)
 }
 
-const HIDDEN_FLAGS = ['token', 'deployId', 'cachedConfig', 'defaultConfig', 'debug', 'env', 'bugsnagKey']
+const HIDDEN_FLAGS = ['token', 'deployId', 'cachedConfig', 'defaultConfig', 'debug', 'env', 'bugsnagKey', 'testOpts']
 
 const logBuildDir = function(buildDir) {
   logSubHeader('Current directory')

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -15,6 +15,7 @@ const loadPlugins = async function({
   api,
   errorMonitor,
   deployId,
+  testOpts,
 }) {
   const pluginsCommands = await Promise.all(
     pluginsOptions.map((pluginOptions, index) =>
@@ -29,6 +30,7 @@ const loadPlugins = async function({
         api,
         errorMonitor,
         deployId,
+        testOpts,
       }),
     ),
   )
@@ -40,7 +42,7 @@ const loadPlugins = async function({
 // Do it by executing the plugin `load` event handler.
 const loadPlugin = async function(
   { package, packageJson, packageJson: { version } = {}, pluginPath, manifest, inputs, loadedFrom, origin },
-  { childProcesses, index, netlifyConfig, utilsData, token, constants, mode, api, errorMonitor, deployId },
+  { childProcesses, index, netlifyConfig, utilsData, token, constants, mode, api, errorMonitor, deployId, testOpts },
 ) {
   const { childProcess } = childProcesses[index]
   const event = 'load'
@@ -49,7 +51,7 @@ const loadPlugin = async function(
     const { pluginCommands } = await callChild(
       childProcess,
       'load',
-      { pluginPath, manifest, inputs, netlifyConfig, utilsData, token, constants },
+      { pluginPath, manifest, inputs, netlifyConfig, utilsData, token, constants, testOpts },
       { plugin: { package, packageJson }, location: { event, package, loadedFrom, origin } },
     )
     const pluginCommandsA = pluginCommands.map(({ event }) => ({
@@ -72,6 +74,7 @@ const loadPlugin = async function(
       netlifyConfig,
       errorMonitor,
       deployId,
+      testOpts,
     })
     throw error
   }

--- a/packages/build/src/plugins/manifest/main.js
+++ b/packages/build/src/plugins/manifest/main.js
@@ -7,7 +7,18 @@ const { getManifestPath } = require('./path')
 // Load plugin's `manifest.yml`
 const useManifest = async function(
   { package, loadedFrom, origin, inputs },
-  { pluginDir, packageDir, packageJson, packageJson: { version }, mode, api, netlifyConfig, errorMonitor, deployId },
+  {
+    pluginDir,
+    packageDir,
+    packageJson,
+    packageJson: { version },
+    mode,
+    api,
+    netlifyConfig,
+    errorMonitor,
+    deployId,
+    testOpts,
+  },
 ) {
   const manifestPath = await getManifestPath(pluginDir, packageDir)
 
@@ -26,6 +37,7 @@ const useManifest = async function(
       netlifyConfig,
       errorMonitor,
       deployId,
+      testOpts,
     })
     throw error
   }

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -19,6 +19,7 @@ const getPluginsOptions = async function({
   api,
   errorMonitor,
   deployId,
+  testOpts,
 }) {
   const corePlugins = getCorePlugins(FUNCTIONS_SRC).map(addCoreProperties)
   const allCorePlugins = corePlugins.filter(corePlugin => !isOptionalCore(corePlugin, plugins))
@@ -27,7 +28,7 @@ const getPluginsOptions = async function({
   const pluginsOptionsA = await resolvePluginsPath({ pluginsOptions, buildDir, mode })
   const pluginsOptionsB = await Promise.all(
     pluginsOptionsA.map(pluginOptions =>
-      loadPluginFiles({ pluginOptions, mode, api, netlifyConfig, errorMonitor, deployId }),
+      loadPluginFiles({ pluginOptions, mode, api, netlifyConfig, errorMonitor, deployId, testOpts }),
     ),
   )
   await installLocalPluginsDependencies({ plugins, pluginsOptions: pluginsOptionsB, buildDir, mode })
@@ -60,6 +61,7 @@ const loadPluginFiles = async function({
   netlifyConfig,
   errorMonitor,
   deployId,
+  testOpts,
 }) {
   const pluginDir = dirname(pluginPath)
   const { packageDir, packageJson } = await getPackageJson(pluginDir)
@@ -72,6 +74,7 @@ const loadPluginFiles = async function({
     netlifyConfig,
     errorMonitor,
     deployId,
+    testOpts,
   })
   return { ...pluginOptions, pluginPath, packageDir, packageJson, manifest, inputs: inputsA }
 }

--- a/packages/build/tests/error/monitor/tests.js
+++ b/packages/build/tests/error/monitor/tests.js
@@ -6,7 +6,7 @@ const hasAnsi = require('has-ansi')
 const { getJsonOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
-const flags = '--bugsnag-key=00000000000000000000000000000000'
+const flags = '--test-opts.error-monitor --bugsnag-key=00000000000000000000000000000000'
 
 test('Report build.command failure', async t => {
   await runFixture(t, 'command', { flags })


### PR DESCRIPTION
The `NETLIFY_BUILD_DEBUG` environment variable is used in tests to change some runtime behavior, such as printing the request payload sent to Bugsnag (because it is hard to mock the API request due to some Bugsnag implementation details).

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switch instead to a boolean parameter/flag `testOpts.errorMonitor`, which is test-friendlier.