### PR TITLE
Add `testOpts.buildImagePluginsDir` flag

### DIFF
--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -25,7 +25,7 @@ const getPluginsOptions = async function({
   const allCorePlugins = corePlugins.filter(corePlugin => !isOptionalCore(corePlugin, plugins))
   const userPlugins = plugins.filter(isUserPlugin)
   const pluginsOptions = [...allCorePlugins, ...userPlugins].map(normalizePluginOptions)
-  const pluginsOptionsA = await resolvePluginsPath({ pluginsOptions, buildDir, mode })
+  const pluginsOptionsA = await resolvePluginsPath({ pluginsOptions, buildDir, mode, testOpts })
   const pluginsOptionsB = await Promise.all(
     pluginsOptionsA.map(pluginOptions =>
       loadPluginFiles({ pluginOptions, mode, api, netlifyConfig, errorMonitor, deployId, testOpts }),

--- a/packages/build/tests/core/flags/tests.js
+++ b/packages/build/tests/core/flags/tests.js
@@ -31,7 +31,7 @@ test('--node-path is not used by core plugins', async t => {
 test('--node-path is not used by build-image cached plugins', async t => {
   const { path } = await getNode(CHILD_NODE_VERSION)
   await runFixture(t, 'build_image', {
-    flags: `--node-path=${path} --mode=buildbot`,
-    env: { TEST_NODE_PATH: execPath, TEST_BUILD_IMAGE_PLUGINS_DIR: `${FIXTURES_DIR}/build_image_cache/node_modules` },
+    flags: `--node-path=${path} --mode=buildbot --test-opts.build-image-plugins-dir=${FIXTURES_DIR}/build_image_cache/node_modules`,
+    env: { TEST_NODE_PATH: execPath },
   })
 })

--- a/packages/build/tests/plugins/load/tests.js
+++ b/packages/build/tests/plugins/load/tests.js
@@ -42,13 +42,12 @@ test('Do not allow overriding core plugins', async t => {
 
 test('Can use plugins cached in the build image', async t => {
   await runFixture(t, 'build_image', {
-    env: { TEST_BUILD_IMAGE_PLUGINS_DIR: `${FIXTURES_DIR}/build_image_cache/node_modules` },
-    flags: '--mode=buildbot',
+    flags: `--test-opts.build-image-plugins-dir=${FIXTURES_DIR}/build_image_cache/node_modules --mode=buildbot`,
   })
 })
 
 test('Does not use plugins cached in the build image in local builds', async t => {
   await runFixture(t, 'build_image', {
-    env: { TEST_BUILD_IMAGE_PLUGINS_DIR: `${FIXTURES_DIR}/build_image_cache/node_modules` },
+    flags: `--test-opts.build-image-plugins-dir=${FIXTURES_DIR}/build_image_cache/node_modules`,
   })
 })


### PR DESCRIPTION
The `TEST_BUILD_IMAGE_PLUGINS_DIR` environment variable is used in tests to mock the location of the `build-image` pre-installed plugins directory.

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switch instead to a boolean parameter/flag `testOpts.buildImagePluginsDir`, which is test-friendlier.