### PR TITLE
Add `testOpts.cachePath` flag

### DIFF
--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -21,7 +21,7 @@ const getPluginsOptions = async function({
   deployId,
   testOpts,
 }) {
-  const corePlugins = getCorePlugins(FUNCTIONS_SRC).map(addCoreProperties)
+  const corePlugins = getCorePlugins(FUNCTIONS_SRC, testOpts).map(addCoreProperties)
   const allCorePlugins = corePlugins.filter(corePlugin => !isOptionalCore(corePlugin, plugins))
   const userPlugins = plugins.filter(isUserPlugin)
   const pluginsOptions = [...allCorePlugins, ...userPlugins].map(normalizePluginOptions)

--- a/packages/build/src/plugins_core/cache/plugin.js
+++ b/packages/build/src/plugins_core/cache/plugin.js
@@ -1,8 +1,5 @@
 const { homedir } = require('os')
-const {
-  version,
-  env: { TEST_CACHE_PATH },
-} = require('process')
+const { version, env } = require('process')
 
 const { logCacheDir } = require('../../log/main')
 
@@ -17,7 +14,7 @@ const cachePlugin = {
 const saveCache = async function({ path, digests, cache, IS_LOCAL }) {
   // In tests we don't run caching since it is slow and make source directory
   // much bigger
-  if (TEST_CACHE_PATH !== undefined && TEST_CACHE_PATH !== path) {
+  if (env.TEST_CACHE_PATH !== undefined && env.TEST_CACHE_PATH !== path) {
     return
   }
 

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -1,7 +1,3 @@
-const {
-  env: { TEST_CACHE_PATH },
-} = require('process')
-
 const FUNCTIONS_INSTALL_PLUGIN = `${__dirname}/functions_install/plugin.js`
 const FUNCTIONS_PLUGIN = `${__dirname}/functions/plugin.js`
 const CACHE_PLUGIN = `${__dirname}/cache/plugin.js`
@@ -9,7 +5,7 @@ const CACHE_PLUGIN = `${__dirname}/cache/plugin.js`
 const { LOCAL_INSTALL_NAME } = require('../install/local')
 
 // Plugins that are installed and enabled by default
-const getCorePlugins = FUNCTIONS_SRC => [
+const getCorePlugins = (FUNCTIONS_SRC, { cachePath }) => [
   // When no "Functions directory" is defined, it means users does not use
   // Netlify Functions.
   // However when it is defined but points to a non-existing directory, this
@@ -20,9 +16,7 @@ const getCorePlugins = FUNCTIONS_SRC => [
     : [{ package: '@netlify/plugin-functions-install-core', pluginPath: FUNCTIONS_INSTALL_PLUGIN, optional: true }]),
   ...(FUNCTIONS_SRC === undefined ? [] : [{ package: '@netlify/plugin-functions-core', pluginPath: FUNCTIONS_PLUGIN }]),
   // TODO: run only inside tests until integrated in the buildbot
-  ...(TEST_CACHE_PATH === undefined || TEST_CACHE_PATH === 'none'
-    ? []
-    : [{ package: '@netlify/plugin-cache-core', pluginPath: CACHE_PLUGIN }]),
+  ...(cachePath === undefined ? [] : [{ package: '@netlify/plugin-cache-core', pluginPath: CACHE_PLUGIN }]),
 ]
 
 const CORE_PLUGINS = [

--- a/packages/build/tests/cache/main/tests.js
+++ b/packages/build/tests/cache/main/tests.js
@@ -5,13 +5,19 @@ const test = require('ava')
 const { runFixture } = require('../../helpers/main')
 
 test('Cache local', async t => {
-  await runFixture(t, 'local', { env: { TEST_CACHE_PATH: 'bower_components' } })
+  await runFixture(t, 'local', {
+    flags: '--test-opts.cache-path=bower_components',
+    env: { TEST_CACHE_PATH: 'bower_components' },
+  })
 })
 
 // This works on Windows locally but not inside GitHub actions
 // TODO: figure out why
 if (platform !== 'win32') {
   test('Cache CI', async t => {
-    await runFixture(t, 'ci', { flags: '--mode=buildbot', env: { TEST_CACHE_PATH: 'bower_components' } })
+    await runFixture(t, 'ci', {
+      flags: '--test-opts.cache-path=bower_components --mode=buildbot',
+      env: { TEST_CACHE_PATH: 'bower_components' },
+    })
   })
 }

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -14,8 +14,6 @@ const runFixture = async function(t, fixtureName, { env: envOption, ...opts } = 
     ...opts,
     binaryPath: await BINARY_PATH,
     env: {
-      // Workarounds to mock caching logic
-      TEST_CACHE_PATH: 'none',
       // Ensure local tokens aren't used during development
       NETLIFY_AUTH_TOKEN: '',
       // Allows executing any locally installed Node modules inside tests,


### PR DESCRIPTION
The `TEST_CACHE_PATH` environment variable is used in tests for two reasons: 
  - mock the location of the cache directory
  - detect whether the core `cache` plugin should be used (it is only used in tests at the moment)

Environment variables are global, making it hard to run several tests in parallel inside the same process. For the second purpose (plugin detection), this PR switch instead to a boolean parameter/flag `testOpts.cachePath`, which is test-friendlier. For the first purpose (location mocking), it keeps the environment variable for the moment, as that value must be available in child processes.