### PR TITLE
Fix codecov script

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,4 +8,4 @@ node="$2"
 node="node_${node//./_}"
 
 curl -s https://codecov.io/bash | \
-  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -F "$os" -F "$node"
+  bash -s -- -Z -f coverage/coverage-final.json -F "$os" -F "$node"


### PR DESCRIPTION
The `-y` flag of Codecov has been deprecated. Codecov now automatically detects `codecov.yml` if it's in the repository root directory.