### PR TITLE
Improve retrieval of the current directory in the `cache` utility

### DIFF
--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -4,12 +4,13 @@ const readdirp = require('readdirp')
 
 const { getCacheDir } = require('./dir')
 const { isManifest } = require('./manifest')
-const { BASES } = require('./path')
+const { getBases } = require('./path')
 
 // List all cached files
 const list = async function({ cacheDir, mode } = {}) {
+  const bases = getBases()
   const cacheDirA = await getCacheDir({ cacheDir, mode })
-  const files = await Promise.all(BASES.map(baseInfo => listBase(baseInfo, cacheDirA)))
+  const files = await Promise.all(bases.map(baseInfo => listBase(baseInfo, cacheDirA)))
   const filesA = files.flat()
   return filesA
 }

--- a/packages/cache-utils/src/path.js
+++ b/packages/cache-utils/src/path.js
@@ -49,8 +49,9 @@ const getCachePath = async function({ srcPath, cacheDir, mode }) {
 // current directory, the home directory or the root directory. Each is tried
 // in order.
 const findBase = function(srcPath) {
+  const bases = getBases()
   const srcPathA = normalizeWindows(srcPath)
-  return BASES.map(({ name, base }) => parseBase(name, base, srcPathA)).find(Boolean)
+  return bases.map(({ name, base }) => parseBase(name, base, srcPathA)).find(Boolean)
 }
 
 // Windows drives are problematic:
@@ -79,10 +80,12 @@ const parseBase = function(name, base, srcPath) {
   return { name, relPath }
 }
 
-const BASES = [
-  { name: 'cwd', base: getCwd() },
-  { name: 'home', base: homedir() },
-  { name: 'root', base: sep },
-]
+const getBases = function() {
+  return [
+    { name: 'cwd', base: getCwd() },
+    { name: 'home', base: homedir() },
+    { name: 'root', base: sep },
+  ]
+}
 
-module.exports = { parsePath, BASES }
+module.exports = { parsePath, getBases }


### PR DESCRIPTION
If the current directory is changed between two calls to the `cache` utility, the second call will not get the new current directory. This PR fixes this.