### PR TITLE
Remove dead code

### DIFF
--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -4,11 +4,11 @@ const { setOldProperty } = require('../error')
 const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
-const run = async function({ event, error, envChanges }, { pluginCommands, api, constants, inputs, netlifyConfig }) {
+const run = async function({ event, error, envChanges }, { pluginCommands, constants, inputs, netlifyConfig }) {
   const { method } = pluginCommands.find(pluginCommand => pluginCommand.event === event)
   const runState = {}
   const utils = getUtils({ constants, runState })
-  const runOptions = { api, utils, constants, inputs, netlifyConfig, error }
+  const runOptions = { utils, constants, inputs, netlifyConfig, error }
   validateOldSyntax(runOptions)
 
   const envBefore = setEnvChanges(envChanges)


### PR DESCRIPTION
This removes the `api` variable since it is now always `undefined` (the feature has been removed).