### PR TITLE
Simplify colors logic

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
 
-// This needs to be done before `chalk` is loaded.
-// Note: `chalk` is also required by some of our dependencies.
-// eslint-disable-next-line import/order
-const { setColorLevel } = require('../log/colors')
-setColorLevel()
-
 const process = require('process')
 
 const filterObj = require('filter-obj')

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -1,34 +1,36 @@
-const { env } = require('process')
 const {
   inspect: { defaultOptions },
 } = require('util')
 
-// Ensure colors are used in the buildbot.
-// For `chalk`, underlying `supports-color` and `console.log()`.
-const setColorLevel = function() {
-  // We cannot use the --mode CLI flag since this must be loaded before `chalk`.
-  if (!env.NETLIFY && env.PARENT_HAS_COLOR !== '1') {
-    return
-  }
-
-  env.FORCE_COLOR = '1'
-  defaultOptions.colors = true
-}
+const supportsColor = require('supports-color')
 
 // Plugin child processes use `stdio: 'pipe'` so they are always
 // non-interactive even if the parent is an interactive TTY. This means they
 // would normally lose colors. If the parent has colors, we pass an environment
 // variable to the child process to force colors.
 const getParentColorEnv = function() {
-  // This must be required after `env.FORCE_COLOR` has been set because it
-  // checks it at require-time.
-  const supportsColor = require('supports-color')
-
-  if (supportsColor.stdout === false) {
+  if (!hasColors()) {
     return {}
   }
 
-  return { PARENT_HAS_COLOR: '1' }
+  return { FORCE_COLOR: '1' }
 }
 
-module.exports = { setColorLevel, getParentColorEnv }
+// Child processes and the buildbot relies on `FORCE_COLOR=1` to set colors.
+// However `utils.inspect()` (used by `console.log()`) uses
+// `process.stdout.hasColors` which is always `undefined` when the TTY is
+// non-interactive. So we need to set `util.inspect.defaultOptions.colors`
+// manually both in plugin processes.
+const setInspectColors = function() {
+  if (!hasColors()) {
+    return
+  }
+
+  defaultOptions.colors = true
+}
+
+const hasColors = function() {
+  return supportsColor.stdout !== false
+}
+
+module.exports = { getParentColorEnv, setInspectColors }

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -1,11 +1,6 @@
 require('../../utils/polyfills')
 
-// This needs to be done before `chalk` is loaded
-// Note: `chalk` is also required by some of our dependencies.
-// eslint-disable-next-line import/order
-const { setColorLevel } = require('../../log/colors')
-setColorLevel()
-
+const { setInspectColors } = require('../../log/colors')
 const { sendEventToParent, getEventsFromParent } = require('../ipc')
 
 const { handleProcessErrors, handleError } = require('./error')
@@ -16,6 +11,7 @@ const { run } = require('./run')
 const bootPlugin = async function() {
   try {
     handleProcessErrors()
+    setInspectColors()
 
     const state = {}
     // We need to fire them in parallel because `process.send()` can be slow

--- a/packages/build/tests/log/tests.js
+++ b/packages/build/tests/log/tests.js
@@ -19,7 +19,11 @@ test('Colors in child process', async t => {
 })
 
 test('Netlify CI', async t => {
-  const { returnValue } = await runFixture(t, 'parent', { ...opts, flags: { dry: true }, env: { NETLIFY: 'true' } })
+  const { returnValue } = await runFixture(t, 'parent', {
+    ...opts,
+    flags: { dry: true, mode: 'buildbot' },
+    env: { FORCE_COLOR: '1' },
+  })
   t.true(hasAnsi(returnValue))
 })
 


### PR DESCRIPTION
The buildbot is now setting the `FORCE_COLOR` environment variable to `1` when calling `@netlify/build` (https://github.com/netlify/buildbot/pull/805).

Thanks to this, we can simplify the logic related to colors. We take care of several uses cases:
  - buildbot vs local plugins. Buildbot relies on setting `FORCE_COLOR=1`. Local builds usually happen in interactive TTYs, so they are automatically detected as supporting colors. This means colors are known at require-time, so `supports-color` does not need to dynamically loaded anymore.
  - colors in the parent process, in the build command, and in Build plugins
  - `FORCE_COLOR=1` in the buildbot forces colors in most libraries like `supports-color` (used by `chalk`)
  - `utils.inspect()` (used by `console.log()`) requires manually setting `utils.inspect.defaultOptions.colors`