### PR TITLE
Fix test randomly failing

### DIFF
--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -48,7 +48,7 @@ const getEventFromChild = async function(childProcess, callId, { plugin, locatio
 }
 
 const childProcessHasExited = function(childProcess) {
-  return !childProcess.connected
+  return !childProcess.connected || childProcess.signalCode !== null || childProcess.exitCode !== null
 }
 
 const getMessage = async function(messagePromise) {


### PR DESCRIPTION
When a Build plugin has exited unexpectedly, we print an error message since we cannot communicate to that process anymore.

The current logic that checks whether the child process has exited is incomplete. It currently checks for `childProcess.connected` being `false`. However, in highly concurrent code like the tests, that attribute is sometimes not `false` yet, while `childProcess.exitCode` or `childProcess.signal` has been set. This makes some tests fail randomly.

This PR fixes this.