### PR TITLE
Add `testOpts.sendStatus` flag

### DIFF
--- a/packages/build/src/status/report.js
+++ b/packages/build/src/status/report.js
@@ -1,5 +1,3 @@
-const { env } = require('process')
-
 const { reportBuildError } = require('../error/monitor/report')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 const { logStatuses, logBuildError } = require('../log/main')
@@ -52,7 +50,7 @@ const shouldPrintStatus = function({ state, summary }) {
 
 // In production, send statuses to the API
 const sendStatuses = async function({ statuses, api, mode, netlifyConfig, errorMonitor, deployId, testOpts }) {
-  if ((mode !== 'buildbot' && env.NETLIFY_BUILD_TEST_STATUS !== '1') || api === undefined || !deployId) {
+  if ((mode !== 'buildbot' && !testOpts.sendStatus) || api === undefined || !deployId) {
     return
   }
 

--- a/packages/build/tests/status/helpers/run.js
+++ b/packages/build/tests/status/helpers/run.js
@@ -32,8 +32,8 @@ const comparePackage = function({ body: { package: packageA } }, { body: { packa
 const runWithApiMock = async function(t, fixture, { flags = '--token=test', env, status } = {}) {
   const { scheme, host, requests, stopServer } = await startServer(STATUS_PATH, {}, { status })
   await runFixture(t, fixture, {
-    flags: `--deploy-id=test ${flags}`,
-    env: { TEST_SCHEME: scheme, TEST_HOST: host, NETLIFY_BUILD_TEST_STATUS: '1', ...env },
+    flags: `--deploy-id=test ${flags} --test-opts.send-status`,
+    env: { TEST_SCHEME: scheme, TEST_HOST: host, ...env },
   })
   await stopServer()
   const snapshots = requests.map(normalizeRequest).sort(comparePackage)


### PR DESCRIPTION
The `NETLIFY_BUILD_TEST_STATUS` environment variable is used in tests to force sending an API status.

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switch instead to a boolean parameter/flag `testOpts.sendStatus`, which is test-friendlier.