### PR TITLE
Refactor default values of `@netlify/config`

### DIFF
--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -8,7 +8,7 @@ const { mergeDefaultConfig } = require('./default_config')
 const { throwError } = require('./error')
 const { handleFiles } = require('./files')
 const { normalizeConfig } = require('./normalize')
-const { normalizeOpts } = require('./options/main')
+const { addDefaultOpts, normalizeOpts } = require('./options/main')
 const { parseConfig } = require('./parse')
 const { getConfigPath } = require('./path')
 const {
@@ -21,9 +21,10 @@ const {
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function({ cachedConfig, ...opts } = {}) {
+const resolveConfig = async function(opts) {
+  const { cachedConfig, ...optsA } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
-  const api = getApiClient(opts)
+  const api = getApiClient(optsA)
 
   // Performance optimization when @netlify/config caller has already previously
   // called it and cached the result.
@@ -44,7 +45,7 @@ const resolveConfig = async function({ cachedConfig, ...opts } = {}) {
     siteId,
     baseRelDir,
     mode,
-  } = await normalizeOpts(opts)
+  } = await normalizeOpts(optsA)
 
   // Retrieve default configuration file. It has less priority and it also does
   // not get normalized, merged with contexts, etc.

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -8,20 +8,13 @@ const { removeFalsy } = require('../utils/remove_falsy')
 const { getBranch } = require('./branch')
 const { getRepositoryRoot } = require('./repository_root')
 
-// Normalize options and assign default values
-const normalizeOpts = async function(opts) {
+// Assign default options
+const addDefaultOpts = function(opts = {}) {
   const optsA = removeFalsy(opts)
-  const optsB = { ...DEFAULT_OPTS(), ...optsA }
-
-  const repositoryRoot = await getRepositoryRoot(optsB)
-  const optsC = { ...optsB, repositoryRoot }
-
-  const branch = await getBranch(optsC)
-  const optsD = { ...optsC, branch }
-
-  const optsE = removeFalsy(optsD)
-  await checkDirs(optsE)
-  return optsE
+  const defaultOpts = DEFAULT_OPTS()
+  const optsB = { ...defaultOpts, ...optsA }
+  const optsC = removeFalsy(optsB)
+  return optsC
 }
 
 const DEFAULT_OPTS = () => ({
@@ -29,6 +22,19 @@ const DEFAULT_OPTS = () => ({
   context: env.CONTEXT || 'production',
   mode: 'require',
 })
+
+// Normalize options
+const normalizeOpts = async function(opts) {
+  const repositoryRoot = await getRepositoryRoot(opts)
+  const optsA = { ...opts, repositoryRoot }
+
+  const branch = await getBranch(optsA)
+  const optsB = { ...optsA, branch }
+
+  const optsC = removeFalsy(optsB)
+  await checkDirs(optsC)
+  return optsC
+}
 
 // Verify that options point to existing directories
 const checkDirs = async function(opts) {
@@ -44,4 +50,4 @@ const checkDir = async function(opts, optName) {
   }
 }
 
-module.exports = { normalizeOpts }
+module.exports = { addDefaultOpts, normalizeOpts }


### PR DESCRIPTION
This is a small refactoring of how options are handled in `@netlify/config` which divides between: 
  - Assigning default option values (sync, happens before `getApiClient()`)
  - Normalizing options (async, happens after `getApiClient()`)

This is refactoring only. It does not change any behavior.