### PR TITLE
Add `testOpts.apiClient` flag

### DIFF
--- a/packages/build/src/plugins/child/api.js
+++ b/packages/build/src/plugins/child/api.js
@@ -1,16 +1,12 @@
-const {
-  env: { NETLIFY_BUILD_API_CLIENT },
-} = require('process')
-
 const NetlifyAPI = require('netlify')
 
 const { failBuild } = require('../error')
 
 // Retrieve Netlify API client, providing a authentication token was provided
-const getApiClient = function({ manifest: { scopes = DEFAULT_SCOPES }, token }) {
+const getApiClient = function({ manifest: { scopes = DEFAULT_SCOPES }, token, testOpts: { apiClient } }) {
   // This feature is not currently finished due to lack of API support
   // See https://github.com/netlify/build/issues/585
-  if (NETLIFY_BUILD_API_CLIENT !== '1') {
+  if (!apiClient) {
     return
   }
 

--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -29,8 +29,11 @@ const isEventHandler = function([, value]) {
 }
 
 // Retrieve context passed to every event handler
-const getContext = function(pluginCommands, { manifest, inputs, netlifyConfig, constants, utilsData, token }) {
-  const api = getApiClient({ manifest, token })
+const getContext = function(
+  pluginCommands,
+  { manifest, inputs, netlifyConfig, constants, utilsData, token, testOpts },
+) {
+  const api = getApiClient({ manifest, token, testOpts })
   return { pluginCommands, api, utilsData, constants, inputs, netlifyConfig }
 }
 

--- a/packages/build/tests/plugins/api/tests.js
+++ b/packages/build/tests/plugins/api/tests.js
@@ -7,7 +7,7 @@ test('--token', async t => {
 })
 
 test('NETLIFY_AUTH_TOKEN environment variable', async t => {
-  await runFixture(t, 'api_call', { env: { NETLIFY_AUTH_TOKEN: 'test', NETLIFY_BUILD_API_CLIENT: '1' } })
+  await runFixture(t, 'api_call', { flags: '--test-opts.api-client', env: { NETLIFY_AUTH_TOKEN: 'test' } })
 })
 
 test('feature flag', async t => {
@@ -15,35 +15,23 @@ test('feature flag', async t => {
 })
 
 test('scopes but no token', async t => {
-  await runFixture(t, 'no_token', { env: { NETLIFY_AUTH_TOKEN: '', NETLIFY_BUILD_API_CLIENT: '1' } })
+  await runFixture(t, 'no_token', { flags: '--test-opts.api-client', env: { NETLIFY_AUTH_TOKEN: '' } })
 })
 
 test('api call', async t => {
-  await runFixture(t, 'api_call', {
-    flags: '--token=test',
-    env: { NETLIFY_BUILD_API_CLIENT: '1' },
-  })
+  await runFixture(t, 'api_call', { flags: '--token=test --test-opts.api-client' })
 })
 
 test('wrong scopes', async t => {
-  await runFixture(t, 'wrong_scopes', {
-    flags: '--token=test',
-    env: { NETLIFY_BUILD_API_CLIENT: '1' },
-  })
+  await runFixture(t, 'wrong_scopes', { flags: '--token=test --test-opts.api-client' })
 })
 
 test('star scopes', async t => {
-  await runFixture(t, 'star_scopes', {
-    flags: '--token=test',
-    env: { NETLIFY_BUILD_API_CLIENT: '1' },
-  })
+  await runFixture(t, 'star_scopes', { flags: '--token=test --test-opts.api-client' })
 })
 
 test('default scopes', async t => {
-  await runFixture(t, 'default_scopes', {
-    flags: '--token=test',
-    env: { NETLIFY_BUILD_API_CLIENT: '1' },
-  })
+  await runFixture(t, 'default_scopes', { flags: '--token=test --test-opts.api-client' })
 })
 
 test('--site-id', async t => {


### PR DESCRIPTION
The `NETLIFY_BUILD_API_CLIENT` environment variable is used in tests to enable the API client feature.

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switch instead to a boolean parameter/flag `testOpts.apiClient`, which is test-friendlier.