### PR TITLE
Add `testOpts.telemetryOrigin` flag

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -104,7 +104,7 @@ const build = async function(flags = {}) {
 
       logBuildSuccess()
       const duration = endTimer(buildTimer, 'Netlify Build')
-      await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, telemetry, mode })
+      await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, telemetry, mode, testOpts })
       return { success: true }
     } catch (error) {
       await maybeCancelBuild({ error, api, deployId })

--- a/packages/build/src/telemetry/complete.js
+++ b/packages/build/src/telemetry/complete.js
@@ -8,9 +8,17 @@ const { version } = require('../../package.json')
 const { analytics } = require('./track')
 
 // Send telemetry request when build completes
-const trackBuildComplete = async function({ commandsCount, netlifyConfig, duration, siteInfo, telemetry, mode }) {
+const trackBuildComplete = async function({
+  commandsCount,
+  netlifyConfig,
+  duration,
+  siteInfo,
+  telemetry,
+  mode,
+  testOpts,
+}) {
   const payload = getPayload({ commandsCount, netlifyConfig, duration, siteInfo, mode })
-  await analytics.track('netlifyCI:buildComplete', { payload, telemetry })
+  await analytics.track('netlifyCI:buildComplete', { payload, telemetry, testOpts })
 }
 
 // Retrieve telemetry information

--- a/packages/build/src/telemetry/request.js
+++ b/packages/build/src/telemetry/request.js
@@ -1,7 +1,4 @@
-const {
-  env: { TEST_SCHEME, TEST_HOST },
-  argv,
-} = require('process')
+const { argv } = require('process')
 
 const got = require('got')
 
@@ -10,19 +7,19 @@ const { version } = require('../../package.json')
 // Send HTTP request to telemetry.
 const sendRequest = async function() {
   const json = JSON.parse(argv[2])
-  await got({ ...GOT_OPTS, json: true, body: json })
+  const origin = argv[3] || DEFAULT_ORIGIN
+  const url = `${origin}/collect`
+  await got({ ...GOT_OPTS, url, body: json })
 }
 
-// TODO: find less intrusive way to mock HTTP requests
-const SCHEME = TEST_SCHEME || 'https'
-const HOST = TEST_HOST || 'telemetry-service.netlify.com'
+const DEFAULT_ORIGIN = 'https://telemetry-service.netlify.com'
 const GOT_OPTS = {
-  url: `${SCHEME}://${HOST}/collect`,
   method: 'POST',
   headers: {
     'X-Netlify-Client': 'NETLIFY_CI',
     'X-Netlify-Client-Version': version,
   },
+  json: true,
 }
 
 sendRequest()

--- a/packages/build/src/telemetry/track.js
+++ b/packages/build/src/telemetry/track.js
@@ -1,7 +1,3 @@
-const {
-  env: { TEST_HOST },
-} = require('process')
-
 const Analytics = require('analytics').default
 const execa = require('execa')
 
@@ -13,17 +9,25 @@ const REQUEST_FILE = `${__dirname}/request.js`
 // to complete, by using a child process.
 // We also ignore any errors. Those might happen for example if the current
 // directory was removed by the build command.
-const track = async function({ payload: { properties: { telemetry, payload: properties } = {}, ...payload } = {} }) {
+const track = async function({
+  payload: {
+    properties: { telemetry, testOpts: { telemetryOrigin = '' } = {}, payload: properties } = {},
+    ...payload
+  } = {},
+}) {
   if (!telemetry) {
     return
   }
 
   const payloadA = { ...payload, properties }
   try {
-    const childProcess = execa('node', [REQUEST_FILE, JSON.stringify(payloadA)], { detached: true, stdio: 'ignore' })
+    const childProcess = execa('node', [REQUEST_FILE, JSON.stringify(payloadA), telemetryOrigin], {
+      detached: true,
+      stdio: 'ignore',
+    })
 
     // During tests, we wait for the HTTP request to complete
-    if (TEST_HOST === undefined) {
+    if (telemetryOrigin === '') {
       childProcess.unref()
     }
 

--- a/packages/build/tests/core/telemetry/tests.js
+++ b/packages/build/tests/core/telemetry/tests.js
@@ -35,8 +35,7 @@ const TELEMETRY_PATH = '/collect'
 test('Telemetry success', async t => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
-    flags: `--site-id=test --telemetry`,
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--site-id=test --telemetry --test-opts.telemetry-origin=${scheme}://${host}`,
     snapshot: false,
   })
   await stopServer()
@@ -47,8 +46,8 @@ test('Telemetry success', async t => {
 test('Telemetry disabled', async t => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
-    flags: '--site-id=test',
-    env: { BUILD_TELEMETRY_DISABLED: 'true', TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--site-id=test --test-opts.telemetry-origin=${scheme}://${host}`,
+    env: { BUILD_TELEMETRY_DISABLED: 'true' },
     snapshot: false,
   })
   await stopServer()
@@ -69,8 +68,7 @@ test('Telemetry disabled with flag', async t => {
 test('Telemetry error', async t => {
   const { stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
-    flags: `--site-id=test --telemetry`,
-    env: { TEST_HOST: '...' },
+    flags: `--site-id=test --telemetry --test-opts.telemetry-origin=https://...`,
   })
   await stopServer()
 })


### PR DESCRIPTION
The `TEST_SCHEME` and `TEST_HOST` environment variables are used in tests to mock the telemetry API endpoint.

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switches instead to a parameter/flag `testOpts.telemetryOrigin`, which is test-friendlier.