### PR TITLE
Run tests using the programmatic main functions

### DIFF
--- a/packages/build/tests/core/build_command/tests.js
+++ b/packages/build/tests/core/build_command/tests.js
@@ -2,7 +2,6 @@ const { platform } = require('process')
 
 const test = require('ava')
 
-const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
 if (platform !== 'win32') {
@@ -30,6 +29,6 @@ test('build.command use correct PWD', async t => {
 })
 
 test('build.command from UI settings', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'node --version' } }))
+  const defaultConfig = JSON.stringify({ build: { command: 'node --version' } })
   await runFixture(t, 'none', { flags: { defaultConfig } })
 })

--- a/packages/build/tests/core/cli/tests.js
+++ b/packages/build/tests/core/cli/tests.js
@@ -4,20 +4,20 @@ const { version } = require('../../../package.json')
 const { runFixture } = require('../../helpers/main')
 
 test('--help', async t => {
-  await runFixture(t, '', { flags: { help: true } })
+  await runFixture(t, '', { flags: { help: true }, useBinary: true })
 })
 
 test('--version', async t => {
-  const { returnValue } = await runFixture(t, '', { flags: { version: true } })
+  const { returnValue } = await runFixture(t, '', { flags: { version: true }, useBinary: true })
   t.is(returnValue, version)
 })
 
 test('Exit code is 0 on success', async t => {
-  const { failed } = await runFixture(t, 'empty')
+  const { failed } = await runFixture(t, 'empty', { useBinary: true })
   t.not(failed)
 })
 
 test('Exit code is 1 on error', async t => {
-  const { failed } = await runFixture(t, '', { flags: { config: '/invalid' } })
+  const { failed } = await runFixture(t, '', { flags: { config: '/invalid' }, useBinary: true })
   t.true(failed)
 })

--- a/packages/build/tests/core/config/tests.js
+++ b/packages/build/tests/core/config/tests.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { runFixture: runFixtureConfig, escapeExecaOpt } = require('../../../../config/tests/helpers/main')
+const { runFixture: runFixtureConfig } = require('../../../../config/tests/helpers/main')
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
 test('--cwd', async t => {
@@ -16,14 +16,13 @@ test('--config', async t => {
 })
 
 test('--defaultConfig', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'echo commandDefault' } }))
+  const defaultConfig = JSON.stringify({ build: { command: 'echo commandDefault' } })
   await runFixture(t, 'empty', { flags: { defaultConfig } })
 })
 
 test('--cachedConfig', async t => {
   const { returnValue } = await runFixtureConfig(t, 'cached_config', { snapshot: false })
-  const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: { cachedConfig } })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue } })
 })
 
 test('--context', async t => {

--- a/packages/build/tests/core/dry/tests.js
+++ b/packages/build/tests/core/dry/tests.js
@@ -11,7 +11,7 @@ test('--dry with several events', async t => {
 })
 
 test('--dry-run', async t => {
-  await runFixture(t, 'single', { flags: { dryRun: true } })
+  await runFixture(t, 'single', { flags: { dryRun: true }, useBinary: true })
 })
 
 test('--dry with build.command but no netlify.toml', async t => {

--- a/packages/build/tests/error/monitor/tests.js
+++ b/packages/build/tests/error/monitor/tests.js
@@ -3,7 +3,6 @@ const { version } = require('process')
 const test = require('ava')
 const hasAnsi = require('has-ansi')
 
-const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
 const flags = { testOpts: { errorMonitor: true }, bugsnagKey: '00000000000000000000000000000000' }
@@ -56,15 +55,15 @@ if (!version.startsWith('v8.')) {
 }
 
 test('Report buildbot mode as releaseStage', async t => {
-  await runFixture(t, 'command', { flags: { ...flags, mode: 'buildbot' } })
+  await runFixture(t, 'command', { flags: { ...flags, mode: 'buildbot' }, useBinary: true })
 })
 
 test('Report CLI mode as releaseStage', async t => {
-  await runFixture(t, 'command', { flags: { ...flags, mode: 'cli' } })
+  await runFixture(t, 'command', { flags: { ...flags, mode: 'cli' }, useBinary: true })
 })
 
 test('Report programmatic mode as releaseStage', async t => {
-  await runFixture(t, 'command', { flags: { ...flags, mode: 'require' } })
+  await runFixture(t, 'command', { flags: { ...flags, mode: 'require' }, useBinary: true })
 })
 
 test('Remove colors in error.message', async t => {
@@ -74,7 +73,7 @@ test('Remove colors in error.message', async t => {
 })
 
 test('Report BUILD_ID', async t => {
-  await runFixture(t, 'command', { flags, env: { BUILD_ID: 'test' } })
+  await runFixture(t, 'command', { flags, env: { BUILD_ID: 'test' }, useBinary: true })
 })
 
 test('Report plugin homepage', async t => {
@@ -82,7 +81,7 @@ test('Report plugin homepage', async t => {
 })
 
 test('Report plugin origin', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ plugins: [{ package: './plugin.js' }] }))
+  const defaultConfig = JSON.stringify({ plugins: [{ package: './plugin.js' }] })
   await runFixture(t, 'plugin_origin', { flags: { ...flags, defaultConfig } })
 })
 
@@ -90,5 +89,6 @@ test('Report build logs URLs', async t => {
   await runFixture(t, 'command', {
     flags,
     env: { DEPLOY_ID: 'testDeployId', DEPLOY_URL: 'https://testDeployId--testSiteName.netlify.app' },
+    useBinary: true,
   })
 })

--- a/packages/build/tests/error/stack/tests.js
+++ b/packages/build/tests/error/stack/tests.js
@@ -1,6 +1,5 @@
 const test = require('ava')
 
-const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture } = require('../../helpers/main')
 
 test('Print stack trace of plugin errors', async t => {
@@ -20,7 +19,7 @@ test('Print stack trace of build.command errors with stack traces', async t => {
 })
 
 test('Print stack trace of Build command UI settings', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'node --invalid' } }))
+  const defaultConfig = JSON.stringify({ build: { command: 'node --invalid' } })
   await runFixture(t, 'none', { flags: { defaultConfig } })
 })
 

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -1,5 +1,7 @@
 const { getBinPath } = require('get-bin-path')
 
+const netlifyBuild = require('../../')
+
 const { runFixtureCommon, FIXTURES_DIR } = require('./common')
 
 const ROOT_DIR = `${__dirname}/../..`
@@ -9,7 +11,12 @@ const runFixture = async function(t, fixtureName, { flags = {}, env = {}, ...opt
   const flagsA = { telemetry: false, buffer: true, ...flags }
   // Ensure local environment variables aren't used during development
   const envA = { BUILD_TELEMETRY_DISABLED: '', NETLIFY_AUTH_TOKEN: '', ...env }
-  return runFixtureCommon(t, fixtureName, { ...opts, flags: flagsA, env: envA, binaryPath })
+  return runFixtureCommon(t, fixtureName, { ...opts, flags: flagsA, env: envA, mainFunc, binaryPath })
+}
+
+const mainFunc = async function(flags) {
+  const { logs } = await netlifyBuild(flags)
+  return [logs.stdout.join('\n'), logs.stderr.join('\n')].filter(Boolean).join('\n\n')
 }
 
 // Use a top-level promise so it's only performed once at load time

--- a/packages/build/tests/log/colors/tests.js
+++ b/packages/build/tests/log/colors/tests.js
@@ -10,12 +10,18 @@ test('Colors in parent process', async t => {
     normalize: false,
     flags: { dry: true },
     env: { FORCE_COLOR: '1' },
+    useBinary: true,
   })
   t.true(hasAnsi(returnValue))
 })
 
 test('Colors in child process', async t => {
-  const { returnValue } = await runFixture(t, 'child', { snapshot: false, normalize: false, env: { FORCE_COLOR: '1' } })
+  const { returnValue } = await runFixture(t, 'child', {
+    snapshot: false,
+    normalize: false,
+    env: { FORCE_COLOR: '1' },
+    useBinary: true,
+  })
   t.true(returnValue.includes(red('onPreBuild')))
 })
 
@@ -25,11 +31,17 @@ test('Netlify CI', async t => {
     normalize: false,
     flags: { dry: true },
     env: { NETLIFY: 'true' },
+    useBinary: true,
   })
   t.true(hasAnsi(returnValue))
 })
 
 test('No TTY', async t => {
-  const { returnValue } = await runFixture(t, 'parent', { snapshot: false, normalize: false, flags: { dry: true } })
+  const { returnValue } = await runFixture(t, 'parent', {
+    snapshot: false,
+    normalize: false,
+    flags: { dry: true },
+    useBinary: true,
+  })
   t.false(hasAnsi(returnValue))
 })

--- a/packages/build/tests/log/old_version/tests.js
+++ b/packages/build/tests/log/old_version/tests.js
@@ -10,5 +10,9 @@ test('Print a warning when using an old version through Netlify CLI', async t =>
   }
 
   // We need to unset some environment variables which would otherwise disable `update-notifier`
-  await runFixture(t, 'error', { flags: { mode: 'cli', testOpts: { oldCliLogs: true } }, env: { NODE_ENV: '' } })
+  await runFixture(t, 'error', {
+    flags: { mode: 'cli', testOpts: { oldCliLogs: true } },
+    env: { NODE_ENV: '' },
+    useBinary: true,
+  })
 })

--- a/packages/build/tests/plugins/load/tests.js
+++ b/packages/build/tests/plugins/load/tests.js
@@ -1,6 +1,5 @@
 const test = require('ava')
 
-const { escapeExecaOpt } = require('../../../../config/tests/helpers/main')
 const { runFixture, FIXTURES_DIR } = require('../../helpers/main')
 
 test('Local plugins', async t => {
@@ -24,7 +23,7 @@ test('Node module plugins', async t => {
 })
 
 test('UI plugins', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ plugins: [{ package: 'netlify-plugin-test' }] }))
+  const defaultConfig = JSON.stringify({ plugins: [{ package: 'netlify-plugin-test' }] })
   await runFixture(t, 'ui', { flags: { defaultConfig } })
 })
 

--- a/packages/build/tests/status/helpers/run.js
+++ b/packages/build/tests/status/helpers/run.js
@@ -29,11 +29,10 @@ const comparePackage = function({ body: { package: packageA } }, { body: { packa
   return packageA < packageB ? -1 : 1
 }
 
-const runWithApiMock = async function(t, fixture, { flags = { token: 'test' }, env, status } = {}) {
+const runWithApiMock = async function(t, fixture, { flags = { token: 'test' }, status } = {}) {
   const { scheme, host, requests, stopServer } = await startServer(STATUS_PATH, {}, { status })
   await runFixture(t, fixture, {
     flags: { deployId: 'test', ...flags, testOpts: { scheme, host, sendStatus: true } },
-    env,
   })
   await stopServer()
   const snapshots = requests.map(normalizeRequest).sort(comparePackage)

--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -31,9 +31,9 @@ const handleCliSuccess = function(result, stable) {
 }
 
 // `api` is not JSON-serializable, so we remove it
-// We still indicate it as a boolean in tests
+// We still indicate it as a boolean
 const serializeApi = function({ api, ...result }) {
-  if (process.env.NETLIFY_BUILD_TEST !== '1' || api === undefined) {
+  if (api === undefined) {
     return result
   }
 

--- a/packages/config/tests/base/tests.js
+++ b/packages/config/tests/base/tests.js
@@ -1,9 +1,9 @@
 const test = require('ava')
 
-const { runFixture, escapeExecaOpt } = require('../helpers/main')
+const { runFixture } = require('../helpers/main')
 
 test('Base from defaultConfig', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { base: 'base' } }))
+  const defaultConfig = JSON.stringify({ build: { base: 'base' } })
   await runFixture(t, 'default_config', { flags: { defaultConfig } })
 })
 

--- a/packages/config/tests/cli/tests.js
+++ b/packages/config/tests/cli/tests.js
@@ -9,31 +9,31 @@ const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 const pWriteFile = promisify(writeFile)
 
 test('--help', async t => {
-  await runFixture(t, '', { flags: { help: true } })
+  await runFixture(t, '', { flags: { help: true }, useBinary: true })
 })
 
 test('--version', async t => {
-  await runFixture(t, '', { flags: { version: true } })
+  await runFixture(t, '', { flags: { version: true }, useBinary: true })
 })
 
 test('Success', async t => {
-  await runFixture(t, 'empty')
+  await runFixture(t, 'empty', { useBinary: true })
 })
 
 test('User error', async t => {
-  await runFixture(t, 'empty', { flags: { config: '/invalid' } })
+  await runFixture(t, 'empty', { flags: { config: '/invalid' }, useBinary: true })
 })
 
 test('CLI flags', async t => {
-  await runFixture(t, 'empty', { flags: { branch: 'test' } })
+  await runFixture(t, 'empty', { flags: { branch: 'test' }, useBinary: true })
 })
 
 test('Stabilitize output with the --stable flag', async t => {
-  await runFixture(t, 'empty', { flags: { stable: true } })
+  await runFixture(t, 'empty', { flags: { stable: true }, useBinary: true })
 })
 
 test('Does not stabilitize output without the --stable flag', async t => {
-  await runFixture(t, 'empty', { flags: { stable: false } })
+  await runFixture(t, 'empty', { flags: { stable: false }, useBinary: true })
 })
 
 test('Handles big outputs', async t => {
@@ -42,7 +42,7 @@ test('Handles big outputs', async t => {
   try {
     const bigContent = getBigNetlifyContent()
     await pWriteFile(bigNetlify, bigContent)
-    const { returnValue } = await runFixture(t, 'big', { snapshot: false })
+    const { returnValue } = await runFixture(t, 'big', { snapshot: false, useBinary: true })
     t.notThrows(() => {
       JSON.parse(returnValue)
     })

--- a/packages/config/tests/helpers/main.js
+++ b/packages/config/tests/helpers/main.js
@@ -1,8 +1,10 @@
+const { stableStringify } = require('fast-safe-stringify')
 const { getBinPath } = require('get-bin-path')
 
 // Tests require the full monorepo to be present at the moment
 // TODO: split tests utility into its own package
-const { runFixtureCommon, FIXTURES_DIR, escapeExecaOpt, startServer } = require('../../../build/tests/helpers/common')
+const resolveConfig = require('../..')
+const { runFixtureCommon, FIXTURES_DIR, startServer } = require('../../../build/tests/helpers/common')
 
 const ROOT_DIR = `${__dirname}/../..`
 
@@ -11,10 +13,26 @@ const runFixture = async function(t, fixtureName, { flags = {}, env, ...opts } =
   const flagsA = { stable: true, branch: 'branch', ...flags }
   // Ensure local environment variables aren't used during development
   const envA = { NETLIFY_AUTH_TOKEN: '', ...env }
-  return runFixtureCommon(t, fixtureName, { ...opts, flags: flagsA, env: envA, binaryPath })
+  return runFixtureCommon(t, fixtureName, { ...opts, flags: flagsA, env: envA, mainFunc, binaryPath })
+}
+
+// In tests, make the return value stable so it can be snapshot
+const mainFunc = async function(flags) {
+  const result = await resolveConfig(flags)
+  const resultA = serializeApi(result)
+  const resultB = stableStringify(resultA, null, 2)
+  return resultB
+}
+
+const serializeApi = function({ api, ...result }) {
+  if (api === undefined) {
+    return result
+  }
+
+  return { ...result, hasApi: true }
 }
 
 // Use a top-level promise so it's only performed once at load time
 const BINARY_PATH = getBinPath({ cwd: ROOT_DIR })
 
-module.exports = { runFixture, FIXTURES_DIR, escapeExecaOpt, startServer }
+module.exports = { runFixture, FIXTURES_DIR, startServer }

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -4,7 +4,7 @@ const { cwd } = require('process')
 const test = require('ava')
 
 const resolveConfig = require('../..')
-const { runFixture, FIXTURES_DIR, escapeExecaOpt } = require('../helpers/main')
+const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
 test('Empty configuration', async t => {
   await runFixture(t, 'empty')
@@ -27,12 +27,12 @@ test('--config with an invalid relative path', async t => {
 })
 
 test('--defaultConfig merge', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { publish: 'publish' } }))
+  const defaultConfig = JSON.stringify({ build: { publish: 'publish' } })
   await runFixture(t, 'default_merge', { flags: { defaultConfig } })
 })
 
 test('--defaultConfig priority', async t => {
-  const defaultConfig = escapeExecaOpt(JSON.stringify({ build: { command: 'echo commandDefault' } }))
+  const defaultConfig = JSON.stringify({ build: { command: 'echo commandDefault' } })
   await runFixture(t, 'default_priority', { flags: { defaultConfig } })
 })
 
@@ -41,16 +41,13 @@ test('--defaultConfig with an invalid relative path', async t => {
 })
 
 test('--defaultConfig merges UI plugins with config plugins', async t => {
-  const defaultConfig = escapeExecaOpt(
-    JSON.stringify({ plugins: [{ package: 'one', inputs: { test: false, testThree: true } }] }),
-  )
+  const defaultConfig = JSON.stringify({ plugins: [{ package: 'one', inputs: { test: false, testThree: true } }] })
   await runFixture(t, 'plugins_merge', { flags: { defaultConfig } })
 })
 
 test('--cachedConfig', async t => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false })
-  const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: { cachedConfig } })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue } })
 })
 
 test('--cachedConfig with an invalid path', async t => {
@@ -59,14 +56,12 @@ test('--cachedConfig with an invalid path', async t => {
 
 test('--cachedConfig with a token', async t => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: { token: 'test' } })
-  const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: { cachedConfig, token: 'test' } })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue, token: 'test' } })
 })
 
 test('--cachedConfig with a siteId', async t => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: { siteId: 'test' } })
-  const cachedConfig = escapeExecaOpt(returnValue)
-  await runFixture(t, 'cached_config', { flags: { cachedConfig, siteId: 'test' } })
+  await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue, siteId: 'test' } })
 })
 
 test('Programmatic', async t => {


### PR DESCRIPTION
This PR runs tests using the Node.js main function instead of using the CLI entry point and spawning a new child process for each test. This makes tests much faster.

Doing it also allows removing the `escapeExecaOpt()` test helper and the `NETLIFY_BUILD_TEST` environment variable as a side effect.

Few tests still require calling the CLI entry point, mostly the tests testing the CLI entry point itself or flags that only exist in CLI such as `--help` or `--version`.