### PR TITLE
Add `cwd` option to `utils.cache.*`

### DIFF
--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -101,6 +101,13 @@ module.exports = {
 }
 ```
 
+#### cwd
+
+_Type_: `string` \
+_Default_:`process.cwd()`
+
+Current directory used to resolve relative paths.
+
 ## restore(path, options?)
 
 `path`: `string`\
@@ -116,7 +123,14 @@ Returns `false` if the file/directory was not cached yet. Returns `true` otherwi
 
 ### options
 
-## remove(path)
+#### cwd
+
+_Type_: `string` \
+_Default_:`process.cwd()`
+
+Current directory used to resolve relative paths.
+
+## remove(path, options?)
 
 `path`: `string`\
 _Returns_: `Promise<Boolean>`
@@ -133,7 +147,16 @@ module.exports = {
 }
 ```
 
-## has(path)
+### options
+
+#### cwd
+
+_Type_: `string` \
+_Default_:`process.cwd()`
+
+Current directory used to resolve relative paths.
+
+## has(path, options?)
 
 `path`: `string`\
 _Returns_: `Promise<Boolean>`
@@ -165,7 +188,16 @@ module.exports = {
 }
 ```
 
-## list()
+### options
+
+#### cwd
+
+_Type_: `string` \
+_Default_:`process.cwd()`
+
+Current directory used to resolve relative paths.
+
+## list(options?)
 
 _Returns_: `Promise<string[]>`
 
@@ -180,3 +212,12 @@ module.exports = {
   },
 }
 ```
+
+### options
+
+#### cwd
+
+_Type_: `string` \
+_Default_:`process.cwd()`
+
+Current directory used to resolve relative paths.

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -7,8 +7,8 @@ const { isManifest } = require('./manifest')
 const { getBases } = require('./path')
 
 // List all cached files
-const list = async function({ cacheDir, mode } = {}) {
-  const bases = await getBases()
+const list = async function({ cacheDir, cwd: cwdOpt, mode } = {}) {
+  const bases = await getBases(cwdOpt)
   const cacheDirA = await getCacheDir({ cacheDir, mode })
   const files = await Promise.all(bases.map(baseInfo => listBase(baseInfo, cacheDirA)))
   const filesA = files.flat()

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -10,8 +10,11 @@ const { getManifestInfo, writeManifest, removeManifest, isExpired } = require('.
 const { parsePath } = require('./path')
 
 // Cache a file
-const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [], cacheDir, mode } = {}) {
-  const { srcPath, cachePath } = await parsePath({ path, cacheDir, mode })
+const saveOne = async function(
+  path,
+  { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [], cacheDir, cwd: cwdOpt, mode } = {},
+) {
+  const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   if (!(await pathExists(srcPath))) {
     return false
@@ -30,8 +33,8 @@ const saveOne = async function(path, { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, d
 }
 
 // Restore a cached file
-const restoreOne = async function(path, { move = DEFAULT_MOVE, cacheDir, mode } = {}) {
-  const { srcPath, cachePath } = await parsePath({ path, cacheDir, mode })
+const restoreOne = async function(path, { move = DEFAULT_MOVE, cacheDir, cwd: cwdOpt, mode } = {}) {
+  const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   if (!(await pathExists(cachePath))) {
     return false
@@ -48,8 +51,8 @@ const restoreOne = async function(path, { move = DEFAULT_MOVE, cacheDir, mode } 
 }
 
 // Remove the cache of a file
-const removeOne = async function(path, { cacheDir, mode } = {}) {
-  const { cachePath } = await parsePath({ path, cacheDir, mode })
+const removeOne = async function(path, { cacheDir, cwd: cwdOpt, mode } = {}) {
+  const { cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   if (!(await pathExists(cachePath))) {
     return false
@@ -62,8 +65,8 @@ const removeOne = async function(path, { cacheDir, mode } = {}) {
 }
 
 // Check if a file is cached
-const hasOne = async function(path, { cacheDir, mode } = {}) {
-  const { cachePath } = await parsePath({ path, cacheDir, mode })
+const hasOne = async function(path, { cacheDir, cwd: cwdOpt, mode } = {}) {
+  const { cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   return (await pathExists(cachePath)) && !(await isExpired(cachePath))
 }

--- a/packages/cache-utils/src/utils/cwd.js
+++ b/packages/cache-utils/src/utils/cwd.js
@@ -3,9 +3,9 @@ const process = require('process')
 const pathExists = require('path-exists')
 
 // Like `process.cwd()` but safer when current directory is wrong
-const safeGetCwd = async function() {
+const safeGetCwd = async function(cwdOpt) {
   try {
-    const cwd = process.cwd()
+    const cwd = getCwdValue(cwdOpt)
 
     if (!(await pathExists(cwd))) {
       return ''
@@ -15,6 +15,10 @@ const safeGetCwd = async function() {
   } catch (error) {
     return ''
   }
+}
+
+const getCwdValue = function(cwdOpt = process.cwd()) {
+  return cwdOpt
 }
 
 module.exports = { safeGetCwd }

--- a/packages/cache-utils/tests/list.js
+++ b/packages/cache-utils/tests/list.js
@@ -23,16 +23,9 @@ test('Should allow listing cached files without an options object', async t => {
 
 // Windows does not allow deleting directory uses as current directory
 if (process.platform !== 'win32') {
-  // Need to use `test.serial()` due to `process.chdir()`
-  test.serial('Should work when cwd does not exist', async t => {
+  test('Should work when cwd does not exist', async t => {
     const tmpDir = await createTmpDir()
-    const oldCwd = process.cwd()
-    process.chdir(tmpDir)
     await removeFiles(tmpDir)
-    try {
-      t.true(Array.isArray(await cacheUtils.list()))
-    } finally {
-      process.chdir(oldCwd)
-    }
+    t.true(Array.isArray(await cacheUtils.list({ cwd: tmpDir })))
   })
 }

--- a/packages/cache-utils/tests/path.js
+++ b/packages/cache-utils/tests/path.js
@@ -29,31 +29,21 @@ test('Should not allow caching a direct parent directory', async t => {
 
 // Windows does not allow deleting directory uses as current directory
 if (process.platform !== 'win32') {
-  // Need to use `test.serial()` due to `process.chdir()`
-  test.serial('Should not allow invalid cwd with relative paths', async t => {
+  test('Should not allow invalid cwd with relative paths', async t => {
     const tmpDir = await createTmpDir()
-    const oldCwd = process.cwd()
-    process.chdir(tmpDir)
     await removeFiles(tmpDir)
-    try {
-      await t.throwsAsync(cacheUtils.save('test'))
-    } finally {
-      process.chdir(oldCwd)
-    }
+    await t.throwsAsync(cacheUtils.save('test', { cwd: tmpDir }))
   })
 
-  test.serial('Should allow invalid cwd with absolute paths', async t => {
+  test('Should allow invalid cwd with absolute paths', async t => {
     const [tmpDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
-    const oldCwd = process.cwd()
-    process.chdir(tmpDir)
     await removeFiles(tmpDir)
     try {
-      await t.notThrowsAsync(cacheUtils.save(srcFile))
+      await t.notThrowsAsync(cacheUtils.save(srcFile, { cwd: tmpDir }))
       await removeFiles(srcFile)
-      await t.notThrowsAsync(cacheUtils.restore(srcFile))
+      await t.notThrowsAsync(cacheUtils.restore(srcFile, { cwd: tmpDir }))
       t.true(await pathExists(srcFile))
     } finally {
-      process.chdir(oldCwd)
       await removeFiles(srcDir)
     }
   })


### PR DESCRIPTION
This adds a `cwd` option to all `utils.cache.*` methods to modify the current directory. The current directory is used mostly to resolve relative paths passed as arguments. 

This is useful in testing, and few tests are simplified thanks to this.