### PR TITLE
Improve error handling of `@netlify/config`

### DIFF
--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -12,9 +12,8 @@ const { parseFlags } = require('./flags')
 
 // CLI entry point
 const runCli = async function() {
-  const { stable, ...flags } = parseFlags()
-
   try {
+    const { stable, ...flags } = parseFlags()
     const result = await resolveConfig(flags)
     handleCliSuccess(result, stable)
   } catch (error) {


### PR DESCRIPTION
This puts one line of code in `@netlify/config` which was not inside the `try`/`catch` block, in case this throws.