### PR TITLE
Fix tests randomly failing

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -262,7 +262,7 @@ const firePluginCommand = async function({
   } catch (newError) {
     return { newError }
   } finally {
-    unpipeOutput(childProcess)
+    await unpipeOutput(childProcess)
   }
 }
 

--- a/packages/build/src/log/stream.js
+++ b/packages/build/src/log/stream.js
@@ -1,4 +1,7 @@
 const { stdout, stderr } = require('process')
+const { promisify } = require('util')
+
+const pSetTimeout = promisify(setTimeout)
 
 // Start streaming Bash command or plugin command output
 const pipeOutput = function(childProcess) {
@@ -7,7 +10,10 @@ const pipeOutput = function(childProcess) {
 }
 
 // Stop streaming/buffering Bash command or plugin command output
-const unpipeOutput = function(childProcess) {
+const unpipeOutput = async function(childProcess) {
+  // Let `childProcess` `stdout` and `stderr` flush before stopping redirecting
+  await pSetTimeout(0)
+
   childProcess.stdout.unpipe(stdout)
   childProcess.stderr.unpipe(stderr)
 }


### PR DESCRIPTION
When a plugin event handler starts, we redirects its stdout/stderr to the parent process. When the event handler stops, we undo it, to leave room to the next plugin. 

However there was a race condition in the current logic: we were not waiting for the plugin's stdout/stderr to be flushed out before switching it off. This led to tests randomly failing.

This PR fixes it by waiting one macrotask (`setTimeout(0)`) before switching off the redirection. This gives enough time for the flush to happen. I made some manual testing with thousands of plugins running in parallel and it always correctly flush out.