### PR TITLE
Fix randomly failing test

### DIFF
--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -259,7 +259,9 @@ test('Exits in plugins', async t => {
 
 // Process exit is different on Windows
 if (platform !== 'win32') {
-  test('Early exit', async t => {
+  // That test relies on timing due to IPC, so we need to run it serially to
+  // prevent race conditions
+  test.serial('Early exit', async t => {
     await runFixture(t, 'early_exit')
   })
 }


### PR DESCRIPTION
A test is randomly failing because it relies on process signals. Process signals are handled by the OS asynchronously, which introduces a timing dimension for this test to pass. Therefore, when tests are run in parallel on a slow machine, this test randomly fails. 

This PR fixes this by ensuring this specific test is not run in parallel.