### PR TITLE
Add `testOpts.oldCliLogs` flag

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -107,7 +107,7 @@ const build = async function(flags = {}) {
       return { success: true }
     } catch (error) {
       await maybeCancelBuild({ error, api, deployId })
-      await logOldCliVersionError(mode)
+      await logOldCliVersionError({ mode, testOpts })
       error.netlifyConfig = netlifyConfig
       error.childEnv = childEnv
       throw error

--- a/packages/build/src/log/old_version.js
+++ b/packages/build/src/log/old_version.js
@@ -1,7 +1,4 @@
-const {
-  env: { NETLIFY_BUILD_TEST },
-  stdout,
-} = require('process')
+const { stdout } = require('process')
 
 const readPkgUp = require('read-pkg-up')
 const UpdateNotifier = require('update-notifier')
@@ -11,23 +8,23 @@ const UpdateNotifier = require('update-notifier')
 // We only print this when Netlify CLI has been used. Programmatic usage might
 // come from a deep dependency calling `@netlify/build` and user might not be
 // able to take any upgrade action, making the message noisy.
-const logOldCliVersionError = async function(mode) {
+const logOldCliVersionError = async function({ mode, testOpts }) {
   if (mode !== 'cli') {
     return
   }
 
-  const pkg = await getPkg()
+  const pkg = await getPkg(testOpts)
   UpdateNotifier({ pkg, updateCheckInterval: 1 }).notify({
     message: OLD_VERSION_MESSAGE,
     shouldNotifyInNpmScript: true,
   })
 }
 
-const getPkg = async function() {
+const getPkg = async function(testOpts) {
   const { packageJson } = await readPkgUp({ cwd: __dirname, normalize: false })
 
   // TODO: Find a way to test this without injecting code in the `src/`
-  if (NETLIFY_BUILD_TEST) {
+  if (testOpts.oldCliLogs) {
     // `update-notifier` does not do anything if not in a TTY.
     // In tests, we need to monkey patch this
     stdout.isTTY = true

--- a/packages/build/tests/log/old_version/tests.js
+++ b/packages/build/tests/log/old_version/tests.js
@@ -10,5 +10,5 @@ test('Print a warning when using an old version through Netlify CLI', async t =>
   }
 
   // We need to unset some environment variables which would otherwise disable `update-notifier`
-  await runFixture(t, 'error', { flags: '--mode=cli', env: { NODE_ENV: '' } })
+  await runFixture(t, 'error', { flags: '--mode=cli --testOpts.oldCliLogs', env: { NODE_ENV: '' } })
 })


### PR DESCRIPTION
The `NETLIFY_BUILD_TEST` environment variable is used in tests to change some runtime behavior, such as forcing `update-notifier` to print a message.

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switch instead to a boolean parameter/flag `testOpts.oldCliLogs`, which is test-friendlier.