### PR TITLE
Use `failed` instead of `exitCode`

### DIFF
--- a/packages/build/tests/core/cli/tests.js
+++ b/packages/build/tests/core/cli/tests.js
@@ -13,13 +13,13 @@ test('--version', async t => {
 })
 
 test('Exit code is 0 on success', async t => {
-  const { exitCode } = await runFixture(t, 'empty')
-  t.is(exitCode, 0)
+  const { failed } = await runFixture(t, 'empty')
+  t.not(failed)
 })
 
 test('Exit code is 1 on error', async t => {
-  const { exitCode } = await runFixture(t, '', { flags: '--config=/invalid' })
-  t.is(exitCode, 1)
+  const { failed } = await runFixture(t, '', { flags: '--config=/invalid' })
+  t.true(failed)
 })
 
 test('--features', async t => {

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -48,7 +48,7 @@ const runFixtureCommon = async function(
   const commandEnv = { FORCE_COLOR, NETLIFY_BUILD_TEST: '1', ...envOption }
   const copyRootDir = await getCopyRootDir({ copyRoot })
   const mainFlags = getMainFlags({ fixtureName, copyRoot, copyRootDir, repositoryRoot, flags })
-  const { stdout, stderr, all, exitCode } = await runCommand({
+  const { stdout, stderr, all, failed } = await runCommand({
     binaryPath,
     mainFlags,
     isPrint,
@@ -61,7 +61,7 @@ const runFixtureCommon = async function(
 
   doTestAction({ t, stdout, stderr, all, isPrint, normalize, snapshot })
 
-  return { stdout, stderr, exitCode }
+  return { stdout, stderr, failed }
 }
 
 // 10 minutes timeout


### PR DESCRIPTION
Tests should use the `failed` return value of `execa` instead of `exitCode`. This is because a future PR will add a test mode where the main function is triggered programmatically instead of through the CLI, in which case there won't be any exit code. This PR prepares the code for this future PR.