### PR TITLE
Fix test failing on Node 8

### DIFF
--- a/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
+++ b/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
@@ -1,5 +1,10 @@
+const { promisify } = require('util')
+
+const pSetTimeout = promisify(setTimeout)
+
 module.exports = {
-  onBuild() {
+  async onBuild() {
     process.kill(process.env.TEST_PID)
+    await pSetTimeout(0)
   },
 }


### PR DESCRIPTION
This fixes a test that is failing on Node 8 (but not Node 14) due to the `child_process` logic having changed between those Node.js versions.