### PR TITLE
Remove `getJsonOpt()` test helper

### DIFF
--- a/packages/build/tests/core/build_command/tests.js
+++ b/packages/build/tests/core/build_command/tests.js
@@ -2,6 +2,7 @@ const { platform } = require('process')
 
 const test = require('ava')
 
+const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
 if (platform !== 'win32') {
@@ -29,5 +30,6 @@ test('build.command use correct PWD', async t => {
 })
 
 test('build.command from UI settings', async t => {
-  await runFixture(t, 'none', { flags: '--defaultConfig={"build":{"command":"node\\ --version"}}' })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'node --version' } }))
+  await runFixture(t, 'none', { flags: `--defaultConfig=${defaultConfig}` })
 })

--- a/packages/build/tests/core/config/tests.js
+++ b/packages/build/tests/core/config/tests.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { runFixture: runFixtureConfig, getJsonOpt, escapeExecaOpt } = require('../../../../config/tests/helpers/main')
+const { runFixture: runFixtureConfig, escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
 test('--cwd', async t => {
@@ -16,7 +16,7 @@ test('--config', async t => {
 })
 
 test('--defaultConfig', async t => {
-  const defaultConfig = getJsonOpt({ build: { command: 'echo commandDefault' } })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'echo commandDefault' } }))
   await runFixture(t, 'empty', { flags: `--defaultConfig=${defaultConfig}` })
 })
 

--- a/packages/build/tests/error/monitor/tests.js
+++ b/packages/build/tests/error/monitor/tests.js
@@ -3,7 +3,7 @@ const { version } = require('process')
 const test = require('ava')
 const hasAnsi = require('has-ansi')
 
-const { getJsonOpt } = require('../../../../config/tests/helpers/main')
+const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
 const flags = '--test-opts.error-monitor --bugsnag-key=00000000000000000000000000000000'
@@ -82,7 +82,7 @@ test('Report plugin homepage', async t => {
 })
 
 test('Report plugin origin', async t => {
-  const defaultConfig = getJsonOpt({ plugins: [{ package: './plugin.js' }] })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ plugins: [{ package: './plugin.js' }] }))
   await runFixture(t, 'plugin_origin', { flags: `${flags} --defaultConfig=${defaultConfig}` })
 })
 

--- a/packages/build/tests/error/stack/tests.js
+++ b/packages/build/tests/error/stack/tests.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 
+const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
 test('Print stack trace of plugin errors', async t => {
@@ -19,7 +20,8 @@ test('Print stack trace of build.command errors with stack traces', async t => {
 })
 
 test('Print stack trace of Build command UI settings', async t => {
-  await runFixture(t, 'none', { flags: '--defaultConfig={"build":{"command":"node\\ --invalid"}}' })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'node --invalid' } }))
+  await runFixture(t, 'none', { flags: `--defaultConfig=${defaultConfig}` })
 })
 
 test('Print stack trace of validation errors', async t => {

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -183,12 +183,6 @@ const isPrint = function() {
   return env.PRINT === '1'
 }
 
-// Get an CLI flag whose value is a JSON object, to be passed to `execa.command()`
-// Used for example by --defaultConfig and --cachedConfig.
-const getJsonOpt = function(object) {
-  return escapeExecaOpt(JSON.stringify(object))
-}
-
 // Escape CLI flag value that might contain a space
 const escapeExecaOpt = function(string) {
   return string.replace(EXECA_COMMAND_REGEXP, '\\ ')
@@ -196,4 +190,4 @@ const escapeExecaOpt = function(string) {
 
 const EXECA_COMMAND_REGEXP = / /g
 
-module.exports = { runFixtureCommon, FIXTURES_DIR, getJsonOpt, escapeExecaOpt, startServer }
+module.exports = { runFixtureCommon, FIXTURES_DIR, escapeExecaOpt, startServer }

--- a/packages/build/tests/plugins/load/tests.js
+++ b/packages/build/tests/plugins/load/tests.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { getJsonOpt } = require('../../../../config/tests/helpers/main')
+const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
 test('Local plugins', async t => {
@@ -24,7 +24,7 @@ test('Node module plugins', async t => {
 })
 
 test('UI plugins', async t => {
-  const defaultConfig = getJsonOpt({ plugins: [{ package: 'netlify-plugin-test' }] })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ plugins: [{ package: 'netlify-plugin-test' }] }))
   await runFixture(t, 'ui', { flags: `--defaultConfig=${defaultConfig}` })
 })
 

--- a/packages/config/tests/base/tests.js
+++ b/packages/config/tests/base/tests.js
@@ -1,9 +1,9 @@
 const test = require('ava')
 
-const { runFixture, getJsonOpt } = require('../helpers/main')
+const { runFixture, escapeExecaOpt } = require('../helpers/main')
 
 test('Base from defaultConfig', async t => {
-  const defaultConfig = getJsonOpt({ build: { base: 'base' } })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { base: 'base' } }))
   await runFixture(t, 'default_config', { flags: `--defaultConfig=${defaultConfig}` })
 })
 

--- a/packages/config/tests/helpers/main.js
+++ b/packages/config/tests/helpers/main.js
@@ -2,13 +2,7 @@ const { getBinPath } = require('get-bin-path')
 
 // Tests require the full monorepo to be present at the moment
 // TODO: split tests utility into its own package
-const {
-  runFixtureCommon,
-  FIXTURES_DIR,
-  getJsonOpt,
-  escapeExecaOpt,
-  startServer,
-} = require('../../../build/tests/helpers/common')
+const { runFixtureCommon, FIXTURES_DIR, escapeExecaOpt, startServer } = require('../../../build/tests/helpers/common')
 
 const ROOT_DIR = `${__dirname}/../..`
 
@@ -28,4 +22,4 @@ const runFixture = async function(t, fixtureName, { env, flags = '', ...opts } =
 }
 const BINARY_PATH = getBinPath({ cwd: ROOT_DIR })
 
-module.exports = { runFixture, FIXTURES_DIR, getJsonOpt, escapeExecaOpt, startServer }
+module.exports = { runFixture, FIXTURES_DIR, escapeExecaOpt, startServer }

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -4,7 +4,7 @@ const { cwd } = require('process')
 const test = require('ava')
 
 const resolveConfig = require('../..')
-const { runFixture, FIXTURES_DIR, getJsonOpt, escapeExecaOpt } = require('../helpers/main')
+const { runFixture, FIXTURES_DIR, escapeExecaOpt } = require('../helpers/main')
 
 test('Empty configuration', async t => {
   await runFixture(t, 'empty')
@@ -27,12 +27,12 @@ test('--config with an invalid relative path', async t => {
 })
 
 test('--defaultConfig merge', async t => {
-  const defaultConfig = getJsonOpt({ build: { publish: 'publish' } })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { publish: 'publish' } }))
   await runFixture(t, 'default_merge', { flags: `--defaultConfig=${defaultConfig}` })
 })
 
 test('--defaultConfig priority', async t => {
-  const defaultConfig = getJsonOpt({ build: { command: 'echo commandDefault' } })
+  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'echo commandDefault' } }))
   await runFixture(t, 'default_priority', { flags: `--defaultConfig=${defaultConfig}` })
 })
 
@@ -41,7 +41,9 @@ test('--defaultConfig with an invalid relative path', async t => {
 })
 
 test('--defaultConfig merges UI plugins with config plugins', async t => {
-  const defaultConfig = getJsonOpt({ plugins: [{ package: 'one', inputs: { test: false, testThree: true } }] })
+  const defaultConfig = escapeExecaOpt(
+    JSON.stringify({ plugins: [{ package: 'one', inputs: { test: false, testThree: true } }] }),
+  )
   await runFixture(t, 'plugins_merge', { flags: `--defaultConfig=${defaultConfig}` })
 })
 


### PR DESCRIPTION
This removes a test helper `getJsonOpt()` used when passing JSON argument to `@netlify/build` or `@netlify/config` binaries. 

A future PR will also remove the `escapeExecaOpt()` test helper.

The reason we want to remove those is because another future PR will call tests programmatically instead of through the CLI.