### PR TITLE
Fix invalid `cwd` in `cache` utility

### DIFF
--- a/packages/cache-utils/tests/path.js
+++ b/packages/cache-utils/tests/path.js
@@ -26,3 +26,35 @@ test('Should not allow caching the current directory', async t => {
 test('Should not allow caching a direct parent directory', async t => {
   await t.throwsAsync(cacheUtils.save('..'))
 })
+
+// Windows does not allow deleting directory uses as current directory
+if (process.platform !== 'win32') {
+  // Need to use `test.serial()` due to `process.chdir()`
+  test.serial('Should not allow invalid cwd with relative paths', async t => {
+    const tmpDir = await createTmpDir()
+    const oldCwd = process.cwd()
+    process.chdir(tmpDir)
+    await removeFiles(tmpDir)
+    try {
+      await t.throwsAsync(cacheUtils.save('test'))
+    } finally {
+      process.chdir(oldCwd)
+    }
+  })
+
+  test.serial('Should allow invalid cwd with absolute paths', async t => {
+    const [tmpDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
+    const oldCwd = process.cwd()
+    process.chdir(tmpDir)
+    await removeFiles(tmpDir)
+    try {
+      await t.notThrowsAsync(cacheUtils.save(srcFile))
+      await removeFiles(srcFile)
+      await t.notThrowsAsync(cacheUtils.restore(srcFile))
+      t.true(await pathExists(srcFile))
+    } finally {
+      process.chdir(oldCwd)
+      await removeFiles(srcDir)
+    }
+  })
+}


### PR DESCRIPTION
Fixes #1537 and #1538.

When `cwd` does not exist, `utils.cache.*` and the `path` is relative, the function must fail since we cannot resolve it (`cwd` being the base of that relative path). However, we should provide a better error message than the current one.

Also, when the `path` is an absolute path, `cwd` is not needed. We should not throw an error then if `cwd` does not exist.