### PR TITLE
Fix `utils.cache.list()` failing if `cwd` does not exist

### DIFF
--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -8,7 +8,7 @@ const { getBases } = require('./path')
 
 // List all cached files
 const list = async function({ cacheDir, mode } = {}) {
-  const bases = getBases()
+  const bases = await getBases()
   const cacheDirA = await getCacheDir({ cacheDir, mode })
   const files = await Promise.all(bases.map(baseInfo => listBase(baseInfo, cacheDirA)))
   const filesA = files.flat()

--- a/packages/cache-utils/src/utils/cwd.js
+++ b/packages/cache-utils/src/utils/cwd.js
@@ -1,0 +1,20 @@
+const process = require('process')
+
+const pathExists = require('path-exists')
+
+// Like `process.cwd()` but safer when current directory is wrong
+const safeGetCwd = async function() {
+  try {
+    const cwd = process.cwd()
+
+    if (!(await pathExists(cwd))) {
+      return ''
+    }
+
+    return cwd
+  } catch (error) {
+    return ''
+  }
+}
+
+module.exports = { safeGetCwd }

--- a/packages/cache-utils/tests/list.js
+++ b/packages/cache-utils/tests/list.js
@@ -1,3 +1,5 @@
+const process = require('process')
+
 const test = require('ava')
 
 const cacheUtils = require('..')
@@ -18,3 +20,19 @@ test('Should allow listing cached files', async t => {
 test('Should allow listing cached files without an options object', async t => {
   t.true(Array.isArray(await cacheUtils.list()))
 })
+
+// Windows does not allow deleting directory uses as current directory
+if (process.platform !== 'win32') {
+  // Need to use `test.serial()` due to `process.chdir()`
+  test.serial('Should work when cwd does not exist', async t => {
+    const tmpDir = await createTmpDir()
+    const oldCwd = process.cwd()
+    process.chdir(tmpDir)
+    await removeFiles(tmpDir)
+    try {
+      t.true(Array.isArray(await cacheUtils.list()))
+    } finally {
+      process.chdir(oldCwd)
+    }
+  })
+}


### PR DESCRIPTION
Fixes #1536.

There are several reasons why `cwd` might not exist when `utils.cache.list()`. For example, it might have been removed by the user or a plugin. Or the build might be canceling ([example deploy](https://app.netlify.com/sites/staffbase-staffbasetest/deploys/5eeb8d5b145f7c0008849492)).

When this happens, the build should not crash.