### PR TITLE
Remove test timeout

### DIFF
--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -64,9 +64,6 @@ const runFixtureCommon = async function(
   return { stdout, stderr, exitCode }
 }
 
-// 10 minutes timeout
-const TIMEOUT = 6e5
-
 // Retrieve flags to the main entry point
 const getMainFlags = function({ fixtureName, copyRoot, copyRootDir, repositoryRoot, flags }) {
   const repositoryRootFlag = getRepositoryRootFlag({ fixtureName, copyRoot, copyRootDir, repositoryRoot })
@@ -134,7 +131,6 @@ const execCommand = function({ binaryPath, mainFlags, isPrint, snapshot, command
     all: isPrint && snapshot,
     reject: false,
     env: commandEnv,
-    timeout: TIMEOUT,
   })
 }
 


### PR DESCRIPTION
This removes the test timeout, as this might be triggered in rare occasions due to all tests being started at once in parallel, and in slow hardware like Windows in GitHub actions.