### PR TITLE
Improve error message on invalid `cwd` in `git` utils

### DIFF
--- a/packages/git-utils/package-lock.json
+++ b/packages/git-utils/package-lock.json
@@ -2628,8 +2628,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -19,7 +19,8 @@
     "execa": "^3.4.0",
     "map-obj": "^4.1.0",
     "micromatch": "^4.0.2",
-    "moize": "^5.4.5"
+    "moize": "^5.4.5",
+    "path-exists": "^4.0.0"
   },
   "devDependencies": {
     "ava": "^2.4.0"

--- a/packages/git-utils/src/exec.js
+++ b/packages/git-utils/src/exec.js
@@ -1,12 +1,38 @@
+const process = require('process')
+
 const execa = require('execa')
 const moize = require('moize').default
+const pathExists = require('path-exists')
 
 // Fires the `git` binary. Memoized.
 const mGit = function(args, cwd) {
-  const { stdout } = execa.sync('git', args, { cwd })
+  const cwdA = safeGetCwd(cwd)
+  const { stdout } = execa.sync('git', args, { cwd: cwdA })
   return stdout
 }
 
 const git = moize(mGit, { isDeepEqual: true })
+
+const safeGetCwd = function(cwd) {
+  const cwdA = getCwdValue(cwd)
+
+  if (!pathExists.sync(cwdA)) {
+    throw new Error(`Current directory does not exist: ${cwdA}`)
+  }
+
+  return cwdA
+}
+
+const getCwdValue = function(cwd) {
+  if (cwd !== undefined) {
+    return cwd
+  }
+
+  try {
+    return process.cwd()
+  } catch (error) {
+    throw new Error('Current directory does not exist')
+  }
+}
 
 module.exports = { git }

--- a/packages/git-utils/src/main.js
+++ b/packages/git-utils/src/main.js
@@ -1,5 +1,3 @@
-const { cwd: getCwd } = require('process')
-
 const { getCommits } = require('./commits')
 const { getDiffFiles } = require('./diff')
 const { fileMatch } = require('./match')
@@ -7,7 +5,7 @@ const { getBase, getHead } = require('./refs')
 const { getLinesOfCode } = require('./stats')
 
 // Main entry point to the git utilities
-const getGitUtils = function({ base, head, cwd = getCwd() } = {}) {
+const getGitUtils = function({ base, head, cwd } = {}) {
   const headA = getHead(head)
   const baseA = getBase(base, headA, cwd)
   const { modifiedFiles, createdFiles, deletedFiles } = getDiffFiles(baseA, headA, cwd)

--- a/packages/git-utils/tests/main.js
+++ b/packages/git-utils/tests/main.js
@@ -68,6 +68,12 @@ test.serial('Should allow overriding the current directory', t => {
   }
 })
 
+test('Should throw when the current directory is invalid', t => {
+  t.throws(() => {
+    getGitUtils({ ...DEFAULT_OPTS, cwd: '/does/not/exist' })
+  })
+})
+
 test('Should return the number of lines of code', t => {
   const { linesOfCode } = getGitUtils(DEFAULT_OPTS)
   t.is(linesOfCode, 163)


### PR DESCRIPTION
Fixes #1540.

When the `cwd` option passed to `git-utils` points to a non-existing directory, we should throw a better error message.