### PR TITLE
Use objects when passing flags in tests

### DIFF
--- a/packages/build/tests/cache/main/tests.js
+++ b/packages/build/tests/cache/main/tests.js
@@ -6,7 +6,7 @@ const { runFixture } = require('../../helpers/main')
 
 test('Cache local', async t => {
   await runFixture(t, 'local', {
-    flags: '--test-opts.cache-path=bower_components',
+    flags: { testOpts: { cachePath: 'bower_components' } },
     env: { TEST_CACHE_PATH: 'bower_components' },
   })
 })
@@ -16,7 +16,7 @@ test('Cache local', async t => {
 if (platform !== 'win32') {
   test('Cache CI', async t => {
     await runFixture(t, 'ci', {
-      flags: '--test-opts.cache-path=bower_components --mode=buildbot',
+      flags: { testOpts: { cachePath: 'bower_components' }, mode: 'buildbot' },
       env: { TEST_CACHE_PATH: 'bower_components' },
     })
   })

--- a/packages/build/tests/core/build_command/tests.js
+++ b/packages/build/tests/core/build_command/tests.js
@@ -31,5 +31,5 @@ test('build.command use correct PWD', async t => {
 
 test('build.command from UI settings', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'node --version' } }))
-  await runFixture(t, 'none', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'none', { flags: { defaultConfig } })
 })

--- a/packages/build/tests/core/cli/tests.js
+++ b/packages/build/tests/core/cli/tests.js
@@ -4,11 +4,11 @@ const { version } = require('../../../package.json')
 const { runFixture } = require('../../helpers/main')
 
 test('--help', async t => {
-  await runFixture(t, '', { flags: '--help' })
+  await runFixture(t, '', { flags: { help: true } })
 })
 
 test('--version', async t => {
-  const { returnValue } = await runFixture(t, '', { flags: '--version' })
+  const { returnValue } = await runFixture(t, '', { flags: { version: true } })
   t.is(returnValue, version)
 })
 
@@ -18,6 +18,6 @@ test('Exit code is 0 on success', async t => {
 })
 
 test('Exit code is 1 on error', async t => {
-  const { failed } = await runFixture(t, '', { flags: '--config=/invalid' })
+  const { failed } = await runFixture(t, '', { flags: { config: '/invalid' } })
   t.true(failed)
 })

--- a/packages/build/tests/core/config/tests.js
+++ b/packages/build/tests/core/config/tests.js
@@ -4,42 +4,42 @@ const { runFixture: runFixtureConfig, escapeExecaOpt } = require('../../../../co
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
 test('--cwd', async t => {
-  await runFixture(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: { cwd: `${FIXTURES_DIR}/empty` } })
 })
 
 test('--repository-root', async t => {
-  await runFixture(t, '', { flags: `--repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: { repositoryRoot: `${FIXTURES_DIR}/empty` } })
 })
 
 test('--config', async t => {
-  await runFixture(t, '', { flags: `--config=${FIXTURES_DIR}/empty/netlify.toml` })
+  await runFixture(t, '', { flags: { config: `${FIXTURES_DIR}/empty/netlify.toml` } })
 })
 
 test('--defaultConfig', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'echo commandDefault' } }))
-  await runFixture(t, 'empty', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'empty', { flags: { defaultConfig } })
 })
 
 test('--cachedConfig', async t => {
   const { returnValue } = await runFixtureConfig(t, 'cached_config', { snapshot: false })
   const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: `--cachedConfig=${cachedConfig}` })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig } })
 })
 
 test('--context', async t => {
-  await runFixture(t, 'context', { flags: '--context=testContext' })
+  await runFixture(t, 'context', { flags: { context: 'testContext' } })
 })
 
 test('--branch', async t => {
-  await runFixture(t, 'context', { flags: '--branch=testContext' })
+  await runFixture(t, 'context', { flags: { branch: 'testContext' } })
 })
 
 test('--baseRelDir', async t => {
-  await runFixtureConfig(t, 'basereldir', { flags: `--no-baseRelDir` })
+  await runFixtureConfig(t, 'basereldir', { flags: { baseRelDir: false } })
 })
 
 test('User error', async t => {
-  await runFixture(t, '', { flags: `--config=/invalid` })
+  await runFixture(t, '', { flags: { config: '/invalid' } })
 })
 
 test('No configuration file', async t => {

--- a/packages/build/tests/core/dry/tests.js
+++ b/packages/build/tests/core/dry/tests.js
@@ -3,17 +3,17 @@ const test = require('ava')
 const { runFixture } = require('../../helpers/main')
 
 test('--dry with one event', async t => {
-  await runFixture(t, 'single', { flags: '--dry' })
+  await runFixture(t, 'single', { flags: { dry: true } })
 })
 
 test('--dry with several events', async t => {
-  await runFixture(t, 'several', { flags: '--dry' })
+  await runFixture(t, 'several', { flags: { dry: true } })
 })
 
 test('--dry-run', async t => {
-  await runFixture(t, 'single', { flags: '--dry-run' })
+  await runFixture(t, 'single', { flags: { dryRun: true } })
 })
 
 test('--dry with build.command but no netlify.toml', async t => {
-  await runFixture(t, 'none', { flags: '--dry --defaultConfig={"build":{"command":"echo"}}' })
+  await runFixture(t, 'none', { flags: { dry: true, defaultConfig: '{"build":{"command":"echo"}}' } })
 })

--- a/packages/build/tests/core/flags/tests.js
+++ b/packages/build/tests/core/flags/tests.js
@@ -10,28 +10,32 @@ const VERY_OLD_NODE_VERSION = '4.0.0'
 
 test('--node-path is used by build.command', async t => {
   const { path } = await getNode(CHILD_NODE_VERSION)
-  await runFixture(t, 'build_command', { flags: `--node-path=${path}`, env: { TEST_NODE_PATH: path } })
+  await runFixture(t, 'build_command', { flags: { nodePath: path }, env: { TEST_NODE_PATH: path } })
 })
 
 test('--node-path is used by local plugins', async t => {
   const { path } = await getNode(CHILD_NODE_VERSION)
-  await runFixture(t, 'local', { flags: `--node-path=${path}`, env: { TEST_NODE_PATH: path } })
+  await runFixture(t, 'local', { flags: { nodePath: path }, env: { TEST_NODE_PATH: path } })
 })
 
 test('--node-path is used by plugins added to package.json', async t => {
   const { path } = await getNode(CHILD_NODE_VERSION)
-  await runFixture(t, 'package', { flags: `--node-path=${path}`, env: { TEST_NODE_PATH: path } })
+  await runFixture(t, 'package', { flags: { nodePath: path }, env: { TEST_NODE_PATH: path } })
 })
 
 test('--node-path is not used by core plugins', async t => {
   const { path } = await getNode(VERY_OLD_NODE_VERSION)
-  await runFixture(t, 'core', { flags: `--node-path=${path}` })
+  await runFixture(t, 'core', { flags: { nodePath: path } })
 })
 
 test('--node-path is not used by build-image cached plugins', async t => {
   const { path } = await getNode(CHILD_NODE_VERSION)
   await runFixture(t, 'build_image', {
-    flags: `--node-path=${path} --mode=buildbot --test-opts.build-image-plugins-dir=${FIXTURES_DIR}/build_image_cache/node_modules`,
+    flags: {
+      nodePath: path,
+      mode: 'buildbot',
+      testOpts: { buildImagePluginsDir: `${FIXTURES_DIR}/build_image_cache/node_modules` },
+    },
     env: { TEST_NODE_PATH: execPath },
   })
 })

--- a/packages/build/tests/core/telemetry/tests.js
+++ b/packages/build/tests/core/telemetry/tests.js
@@ -35,7 +35,7 @@ const TELEMETRY_PATH = '/collect'
 test('Telemetry success', async t => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
-    flags: `--site-id=test --test-opts.telemetry-origin=${scheme}://${host} --telemetry`,
+    flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: true },
     snapshot: false,
   })
   await stopServer()
@@ -46,7 +46,7 @@ test('Telemetry success', async t => {
 test('Telemetry disabled', async t => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
-    flags: `--site-id=test --test-opts.telemetry-origin=${scheme}://${host}`,
+    flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` } },
     env: { BUILD_TELEMETRY_DISABLED: 'true' },
     snapshot: false,
   })
@@ -57,7 +57,7 @@ test('Telemetry disabled', async t => {
 test('Telemetry disabled with flag', async t => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
-    flags: `--site-id=test --test-opts.telemetry-origin=${scheme}://${host} --no-telemetry`,
+    flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: false },
     snapshot: false,
   })
   await stopServer()
@@ -66,6 +66,8 @@ test('Telemetry disabled with flag', async t => {
 
 test('Telemetry error', async t => {
   const { stopServer } = await startServer(TELEMETRY_PATH)
-  await runFixture(t, 'success', { flags: `--site-id=test --test-opts.telemetry-origin=https://... --telemetry` })
+  await runFixture(t, 'success', {
+    flags: { siteId: 'test', testOpts: { telemetryOrigin: `https://...` }, telemetry: true },
+  })
   await stopServer()
 })

--- a/packages/build/tests/env/git/tests.js
+++ b/packages/build/tests/env/git/tests.js
@@ -7,7 +7,7 @@ test('Environment variable git', async t => {
 })
 
 test('Environment variable git with --branch', async t => {
-  await runFixture(t, 'git_branch', { flags: '--branch=test' })
+  await runFixture(t, 'git_branch', { flags: { branch: 'test' } })
 })
 
 test('Environment variable git no repository', async t => {

--- a/packages/build/tests/env/main/tests.js
+++ b/packages/build/tests/env/main/tests.js
@@ -28,7 +28,7 @@ test('Environment variable NETLIFY local', async t => {
 // TODO: figure out why those tests randomly fail on Linux
 if (platform !== 'linux' || !isCI) {
   test('Environment variable NETLIFY CI', async t => {
-    await runFixture(t, 'netlify', { flags: '--mode=buildbot', env: { NETLIFY: 'true' } })
+    await runFixture(t, 'netlify', { flags: { mode: 'buildbot' }, env: { NETLIFY: 'true' } })
   })
 }
 
@@ -53,9 +53,7 @@ const SITE_INFO_DATA = { url: 'test', build_settings: { repo_url: 'test' } }
 
 test('Environment variable siteInfo success', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
-  await runFixture(t, 'site_info', {
-    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'site_info', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 

--- a/packages/build/tests/error/build/tests.js
+++ b/packages/build/tests/error/build/tests.js
@@ -45,23 +45,21 @@ test('build.cancelBuild() error option', async t => {
 
 test('build.cancelBuild() API call', async t => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
-  await runFixture(t, 'cancel', {
-    flags: `--token=test --deploy-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'cancel', { flags: { token: 'test', deployId: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.snapshot(requests)
 })
 
 test('build.cancelBuild() API call no DEPLOY_ID', async t => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
-  await runFixture(t, 'cancel', { flags: `--token=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
+  await runFixture(t, 'cancel', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.is(requests.length, 0)
 })
 
 test('build.cancelBuild() API call no token', async t => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
-  await runFixture(t, 'cancel', { flags: `--deploy-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
+  await runFixture(t, 'cancel', { flags: { deployId: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.is(requests.length, 0)
 })
@@ -70,7 +68,7 @@ test('build.cancelBuild() API call no token', async t => {
 // inconsistent test snapshots
 if (!version.startsWith('v8.')) {
   test('build.cancelBuild() API call failure', async t => {
-    await runFixture(t, 'cancel', { flags: `--token=test --deploy-id=test --testOpts.host=...` })
+    await runFixture(t, 'cancel', { flags: { token: 'test', deployId: 'test', testOpts: { host: '...' } } })
   })
 }
 

--- a/packages/build/tests/error/monitor/tests.js
+++ b/packages/build/tests/error/monitor/tests.js
@@ -6,7 +6,7 @@ const hasAnsi = require('has-ansi')
 const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
-const flags = '--test-opts.error-monitor --bugsnag-key=00000000000000000000000000000000'
+const flags = { testOpts: { errorMonitor: true }, bugsnagKey: '00000000000000000000000000000000' }
 
 test('Report build.command failure', async t => {
   await runFixture(t, 'command', { flags })
@@ -45,7 +45,7 @@ test('Report IPC error', async t => {
 })
 
 test('Report API error', async t => {
-  await runFixture(t, 'cancel_build', { flags: `${flags} --token=test --deploy-id=test` })
+  await runFixture(t, 'cancel_build', { flags: { ...flags, token: 'test', deployId: 'test' } })
 })
 
 // Node v8 uses a different error message format
@@ -56,15 +56,15 @@ if (!version.startsWith('v8.')) {
 }
 
 test('Report buildbot mode as releaseStage', async t => {
-  await runFixture(t, 'command', { flags: `${flags} --mode=buildbot` })
+  await runFixture(t, 'command', { flags: { ...flags, mode: 'buildbot' } })
 })
 
 test('Report CLI mode as releaseStage', async t => {
-  await runFixture(t, 'command', { flags: `${flags} --mode=cli` })
+  await runFixture(t, 'command', { flags: { ...flags, mode: 'cli' } })
 })
 
 test('Report programmatic mode as releaseStage', async t => {
-  await runFixture(t, 'command', { flags: `${flags} --mode=require` })
+  await runFixture(t, 'command', { flags: { ...flags, mode: 'require' } })
 })
 
 test('Remove colors in error.message', async t => {
@@ -83,7 +83,7 @@ test('Report plugin homepage', async t => {
 
 test('Report plugin origin', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ plugins: [{ package: './plugin.js' }] }))
-  await runFixture(t, 'plugin_origin', { flags: `${flags} --defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'plugin_origin', { flags: { ...flags, defaultConfig } })
 })
 
 test('Report build logs URLs', async t => {

--- a/packages/build/tests/error/stack/tests.js
+++ b/packages/build/tests/error/stack/tests.js
@@ -21,9 +21,9 @@ test('Print stack trace of build.command errors with stack traces', async t => {
 
 test('Print stack trace of Build command UI settings', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'node --invalid' } }))
-  await runFixture(t, 'none', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'none', { flags: { defaultConfig } })
 })
 
 test('Print stack trace of validation errors', async t => {
-  await runFixture(t, '', { flags: '--config=/invalid' })
+  await runFixture(t, '', { flags: { config: '/invalid' } })
 })

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -9,11 +9,11 @@ const { runFixtureCommon, FIXTURES_DIR } = require('./common')
 const ROOT_DIR = `${__dirname}/../..`
 const BUILD_BIN_DIR = `${ROOT_DIR}/node_modules/.bin`
 
-const runFixture = async function(t, fixtureName, { env: envOption, flags = '', ...opts } = {}) {
+const runFixture = async function(t, fixtureName, { env: envOption, flags = {}, ...opts } = {}) {
   return runFixtureCommon(t, fixtureName, {
     ...opts,
     binaryPath: await BINARY_PATH,
-    flags: `--no-telemetry --buffer ${flags}`,
+    flags: { telemetry: false, buffer: true, ...flags },
     env: {
       BUILD_TELEMETRY_DISABLED: '',
       // Ensure local tokens aren't used during development

--- a/packages/build/tests/install/functions/tests.js
+++ b/packages/build/tests/install/functions/tests.js
@@ -32,7 +32,7 @@ test('Functions: install dependencies with Yarn locally', async t => {
 
 test('Functions: install dependencies with Yarn in CI', async t => {
   await removeDir([`${FIXTURES_DIR}/yarn_ci/.netlify/functions/`, `${FIXTURES_DIR}/yarn_ci/functions/node_modules/`])
-  await runFixture(t, 'yarn_ci', { flags: '--mode=buildbot' })
+  await runFixture(t, 'yarn_ci', { flags: { mode: 'buildbot' } })
   t.true(await pathExists(`${FIXTURES_DIR}/yarn_ci/functions/node_modules/`))
   await removeDir([`${FIXTURES_DIR}/yarn_ci/.netlify/functions/`, `${FIXTURES_DIR}/yarn_ci/functions/node_modules/`])
 })

--- a/packages/build/tests/install/local/tests.js
+++ b/packages/build/tests/install/local/tests.js
@@ -20,7 +20,7 @@ test('Install local plugin dependencies: with yarn locally', async t => {
 
 test('Install local plugin dependencies: with yarn in CI', async t => {
   await removeDir(`${FIXTURES_DIR}/yarn_ci/plugin/node_modules`)
-  await runFixture(t, 'yarn_ci', { flags: '--mode=buildbot' })
+  await runFixture(t, 'yarn_ci', { flags: { mode: 'buildbot' } })
   t.true(await pathExists(`${FIXTURES_DIR}/yarn_ci/plugin/node_modules`))
   await removeDir(`${FIXTURES_DIR}/yarn_ci/plugin/node_modules`)
 })

--- a/packages/build/tests/install/missing/tests.js
+++ b/packages/build/tests/install/missing/tests.js
@@ -7,7 +7,7 @@ test('Automatically install missing plugins locally', async t => {
 })
 
 test('Automatically install missing plugins in CI', async t => {
-  await runFixture(t, 'main', { copyRoot: {}, flags: '--mode=buildbot' })
+  await runFixture(t, 'main', { copyRoot: {}, flags: { mode: 'buildbot' } })
 })
 
 test('Re-use previously automatically installed plugins', async t => {

--- a/packages/build/tests/log/colors/tests.js
+++ b/packages/build/tests/log/colors/tests.js
@@ -8,7 +8,7 @@ test('Colors in parent process', async t => {
   const { returnValue } = await runFixture(t, 'parent', {
     snapshot: false,
     normalize: false,
-    flags: '--dry',
+    flags: { dry: true },
     env: { FORCE_COLOR: '1' },
   })
   t.true(hasAnsi(returnValue))
@@ -23,13 +23,13 @@ test('Netlify CI', async t => {
   const { returnValue } = await runFixture(t, 'parent', {
     snapshot: false,
     normalize: false,
-    flags: '--dry',
+    flags: { dry: true },
     env: { NETLIFY: 'true' },
   })
   t.true(hasAnsi(returnValue))
 })
 
 test('No TTY', async t => {
-  const { returnValue } = await runFixture(t, 'parent', { snapshot: false, normalize: false, flags: '--dry' })
+  const { returnValue } = await runFixture(t, 'parent', { snapshot: false, normalize: false, flags: { dry: true } })
   t.false(hasAnsi(returnValue))
 })

--- a/packages/build/tests/log/old_version/tests.js
+++ b/packages/build/tests/log/old_version/tests.js
@@ -10,5 +10,5 @@ test('Print a warning when using an old version through Netlify CLI', async t =>
   }
 
   // We need to unset some environment variables which would otherwise disable `update-notifier`
-  await runFixture(t, 'error', { flags: '--mode=cli --testOpts.oldCliLogs', env: { NODE_ENV: '' } })
+  await runFixture(t, 'error', { flags: { mode: 'cli', testOpts: { oldCliLogs: true } }, env: { NODE_ENV: '' } })
 })

--- a/packages/build/tests/plugins/constants/tests.js
+++ b/packages/build/tests/plugins/constants/tests.js
@@ -60,16 +60,16 @@ test('constants.CACHE_DIR local', async t => {
 // TODO: figure out why those tests randomly fail on Linux
 if (platform !== 'linux' || !isCI) {
   test('constants.CACHE_DIR CI', async t => {
-    await runFixture(t, 'cache', { flags: '--mode=buildbot' })
+    await runFixture(t, 'cache', { flags: { mode: 'buildbot' } })
   })
 
   test('constants.IS_LOCAL CI', async t => {
-    await runFixture(t, 'is_local', { flags: '--mode=buildbot' })
+    await runFixture(t, 'is_local', { flags: { mode: 'buildbot' } })
   })
 }
 
 test('constants.SITE_ID', async t => {
-  await runFixture(t, 'site_id', { flags: '--site-id test' })
+  await runFixture(t, 'site_id', { flags: { siteId: 'test' } })
 })
 
 test('constants.IS_LOCAL local', async t => {

--- a/packages/build/tests/plugins/load/tests.js
+++ b/packages/build/tests/plugins/load/tests.js
@@ -25,11 +25,11 @@ test('Node module plugins', async t => {
 
 test('UI plugins', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ plugins: [{ package: 'netlify-plugin-test' }] }))
-  await runFixture(t, 'ui', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'ui', { flags: { defaultConfig } })
 })
 
 test('Resolution is relative to the build directory', async t => {
-  await runFixture(t, 'basedir', { flags: `--config=${FIXTURES_DIR}/basedir/base/netlify.toml` })
+  await runFixture(t, 'basedir', { flags: { config: `${FIXTURES_DIR}/basedir/base/netlify.toml` } })
 })
 
 test('Non-existing plugins', async t => {
@@ -42,12 +42,12 @@ test('Do not allow overriding core plugins', async t => {
 
 test('Can use plugins cached in the build image', async t => {
   await runFixture(t, 'build_image', {
-    flags: `--test-opts.build-image-plugins-dir=${FIXTURES_DIR}/build_image_cache/node_modules --mode=buildbot`,
+    flags: { testOpts: { buildImagePluginsDir: `${FIXTURES_DIR}/build_image_cache/node_modules` }, mode: 'buildbot' },
   })
 })
 
 test('Does not use plugins cached in the build image in local builds', async t => {
   await runFixture(t, 'build_image', {
-    flags: `--test-opts.build-image-plugins-dir=${FIXTURES_DIR}/build_image_cache/node_modules`,
+    flags: { testOpts: { buildImagePluginsDir: `${FIXTURES_DIR}/build_image_cache/node_modules` } },
   })
 })

--- a/packages/build/tests/plugins/node_version/tests.js
+++ b/packages/build/tests/plugins/node_version/tests.js
@@ -8,19 +8,19 @@ const getNodePath = function(version) {
 
 test('Validate --node-path version is supported by our codebase', async t => {
   const nodePath = getNodePath('8.2.0')
-  await runFixture(t, 'simple', { flags: `--node-path=${nodePath}` })
+  await runFixture(t, 'simple', { flags: { nodePath } })
 })
 
 test('Validate --node-path unsupported version does not fail when no plugins are used', async t => {
   const nodePath = getNodePath('8.2.0')
-  await runFixture(t, 'empty', { flags: `--node-path=${nodePath}` })
+  await runFixture(t, 'empty', { flags: { nodePath } })
 })
 
 test('Validate --node-path version is supported by the plugin', async t => {
   const nodePath = getNodePath('9.0.0')
-  await runFixture(t, 'engines', { flags: `--node-path=${nodePath}` })
+  await runFixture(t, 'engines', { flags: { nodePath } })
 })
 
 test('Validate --node-path', async t => {
-  await runFixture(t, 'simple', { flags: '--node-path=/doesNotExist' })
+  await runFixture(t, 'simple', { flags: { nodePath: '/doesNotExist' } })
 })

--- a/packages/build/tests/status/helpers/run.js
+++ b/packages/build/tests/status/helpers/run.js
@@ -29,10 +29,10 @@ const comparePackage = function({ body: { package: packageA } }, { body: { packa
   return packageA < packageB ? -1 : 1
 }
 
-const runWithApiMock = async function(t, fixture, { flags = '--token=test', env, status } = {}) {
+const runWithApiMock = async function(t, fixture, { flags = { token: 'test' }, env, status } = {}) {
   const { scheme, host, requests, stopServer } = await startServer(STATUS_PATH, {}, { status })
   await runFixture(t, fixture, {
-    flags: `--deploy-id=test ${flags} --testOpts.send-status --testOpts.scheme=${scheme} --testOpts.host=${host}`,
+    flags: { deployId: 'test', ...flags, testOpts: { scheme, host, sendStatus: true } },
     env,
   })
   await stopServer()

--- a/packages/build/tests/status/report/tests.js
+++ b/packages/build/tests/status/report/tests.js
@@ -8,7 +8,7 @@ test('utils.status.show() are printed locally', async t => {
 })
 
 test('utils.status.show() are not printed in production', async t => {
-  await runFixture(t, 'print', { flags: '--mode=buildbot' })
+  await runFixture(t, 'print', { flags: { mode: 'buildbot' } })
 })
 
 test('utils.status.show() statuses are sent to the API', async t => {
@@ -16,11 +16,11 @@ test('utils.status.show() statuses are sent to the API', async t => {
 })
 
 test('utils.status.show() statuses are not sent to the API without a token', async t => {
-  await runWithApiMock(t, 'print', { flags: '' })
+  await runWithApiMock(t, 'print', { flags: { token: '' } })
 })
 
 test('utils.status.show() statuses are not sent to the API without a DEPLOY_ID', async t => {
-  await runWithApiMock(t, 'print', { flags: '--deploy-id=""' })
+  await runWithApiMock(t, 'print', { flags: { deployId: '' } })
 })
 
 test('utils.status.show() statuses API errors are handled', async t => {

--- a/packages/config/tests/api/tests.js
+++ b/packages/config/tests/api/tests.js
@@ -3,7 +3,7 @@ const test = require('ava')
 const { runFixture, startServer } = require('../helpers/main')
 
 test('--token', async t => {
-  await runFixture(t, 'empty', { flags: '--token=test' })
+  await runFixture(t, 'empty', { flags: { token: 'test' } })
 })
 
 test('NETLIFY_AUTH_TOKEN environment variable', async t => {
@@ -11,7 +11,7 @@ test('NETLIFY_AUTH_TOKEN environment variable', async t => {
 })
 
 test('--site-id', async t => {
-  await runFixture(t, 'empty', { flags: '--site-id=test' })
+  await runFixture(t, 'empty', { flags: { siteId: 'test' } })
 })
 
 const SITE_INFO_PATH = '/api/v1/sites/test'
@@ -20,36 +20,32 @@ const SITE_INFO_ERROR = { error: 'invalid' }
 
 test('Environment variable siteInfo success', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
-  await runFixture(t, 'empty', {
-    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo API error', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_ERROR, { status: 400 })
-  await runFixture(t, 'empty', {
-    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo no token', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
-  await runFixture(t, 'empty', { flags: `--site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
+  await runFixture(t, 'empty', { flags: { siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo no siteId', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
-  await runFixture(t, 'empty', { flags: `--token=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
+  await runFixture(t, 'empty', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo CI', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', {
-    flags: `--token=test --site-id=test --mode=buildbot --testOpts.scheme=${scheme} --testOpts.host=${host}`,
+    flags: { token: 'test', siteId: 'test', mode: 'buildbot', testOpts: { scheme, host } },
   })
   await stopServer()
 })
@@ -61,9 +57,7 @@ const SITE_INFO_BUILD_SETTINGS_NULL = {
 
 test('Build settings can be null', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS_NULL)
-  await runFixture(t, 'empty', {
-    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
@@ -82,44 +76,40 @@ const SITE_INFO_BUILD_SETTINGS = {
 
 test('Use build settings if a siteId and token are provided', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
-  await runFixture(t, 'base', {
-    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'base', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings have low merging priority', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'build_settings', {
-    flags: `--token=test --site-id=test --baseRelDir --testOpts.scheme=${scheme} --testOpts.host=${host}`,
+    flags: { token: 'test', siteId: 'test', baseRelDir: true, testOpts: { scheme, host } },
   })
   await stopServer()
 })
 
 test('Build settings are not used if getSite call fails', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS, { status: 400 })
-  await runFixture(t, 'base', {
-    flags: `--token=test --site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}`,
-  })
+  await runFixture(t, 'base', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings are not used without a token', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
-  await runFixture(t, 'base', { flags: `--site-id=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
+  await runFixture(t, 'base', { flags: { siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings are not used without a siteId', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
-  await runFixture(t, 'base', { flags: `--token=test --testOpts.scheme=${scheme} --testOpts.host=${host}` })
+  await runFixture(t, 'base', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings are not used in CI', async t => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', {
-    flags: `--token=test --site-id=test --mode=buildbot --testOpts.scheme=${scheme} --testOpts.host=${host}`,
+    flags: { token: 'test', siteId: 'test', mode: 'buildbot', testOpts: { scheme, host } },
   })
   await stopServer()
 })

--- a/packages/config/tests/base/tests.js
+++ b/packages/config/tests/base/tests.js
@@ -4,7 +4,7 @@ const { runFixture, escapeExecaOpt } = require('../helpers/main')
 
 test('Base from defaultConfig', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { base: 'base' } }))
-  await runFixture(t, 'default_config', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'default_config', { flags: { defaultConfig } })
 })
 
 test('Base from configuration file property', async t => {
@@ -25,7 +25,7 @@ test('Base logic is not recursive', async t => {
 })
 
 test('BaseRelDir feature flag', async t => {
-  const { returnValue } = await runFixture(t, 'prop_config', { flags: `--no-baseRelDir` })
+  const { returnValue } = await runFixture(t, 'prop_config', { flags: { baseRelDir: false } })
   const {
     buildDir,
     config: {

--- a/packages/config/tests/cli/tests.js
+++ b/packages/config/tests/cli/tests.js
@@ -9,11 +9,11 @@ const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 const pWriteFile = promisify(writeFile)
 
 test('--help', async t => {
-  await runFixture(t, '', { flags: '--help' })
+  await runFixture(t, '', { flags: { help: true } })
 })
 
 test('--version', async t => {
-  await runFixture(t, '', { flags: '--version' })
+  await runFixture(t, '', { flags: { version: true } })
 })
 
 test('Success', async t => {
@@ -21,19 +21,19 @@ test('Success', async t => {
 })
 
 test('User error', async t => {
-  await runFixture(t, 'empty', { flags: '--config=/invalid' })
+  await runFixture(t, 'empty', { flags: { config: '/invalid' } })
 })
 
 test('CLI flags', async t => {
-  await runFixture(t, 'empty', { flags: '--branch=test' })
+  await runFixture(t, 'empty', { flags: { branch: 'test' } })
 })
 
 test('Stabilitize output with the --stable flag', async t => {
-  await runFixture(t, 'empty', { flags: '--stable' })
+  await runFixture(t, 'empty', { flags: { stable: true } })
 })
 
 test('Does not stabilitize output without the --stable flag', async t => {
-  await runFixture(t, 'empty', { flags: '--no-stable' })
+  await runFixture(t, 'empty', { flags: { stable: false } })
 })
 
 test('Handles big outputs', async t => {

--- a/packages/config/tests/context/tests.js
+++ b/packages/config/tests/context/tests.js
@@ -3,7 +3,7 @@ const test = require('ava')
 const { runFixture } = require('../helpers/main')
 
 test('Context with context CLI flag', async t => {
-  await runFixture(t, 'context_flag', { flags: '--context=testContext' })
+  await runFixture(t, 'context_flag', { flags: { context: 'testContext' } })
 })
 
 test('Context environment variable', async t => {
@@ -15,19 +15,19 @@ test('Context default value', async t => {
 })
 
 test('Context with branch CLI flag', async t => {
-  await runFixture(t, 'branch', { flags: '--branch=testBranch' })
+  await runFixture(t, 'branch', { flags: { branch: 'testBranch' } })
 })
 
 test('Context with branch environment variable', async t => {
-  await runFixture(t, 'branch', { env: { BRANCH: 'testBranch' }, flags: '--branch=""' })
+  await runFixture(t, 'branch', { env: { BRANCH: 'testBranch' }, flags: { branch: '' } })
 })
 
 test('Context with branch git', async t => {
-  await runFixture(t, 'branch', { copyRoot: { branch: 'testBranch' }, flags: '--branch=""' })
+  await runFixture(t, 'branch', { copyRoot: { branch: 'testBranch' }, flags: { branch: '' } })
 })
 
 test('Context with branch fallback', async t => {
-  await runFixture(t, 'branch_fallback', { copyRoot: { git: false }, flags: '--branch=""' })
+  await runFixture(t, 'branch_fallback', { copyRoot: { git: false }, flags: { branch: '' } })
 })
 
 test('Context deep merge', async t => {
@@ -39,5 +39,5 @@ test('Context array merge', async t => {
 })
 
 test('Context merge priority', async t => {
-  await runFixture(t, 'priority_merge', { flags: '--branch=testBranch' })
+  await runFixture(t, 'priority_merge', { flags: { branch: 'testBranch' } })
 })

--- a/packages/config/tests/cwd/tests.js
+++ b/packages/config/tests/cwd/tests.js
@@ -6,13 +6,11 @@ const test = require('ava')
 const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
 test('--cwd with no config', async t => {
-  await runFixture(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: { cwd: `${FIXTURES_DIR}/empty` } })
 })
 
 test('--cwd with a relative path config', async t => {
-  await runFixture(t, '', {
-    flags: `--cwd=${relative(cwd(), FIXTURES_DIR)} --config=empty/netlify.toml`,
-  })
+  await runFixture(t, '', { flags: { cwd: `${relative(cwd(), FIXTURES_DIR)}`, config: 'empty/netlify.toml' } })
 })
 
 test('build.base current directory', async t => {
@@ -20,7 +18,7 @@ test('build.base current directory', async t => {
 })
 
 test('--repository-root', async t => {
-  await runFixture(t, '', { flags: `--repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: { repositoryRoot: `${FIXTURES_DIR}/empty` } })
 })
 
 test('No .git', async t => {
@@ -28,17 +26,19 @@ test('No .git', async t => {
 })
 
 test('--cwd non-existing', async t => {
-  await runFixture(t, '', { flags: `--cwd=/invalid --repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', { flags: { cwd: '/invalid', repositoryRoot: `${FIXTURES_DIR}/empty` } })
 })
 
 test('--cwd points to a non-directory file', async t => {
-  await runFixture(t, '', { flags: `--cwd=${FIXTURES_DIR}/empty/netlify.toml --repository-root=${FIXTURES_DIR}/empty` })
+  await runFixture(t, '', {
+    flags: { cwd: `${FIXTURES_DIR}/empty/netlify.toml`, repositoryRoot: `${FIXTURES_DIR}/empty` },
+  })
 })
 
 test('--repositoryRoot non-existing', async t => {
-  await runFixture(t, '', { flags: `--repositoryRoot=/invalid` })
+  await runFixture(t, '', { flags: { repositoryRoot: '/invalid' } })
 })
 
 test('--repositoryRoot points to a non-directory file', async t => {
-  await runFixture(t, '', { flags: `--repositoryRoot=${FIXTURES_DIR}/empty/netlify.toml` })
+  await runFixture(t, '', { flags: { repositoryRoot: `${FIXTURES_DIR}/empty/netlify.toml` } })
 })

--- a/packages/config/tests/helpers/main.js
+++ b/packages/config/tests/helpers/main.js
@@ -6,15 +6,13 @@ const { runFixtureCommon, FIXTURES_DIR, escapeExecaOpt, startServer } = require(
 
 const ROOT_DIR = `${__dirname}/../..`
 
-const runFixture = async function(t, fixtureName, { env, flags = '', ...opts } = {}) {
-  const flagsA = flags.includes('--branch') ? flags : `--branch=branch ${flags}`
-  const flagsB = `--stable ${flagsA}`
+const runFixture = async function(t, fixtureName, { env, flags = {}, ...opts } = {}) {
   return runFixtureCommon(t, fixtureName, {
     ...opts,
     binaryPath: await BINARY_PATH,
     // Ensure local tokens aren't used during development
     env: { NETLIFY_AUTH_TOKEN: '', ...env },
-    flags: flagsB,
+    flags: { branch: 'branch', stable: true, ...flags },
   })
 }
 const BINARY_PATH = getBinPath({ cwd: ROOT_DIR })

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -15,58 +15,58 @@ test('No --config but none found', async t => {
 })
 
 test('--config with an absolute path', async t => {
-  await runFixture(t, '', { flags: `--config=${FIXTURES_DIR}/empty/netlify.toml` })
+  await runFixture(t, '', { flags: { config: `${FIXTURES_DIR}/empty/netlify.toml` } })
 })
 
 test('--config with a relative path', async t => {
-  await runFixture(t, '', { flags: `--config=${relative(cwd(), FIXTURES_DIR)}/empty/netlify.toml` })
+  await runFixture(t, '', { flags: { config: `${relative(cwd(), FIXTURES_DIR)}/empty/netlify.toml` } })
 })
 
 test('--config with an invalid relative path', async t => {
-  await runFixture(t, '', { flags: '--config=/invalid' })
+  await runFixture(t, '', { flags: { config: '/invalid' } })
 })
 
 test('--defaultConfig merge', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { publish: 'publish' } }))
-  await runFixture(t, 'default_merge', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'default_merge', { flags: { defaultConfig } })
 })
 
 test('--defaultConfig priority', async t => {
   const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'echo commandDefault' } }))
-  await runFixture(t, 'default_priority', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'default_priority', { flags: { defaultConfig } })
 })
 
 test('--defaultConfig with an invalid relative path', async t => {
-  await runFixture(t, '', { flags: '--defaultConfig={{}' })
+  await runFixture(t, '', { flags: { defaultConfig: '{{}' } })
 })
 
 test('--defaultConfig merges UI plugins with config plugins', async t => {
   const defaultConfig = escapeExecaOpt(
     JSON.stringify({ plugins: [{ package: 'one', inputs: { test: false, testThree: true } }] }),
   )
-  await runFixture(t, 'plugins_merge', { flags: `--defaultConfig=${defaultConfig}` })
+  await runFixture(t, 'plugins_merge', { flags: { defaultConfig } })
 })
 
 test('--cachedConfig', async t => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false })
   const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: `--cachedConfig=${cachedConfig}` })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig } })
 })
 
 test('--cachedConfig with an invalid path', async t => {
-  await runFixture(t, '', { flags: '--cachedConfig={{}' })
+  await runFixture(t, '', { flags: { cachedConfig: '{{}' } })
 })
 
 test('--cachedConfig with a token', async t => {
-  const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: '--token=test' })
+  const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: { token: 'test' } })
   const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: `--cachedConfig=${cachedConfig} --token=test` })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig, token: 'test' } })
 })
 
 test('--cachedConfig with a siteId', async t => {
-  const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: '--siteId=test' })
+  const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: { siteId: 'test' } })
   const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: `--cachedConfig=${cachedConfig} --siteId=test` })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig, siteId: 'test' } })
 })
 
 test('Programmatic', async t => {

--- a/packages/config/tests/parse/tests.js
+++ b/packages/config/tests/parse/tests.js
@@ -12,7 +12,7 @@ test('Configuration file - netlify.toml', async t => {
 // Node 10 also changed errors there, so Node 8 shows different error messages.
 if (platform !== 'win32' && !version.startsWith('v8.')) {
   test('Configuration file - read permission error', async t => {
-    await runFixture(t, '', { flags: `--config=${FIXTURES_DIR}/read_error/netlify.toml` })
+    await runFixture(t, '', { flags: { config: `${FIXTURES_DIR}/read_error/netlify.toml` } })
   })
 }
 

--- a/packages/config/tests/validate/tests.js
+++ b/packages/config/tests/validate/tests.js
@@ -83,11 +83,11 @@ test('build.command: array', async t => {
 })
 
 test('build.context: property', async t => {
-  await runFixture(t, 'build_context_property', { flags: '--context=development' })
+  await runFixture(t, 'build_context_property', { flags: { context: 'development' } })
 })
 
 test('build.context: nested property', async t => {
-  await runFixture(t, 'build_context_nested_property', { flags: '--context=development' })
+  await runFixture(t, 'build_context_nested_property', { flags: { context: 'development' } })
 })
 
 test('build.context: object', async t => {


### PR DESCRIPTION
Tests currently pass flags/options as strings such as `--option=value`. This PR changes it to passing those as `{ option: value }` instead. We convert those under the hood to `--option=value`.

The reason is because an upcoming PR is going to convert most tests from calling `@netlify/build` binary to using the programmatic main function instead, which uses flag objects instead.