### PR TITLE
Use `testOpts.host|port` with `@netlify/config`

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -35,25 +35,28 @@ const DEFAULT_FLAGS = () => ({
 })
 
 // Retrieve configuration object
-const loadConfig = async function({
-  config,
-  defaultConfig,
-  cachedConfig,
-  cwd,
-  repositoryRoot,
-  dry,
-  nodePath,
-  token,
-  siteId,
-  deployId,
-  context,
-  branch,
-  baseRelDir,
-  env: envOpt,
-  telemetry,
-  mode,
-  debug,
-}) {
+const loadConfig = async function(
+  {
+    config,
+    defaultConfig,
+    cachedConfig,
+    cwd,
+    repositoryRoot,
+    dry,
+    nodePath,
+    token,
+    siteId,
+    deployId,
+    context,
+    branch,
+    baseRelDir,
+    env: envOpt,
+    telemetry,
+    mode,
+    debug,
+  },
+  testOpts,
+) {
   const {
     configPath,
     buildDir,
@@ -74,6 +77,7 @@ const loadConfig = async function({
     token,
     siteId,
     mode,
+    testOpts,
   })
   logBuildDir(buildDir)
   logConfigPath(configPath)
@@ -115,6 +119,7 @@ const resolveFullConfig = async function({
   token,
   siteId,
   mode,
+  testOpts,
 }) {
   try {
     return await resolveConfig({
@@ -129,6 +134,7 @@ const resolveFullConfig = async function({
       token,
       siteId,
       mode,
+      testOpts,
     })
   } catch (error) {
     if (error.type === 'userError') {

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -60,7 +60,7 @@ const build = async function(flags = {}) {
       envOpt,
       telemetry,
       mode,
-    } = await loadConfig(flagsA)
+    } = await loadConfig(flagsA, testOpts)
     const childEnv = await getChildEnv({ netlifyConfig, buildDir, context, branch, siteInfo, deployId, envOpt, mode })
 
     try {

--- a/packages/build/tests/env/main/tests.js
+++ b/packages/build/tests/env/main/tests.js
@@ -54,8 +54,7 @@ const SITE_INFO_DATA = { url: 'test', build_settings: { repo_url: 'test' } }
 test('Environment variable siteInfo success', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'site_info', {
-    flags: '--token=test --site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })

--- a/packages/build/tests/error/build/tests.js
+++ b/packages/build/tests/error/build/tests.js
@@ -46,8 +46,7 @@ test('build.cancelBuild() error option', async t => {
 test('build.cancelBuild() API call', async t => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
   await runFixture(t, 'cancel', {
-    flags: '--token=test --deploy-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --deploy-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
   t.snapshot(requests)
@@ -55,17 +54,14 @@ test('build.cancelBuild() API call', async t => {
 
 test('build.cancelBuild() API call no DEPLOY_ID', async t => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
-  await runFixture(t, 'cancel', { flags: '--token=test', env: { TEST_SCHEME: scheme, TEST_HOST: host } })
+  await runFixture(t, 'cancel', { flags: `--token=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
   await stopServer()
   t.is(requests.length, 0)
 })
 
 test('build.cancelBuild() API call no token', async t => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
-  await runFixture(t, 'cancel', {
-    flags: '--deploy-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
-  })
+  await runFixture(t, 'cancel', { flags: `--deploy-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
   await stopServer()
   t.is(requests.length, 0)
 })
@@ -74,10 +70,7 @@ test('build.cancelBuild() API call no token', async t => {
 // inconsistent test snapshots
 if (!version.startsWith('v8.')) {
   test('build.cancelBuild() API call failure', async t => {
-    await runFixture(t, 'cancel', {
-      flags: '--token=test --deploy-id=test',
-      env: { TEST_HOST: '...' },
-    })
+    await runFixture(t, 'cancel', { flags: `--token=test --deploy-id=test --testOpts.host=...` })
   })
 }
 

--- a/packages/build/tests/status/helpers/run.js
+++ b/packages/build/tests/status/helpers/run.js
@@ -32,8 +32,8 @@ const comparePackage = function({ body: { package: packageA } }, { body: { packa
 const runWithApiMock = async function(t, fixture, { flags = '--token=test', env, status } = {}) {
   const { scheme, host, requests, stopServer } = await startServer(STATUS_PATH, {}, { status })
   await runFixture(t, fixture, {
-    flags: `--deploy-id=test ${flags} --test-opts.send-status`,
-    env: { TEST_SCHEME: scheme, TEST_HOST: host, ...env },
+    flags: `--deploy-id=test ${flags} --test-opts.send-status --testOpts.scheme=${scheme} --testOpts.host=${host}`,
+    env,
   })
   await stopServer()
   const snapshots = requests.map(normalizeRequest).sort(comparePackage)

--- a/packages/config/src/api/client.js
+++ b/packages/config/src/api/client.js
@@ -1,19 +1,15 @@
-const {
-  env: { TEST_SCHEME, TEST_HOST },
-} = require('process')
-
 const NetlifyAPI = require('netlify')
 
 const { removeFalsy } = require('../utils/remove_falsy')
 
 // Retrieve Netlify API client, if an access token was passed
-const getApiClient = function(token) {
+const getApiClient = function(token, { scheme, host }) {
   if (!token) {
     return
   }
 
   // TODO: find less intrusive way to mock HTTP requests
-  const parameters = removeFalsy({ scheme: TEST_SCHEME, host: TEST_HOST })
+  const parameters = removeFalsy({ scheme, host })
   const api = new NetlifyAPI(token, parameters)
   return api
 }

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -23,9 +23,15 @@ const {
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function({ cachedConfig, token = env.NETLIFY_AUTH_TOKEN, siteId, ...opts } = {}) {
+const resolveConfig = async function({
+  cachedConfig,
+  token = env.NETLIFY_AUTH_TOKEN,
+  siteId,
+  testOpts = {},
+  ...opts
+} = {}) {
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
-  const api = getApiClient(token)
+  const api = getApiClient(token, testOpts)
 
   // Performance optimization when @netlify/config caller has already previously
   // called it and cached the result.

--- a/packages/config/tests/api/tests.js
+++ b/packages/config/tests/api/tests.js
@@ -21,8 +21,7 @@ const SITE_INFO_ERROR = { error: 'invalid' }
 test('Environment variable siteInfo success', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', {
-    flags: '--token=test --site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
@@ -30,35 +29,27 @@ test('Environment variable siteInfo success', async t => {
 test('Environment variable siteInfo API error', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_ERROR, { status: 400 })
   await runFixture(t, 'empty', {
-    flags: '--token=test --site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
 
 test('Environment variable siteInfo no token', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
-  await runFixture(t, 'empty', {
-    flags: '--site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
-  })
+  await runFixture(t, 'empty', { flags: `--site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
   await stopServer()
 })
 
 test('Environment variable siteInfo no siteId', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
-  await runFixture(t, 'empty', {
-    flags: '--token=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
-  })
+  await runFixture(t, 'empty', { flags: `--token=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
   await stopServer()
 })
 
 test('Environment variable siteInfo CI', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', {
-    flags: '--token=test --site-id=test --mode=buildbot',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --mode=buildbot --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
@@ -71,8 +62,7 @@ const SITE_INFO_BUILD_SETTINGS_NULL = {
 test('Build settings can be null', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS_NULL)
   await runFixture(t, 'empty', {
-    flags: '--token=test --site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
@@ -93,8 +83,7 @@ const SITE_INFO_BUILD_SETTINGS = {
 test('Use build settings if a siteId and token are provided', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', {
-    flags: '--token=test --site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
@@ -102,8 +91,7 @@ test('Use build settings if a siteId and token are provided', async t => {
 test('Build settings have low merging priority', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'build_settings', {
-    flags: '--token=test --site-id=test --baseRelDir',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --baseRelDir --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
@@ -111,35 +99,27 @@ test('Build settings have low merging priority', async t => {
 test('Build settings are not used if getSite call fails', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS, { status: 400 })
   await runFixture(t, 'base', {
-    flags: '--token=test --site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })
 
 test('Build settings are not used without a token', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
-  await runFixture(t, 'base', {
-    flags: '--site-id=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
-  })
+  await runFixture(t, 'base', { flags: `--site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
   await stopServer()
 })
 
 test('Build settings are not used without a siteId', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
-  await runFixture(t, 'base', {
-    flags: '--token=test',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
-  })
+  await runFixture(t, 'base', { flags: `--token=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
   await stopServer()
 })
 
 test('Build settings are not used in CI', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', {
-    flags: '--token=test --site-id=test --mode=buildbot',
-    env: { TEST_SCHEME: scheme, TEST_HOST: host },
+    flags: `--token=test --site-id=test --mode=buildbot --testOpts.scheme=${scheme} --testOpts.host=${host}`,
   })
   await stopServer()
 })


### PR DESCRIPTION
The `TEST_HOST` and `TEST_PORT` environment variables are used in tests to mock the Bitballoon API endpoint/

Environment variables are global, making it hard to run several tests in parallel inside the same process. This PR switch instead to parameters/flags `testOpts.host|port`, which is test-friendlier.