### PR TITLE
Add support for `SITE_NAME`

### DIFF
--- a/packages/build/src/env/metadata.js
+++ b/packages/build/src/env/metadata.js
@@ -16,6 +16,8 @@ const ENVIRONMENT_VARIABLES = [
   // URL and IDs
   'BUILD_ID',
   'DEPLOY_ID',
+  'SITE_NAME',
+  'SITE_ID',
   'REPOSITORY_URL',
   'URL',
   'DEPLOY_URL',

--- a/packages/build/src/error/monitor/location.js
+++ b/packages/build/src/error/monitor/location.js
@@ -10,31 +10,14 @@ const getLocationMetadata = function(location, envMetadata) {
 }
 
 // Retrieve the URL to the build logs
-const getBuildLogs = function({ DEPLOY_URL, DEPLOY_ID }) {
-  const siteName = getSiteName(DEPLOY_URL)
-
-  if (siteName === undefined) {
+const getBuildLogs = function({ SITE_NAME, DEPLOY_ID }) {
+  if (SITE_NAME === undefined || DEPLOY_ID === undefined) {
     return
   }
 
-  return `${NETLIFY_ORIGIN}/sites/${siteName}/deploys/${DEPLOY_ID}`
+  return `${NETLIFY_ORIGIN}/sites/${SITE_NAME}/deploys/${DEPLOY_ID}`
 }
 
-// Retrieve the site's name using the `DEPLOY_URL`
-const getSiteName = function(DEPLOY_URL) {
-  if (DEPLOY_URL === undefined) {
-    return
-  }
-
-  const result = DEPLOY_URL_REGEXP.exec(DEPLOY_URL)
-  if (result === null) {
-    return
-  }
-
-  return result[1]
-}
-
-const DEPLOY_URL_REGEXP = /^https:\/\/[^-]+--(.*)\.netlify\.app$/
 const NETLIFY_ORIGIN = 'https://app.netlify.com'
 
 module.exports = { getLocationMetadata }

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -216,7 +216,7 @@ test('Report plugin origin', async t => {
 test('Report build logs URLs', async t => {
   await runFixture(t, 'command', {
     flags,
-    env: { DEPLOY_ID: 'testDeployId', DEPLOY_URL: 'https://testDeployId--testSiteName.netlify.app' },
+    env: { DEPLOY_ID: 'testDeployId', SITE_NAME: 'testSiteName' },
     useBinary: true,
   })
 })


### PR DESCRIPTION
The `SITE_NAME` and `SITE_ID` environment variables have just been added.

This PR allows us to simplify some code which was trying to figure out the site's name by extracting it from the `DEPLOY_URL` environment variable.

This PR also sends those two to Bugsnag on build errors, for debugging purpose.