### PR TITLE
Refactor `siteId` in `@netlify/config`

### DIFF
--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -21,7 +21,7 @@ const {
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function({ cachedConfig, siteId, ...opts } = {}) {
+const resolveConfig = async function({ cachedConfig, ...opts } = {}) {
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
   const api = getApiClient(opts)
 
@@ -41,6 +41,7 @@ const resolveConfig = async function({ cachedConfig, siteId, ...opts } = {}) {
     context,
     repositoryRoot,
     branch,
+    siteId,
     baseRelDir,
     mode,
   } = await normalizeOpts(opts)


### PR DESCRIPTION
This is a small refactoring of how `siteId` is passed around in `@netlify/config`.
It does not change any behavior.