### PR TITLE
Fix color support

### DIFF
--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -3,8 +3,6 @@ const {
   inspect: { defaultOptions },
 } = require('util')
 
-const supportsColor = require('supports-color')
-
 // Ensure colors are used in the buildbot.
 // For `chalk`, underlying `supports-color` and `console.log()`.
 const setColorLevel = function() {
@@ -22,6 +20,10 @@ const setColorLevel = function() {
 // would normally lose colors. If the parent has colors, we pass an environment
 // variable to the child process to force colors.
 const getParentColorEnv = function() {
+  // This must be required after `env.FORCE_COLOR` has been set because it
+  // checks it at require-time.
+  const supportsColor = require('supports-color')
+
   if (supportsColor.stdout === false) {
     return {}
   }


### PR DESCRIPTION
We set the environment variable `FORCE_COLOR=1` in production because we use a non-interactive terminal because we still want to show colors in the browser.

This should be done before `supports-color` is required, because that library performs its function at require-time. This PR fixes this.

Otherwise, no colors are shown in production.