### PR TITLE
Fix randomly failing test

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -12405,6 +12405,15 @@
         "parse-ms": "^2.1.0"
       }
     },
+    "process-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/process-exists/-/process-exists-4.0.0.tgz",
+      "integrity": "sha512-BnlcYPiZjSW+fye12g9B7UeCzMAOdMkxuTz3zcytJ2BHwYZf2RoKvuuwUcJLeXlGj58x9YQrvhT21PmKhUc4UQ==",
+      "dev": true,
+      "requires": {
+        "ps-list": "^6.3.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -12414,6 +12423,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
+    "ps-list": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-6.3.0.tgz",
+      "integrity": "sha512-qau0czUSB0fzSlBOQt0bo+I2v6R+xiQdj78e1BR/Qjfl5OHWJ/urXi8+ilw1eHe+5hSeDI1wrwVTgDp2wst4oA==",
       "dev": true
     },
     "pseudomap": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -83,6 +83,7 @@
     "moize": "^5.4.6",
     "nock": "^11.9.1",
     "path-key": "^3.1.1",
+    "process-exists": "^4.0.0",
     "yarn": "^1.22.4"
   },
   "engines": {

--- a/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
+++ b/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
@@ -1,10 +1,16 @@
 const { promisify } = require('util')
 
+const processExists = require('process-exists')
+
 const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
   async onBuild() {
     process.kill(process.env.TEST_PID)
-    await pSetTimeout(0)
+
+    // Signals are async, so we need to wait for the child process to exit
+    while (await processExists(process.env.TEST_PID)) {
+      await pSetTimeout(1e2)
+    }
   },
 }

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -259,9 +259,7 @@ test('Exits in plugins', async t => {
 
 // Process exit is different on Windows
 if (platform !== 'win32') {
-  // That test relies on timing due to IPC, so we need to run it serially to
-  // prevent race conditions
-  test.serial('Early exit', async t => {
+  test('Early exit', async t => {
     await runFixture(t, 'early_exit')
   })
 }


### PR DESCRIPTION
One test relies on one Build plugin sending a process signal to another plugin. 
Signals are handled asynchronously by the OS. This made the test randomly fail due to this timing dimension. A previous PR #1484 partially fixed it using `test.serial()`, but this is not bullet-proof.

This PR uses a more resilient approach: poll using the `process-exists` library to wait until the other plugin's process has exited.