### PR TITLE
Improve environment variables usage in `@netlify/config`

### DIFF
--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -1,8 +1,6 @@
 require('./utils/polyfills')
 
-const {
-  env: { NETLIFY_AUTH_TOKEN },
-} = require('process')
+const { env } = require('process')
 
 const { addBuildSettings } = require('./api/build_settings')
 const { getApiClient } = require('./api/client')
@@ -25,7 +23,7 @@ const {
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function({ cachedConfig, token = NETLIFY_AUTH_TOKEN, siteId, ...opts } = {}) {
+const resolveConfig = async function({ cachedConfig, token = env.NETLIFY_AUTH_TOKEN, siteId, ...opts } = {}) {
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
   const api = getApiClient(token)
 

--- a/packages/config/src/options/branch.js
+++ b/packages/config/src/options/branch.js
@@ -1,6 +1,4 @@
-const {
-  env: { BRANCH },
-} = require('process')
+const { env } = require('process')
 
 const execa = require('execa')
 
@@ -14,8 +12,8 @@ const getBranch = async function({ branch, repositoryRoot }) {
     return branch
   }
 
-  if (BRANCH) {
-    return BRANCH
+  if (env.BRANCH) {
+    return env.BRANCH
   }
 
   const gitBranch = await getGitBranch(repositoryRoot)

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -1,7 +1,4 @@
-const {
-  cwd: getCwd,
-  env: { CONTEXT },
-} = require('process')
+const { cwd: getCwd, env } = require('process')
 
 const { throwError } = require('../error')
 const { dirExists } = require('../utils/dir-exists')
@@ -13,7 +10,7 @@ const { getRepositoryRoot } = require('./repository_root')
 // Normalize options and assign default values
 const normalizeOpts = async function(opts) {
   const optsA = removeFalsy(opts)
-  const optsB = { ...DEFAULT_OPTS, ...optsA }
+  const optsB = { ...DEFAULT_OPTS(), ...optsA }
 
   const repositoryRoot = await getRepositoryRoot(optsB)
   const optsC = { ...optsB, repositoryRoot }
@@ -26,11 +23,11 @@ const normalizeOpts = async function(opts) {
   return optsE
 }
 
-const DEFAULT_OPTS = {
+const DEFAULT_OPTS = () => ({
   cwd: getCwd(),
-  context: CONTEXT || 'production',
+  context: env.CONTEXT || 'production',
   mode: 'require',
-}
+})
 
 // Verify that options point to existing directories
 const checkDirs = async function(opts) {


### PR DESCRIPTION
`@netlify/config` might be called several times within the same process. Between those calls, environment variables might be modified using `process.env`. This happens for example in some tests.

At the moment, environment variables are retrieved when `@netlify/config` loads. This changes it to retrieving their values each time `@netlify/config` is run, to make it test-friendlier.