### PR TITLE
Small refactor of test helper

### DIFF
--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -71,11 +71,7 @@ const runFixtureCommon = async function(
 // Retrieve flags to the main entry point
 const getMainFlags = function({ fixtureName, copyRoot, copyRootDir, repositoryRoot, flags }) {
   const repositoryRootFlag = getRepositoryRootFlag({ fixtureName, copyRoot, copyRootDir, repositoryRoot })
-  return { ...DEFAULT_FLAGS, ...repositoryRootFlag, ...flags }
-}
-
-const DEFAULT_FLAGS = {
-  debug: true,
+  return { ...repositoryRootFlag, ...flags }
 }
 
 // The `repositoryRoot` flag can be overriden, but defaults to the fixture

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -13,7 +13,7 @@ const BUILD_BIN_DIR = normalize(`${ROOT_DIR}/node_modules/.bin`)
 
 const runFixture = async function(t, fixtureName, { flags = {}, env: envOption = {}, ...opts } = {}) {
   const binaryPath = await BINARY_PATH
-  const flagsA = { telemetry: false, buffer: true, ...flags }
+  const flagsA = { debug: true, telemetry: false, buffer: true, ...flags }
   const envOptionA = {
     // Ensure local environment variables aren't used during development
     BUILD_TELEMETRY_DISABLED: '',


### PR DESCRIPTION
The `debug` flag is passed to every test. However it is specific to `@netlify/build`, not `@netlify/config`, so should be moved to logic that is not common to both.