### PR TITLE
Improve colors support

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -12330,6 +12330,14 @@
               }
             }
           }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -13306,11 +13314,18 @@
       }
     },
     "supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        }
       }
     },
     "symbol-observable": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -67,6 +67,7 @@
     "semver": "^7.1.3",
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",
+    "supports-color": "^7.1.0",
     "update-notifier": "^4.1.0",
     "uuid": "^7.0.2",
     "yargs": "^15.3.1"

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+
+// This needs to be done before `chalk` is loaded.
+// Note: `chalk` is also required by some of our dependencies.
+// eslint-disable-next-line import/order
+const { setColorLevel } = require('../log/colors')
+setColorLevel()
+
 const process = require('process')
 
 const filterObj = require('filter-obj')

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -1,11 +1,5 @@
 require('../utils/polyfills')
 
-// This needs to be done before `chalk` is loaded.
-// Note: `chalk` is also required by some of our dependencies.
-// eslint-disable-next-line import/order
-const { setColorLevel } = require('../log/colors')
-setColorLevel()
-
 const { getChildEnv } = require('../env/main')
 const { maybeCancelBuild } = require('../error/cancel')
 const { removeErrorColors } = require('../error/colors')

--- a/packages/build/src/env/main.js
+++ b/packages/build/src/env/main.js
@@ -1,5 +1,6 @@
 const { env } = require('process')
 
+const { getParentColorEnv } = require('../log/colors')
 const { omit } = require('../utils/omit')
 const { removeFalsy } = require('../utils/remove_falsy')
 
@@ -33,6 +34,7 @@ const getDefaultEnv = function() {
 
 // Environment variables that can be unset by configuration ones but not local
 const getConfigurableEnv = function() {
+  const parentColorEnv = getParentColorEnv()
   return {
     // Localization
     LANG: 'en_US.UTF-8',
@@ -41,6 +43,8 @@ const getConfigurableEnv = function() {
     // Disable telemetry of some tools
     GATSBY_TELEMETRY_DISABLED: '1',
     NEXT_TELEMETRY_DISABLED: '1',
+    // Colors
+    ...parentColorEnv,
   }
 }
 

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -1,59 +1,32 @@
-const {
-  env,
-  // eslint-disable-next-line node/no-unsupported-features/node-builtins
-  stdout: { isTTY, getColorDepth },
-} = require('process')
+const { env } = require('process')
 const {
   inspect: { defaultOptions },
 } = require('util')
 
-// Set the amount of colors to use by `chalk` (and underlying `supports-color`)
-// 0 is no colors, 1 is 16 colors, 2 is 256 colors, 3 is 16 million colors.
+const supportsColor = require('supports-color')
+
+// Ensure colors are used in the buildbot.
+// For `chalk`, underlying `supports-color` and `console.log()`.
 const setColorLevel = function() {
-  env.FORCE_COLOR = getColorLevel()
-  defaultOptions.colors = hasColors()
+  // We cannot use the --mode CLI flag since this must be loaded before `chalk`.
+  if (!env.NETLIFY && env.PARENT_HAS_COLOR !== '1') {
+    return
+  }
+
+  env.FORCE_COLOR = '1'
+  defaultOptions.colors = true
 }
 
-const getColorLevel = function() {
-  // Allow user overridding this logic
-  if (env.FORCE_COLOR) {
-    return env.FORCE_COLOR
+// Plugin child processes use `stdio: 'pipe'` so they are always
+// non-interactive even if the parent is an interactive TTY. This means they
+// would normally lose colors. If the parent has colors, we pass an environment
+// variable to the child process to force colors.
+const getParentColorEnv = function() {
+  if (supportsColor.stdout === false) {
+    return {}
   }
 
-  // In unit tests when using `PRINT` mode
-  if (env.PRINT === '1') {
-    return '1'
-  }
-
-  // This also ensure colors are used in the BuildBot
-  // We cannot use the --mode CLI flag since this must be loaded before `chalk`
-  if (env.NETLIFY) {
-    return '1'
-  }
-
-  // If the output is not a console (e.g. redirected to `less` or to a file),
-  // we disable colors because ANSI sequences are a problem most of the time in
-  // that case
-  // We cannot test this since unit tests are never in an interactive terminal
-  if (!isTTY) {
-    return '0'
-  }
-
-  // Node <9.9.0 does not have `getColorDepth()`. Default to 16 colors then.
-  if (getColorDepth === undefined) {
-    return '1'
-  }
-
-  // Guess how many colors are supported, mostly based on environment variables
-  // This allows using 256 colors or 16 million colors on terminals that
-  // support it
-  return DEPTH_TO_LEVEL[getColorDepth()]
+  return { PARENT_HAS_COLOR: '1' }
 }
 
-const DEPTH_TO_LEVEL = { 1: '0', 4: '1', 8: '2', 24: '3' }
-
-const hasColors = function() {
-  return env.FORCE_COLOR !== '0' && env.FORCE_COLOR !== 'false'
-}
-
-module.exports = { setColorLevel, hasColors }
+module.exports = { setColorLevel, getParentColorEnv }

--- a/packages/build/src/plugins/child/error.js
+++ b/packages/build/src/plugins/child/error.js
@@ -2,7 +2,6 @@
 const logProcessErrors = require('log-process-errors')
 const safeJsonStringify = require('safe-json-stringify')
 
-const { hasColors } = require('../../log/colors')
 const { isBuildError, ERROR_TYPE_SYM } = require('../error')
 const { sendEventToParent } = require('../ipc')
 
@@ -26,7 +25,7 @@ const DEFAULT_ERROR_TYPE = 'pluginInternal'
 // On uncaught exceptions and unhandled rejections, print the stack trace.
 // Also, prevent child processes from crashing on uncaught exceptions.
 const handleProcessErrors = function() {
-  logProcessErrors({ log: handleProcessError, colors: hasColors(), exitOn: [], level: { multipleResolves: 'silent' } })
+  logProcessErrors({ log: handleProcessError, exitOn: [], level: { multipleResolves: 'silent' } })
 }
 
 const handleProcessError = async function(error, level, originalError) {

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -44,8 +44,7 @@ const runFixtureCommon = async function(
   } = {},
 ) {
   const isPrint = PRINT === '1'
-  const FORCE_COLOR = isPrint ? '1' : ''
-  const commandEnv = { FORCE_COLOR, NETLIFY_BUILD_TEST: '1', ...envOption }
+  const commandEnv = { NETLIFY_BUILD_TEST: '1', ...envOption }
   const copyRootDir = await getCopyRootDir({ copyRoot })
   const mainFlags = getMainFlags({ fixtureName, copyRoot, copyRootDir, repositoryRoot, flags })
   const { stdout, stderr, all, exitCode } = await runCommand({


### PR DESCRIPTION
We have some logic to decide whether colors should be shown in the parent process and each child process. 

`supports-color` is the main library used by other libraries (like `chalk`) to detect this. It performs its logic at load time, so we must set any environment variable before `chalk` is loaded. `util.inspect.defaultOptions.colors` is also used by `console.*()`.

The current logic we have relies on a number of things such as `stdout.isTTY`. However both `supports-color` (used by `chalk`) and `process.getColorDepth()` (which is used by core Node.js) use a similar logic. Their logic is actually even more advanced.

Therefore this PR removes most of our colors logic to let those underlying libraries do their job.

It still keeps two things:
  - In production/buildbot, the terminal is non-interactive and is automatically detected as not supporting colors. However we do want to print colors because the output is rendered in the browser. As opposed to before, this is only done when the CLI entry point was used, not the programmatic main function. 
  - Plugin child processes use `stdio: 'pipe'` which makes them non-interactive TTY even if the parent is an interactive TTY. This means they won't show colors by default for example when the build was run with Netlify CLI. We fix this by detecting if the parent process supports color, then pass that information as an environment variable `PARENT_HAS_COLOR` to child processes, which then set the `FORCE_COLOR` environment variable accordingly.

I have tested this, and the colors are showing (or not) as expected. We also have already 4 tests covering colors, and they pass.

This PR does not change any color behavior, it just simplifies code.