### PR TITLE
Add `utils.functions.listAll()`

### DIFF
--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -32,7 +32,8 @@ const getFunctionsUtils = function(FUNCTIONS_SRC) {
   const functionsUtils = require('@netlify/functions-utils')
   const add = src => functionsUtils.add(src, FUNCTIONS_SRC, { fail: failBuild })
   const list = functionsUtils.list.bind(null, FUNCTIONS_SRC, { fail: failBuild })
-  return { add, list }
+  const listAll = functionsUtils.listAll.bind(null, FUNCTIONS_SRC, { fail: failBuild })
+  return { add, list, listAll }
 }
 
 const getStatusUtils = function(runState) {

--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -27,15 +27,24 @@ module.exports = {
 
 _Returns_: `Promise<object[]>`
 
-Returns the list of Netlify Functions as a Promise resolving to an array of objects with the following properties:
+Returns the list of Netlify Functions main files as a Promise resolving to an array of objects with the following
+properties:
 
 - `mainFile` `{string}`: absolute path to the Function's main file
-- `srcFiles` `{string[]}`: absolute path to all the Function's files (main files and required files)
 - `extension` `{string}`: file extension of the Function's main file. For Go Functions, this might be an empty string.
   For Node.js Functions, this is either `.js` or `.zip`.
 - `runtime` `"js" | "go"`: Function's programming language
 
 This throws when no `functions` directory was specified by the user, or when it points to a non-existing directory.
+
+## listAll()
+
+_Returns_: `Promise<object[]>`
+
+Same as `list()` except it also returns the files required by the Functions main files. This is much slower. The object
+have the following additional member:
+
+- `srcFile` `{string}`: absolute path to the file
 
 ## add(path)
 

--- a/packages/functions-utils/src/main.js
+++ b/packages/functions-utils/src/main.js
@@ -2,7 +2,7 @@ const { stat } = require('fs')
 const { basename, dirname } = require('path')
 const { promisify } = require('util')
 
-const { listFunctions } = require('@netlify/zip-it-and-ship-it')
+const { listFunctions, listFunctionsFiles } = require('@netlify/zip-it-and-ship-it')
 const cpy = require('cpy')
 const pathExists = require('path-exists')
 
@@ -55,8 +55,20 @@ const list = async function(functionsSrc, { fail = defaultFail } = {}) {
   }
 }
 
+const listAll = async function(functionsSrc, { fail = defaultFail } = {}) {
+  if (functionsSrc === undefined) {
+    return fail('No function directory was specified')
+  }
+
+  try {
+    return await listFunctionsFiles(functionsSrc)
+  } catch (error) {
+    fail('Could not list Netlify Functions files', { error })
+  }
+}
+
 const defaultFail = function(message) {
   throw new Error(message)
 }
 
-module.exports = { add, list }
+module.exports = { add, list, listAll }

--- a/packages/functions-utils/tests/main.js
+++ b/packages/functions-utils/tests/main.js
@@ -3,7 +3,7 @@ const { normalize } = require('path')
 const test = require('ava')
 const pathExists = require('path-exists')
 
-const { add, list } = require('..')
+const { add, list, listAll } = require('..')
 
 const { getDist, createDist, removeDist } = require('./helpers/main')
 
@@ -80,23 +80,39 @@ test('Should allow "fail" option to customize failures', async t => {
   t.is(typeof failMessage, 'string')
 })
 
-const normalizeFiles = function(fixtureDir, { mainFile, runtime, extension, srcFiles }) {
+const normalizeFiles = function(fixtureDir, { mainFile, runtime, extension, srcFile }) {
   const mainFileA = normalize(`${fixtureDir}/${mainFile}`)
-  const srcFilesA = srcFiles.map(file => normalize(`${fixtureDir}/${file}`))
-  return { mainFile: mainFileA, runtime, extension, srcFiles: srcFilesA }
+  const srcFileA = srcFile === undefined ? {} : { srcFile: normalize(`${fixtureDir}/${srcFile}`) }
+  return { mainFile: mainFileA, runtime, extension, ...srcFileA }
 }
 
-test.skip('Can list function file with list()', async t => {
+test('Can list function main files with list()', async t => {
   const fixtureDir = `${FIXTURES_DIR}/list`
   const functions = await list(fixtureDir)
   t.deepEqual(
     functions,
     [
-      { mainFile: 'one/index.js', runtime: 'js', extension: '.js', srcFiles: ['one/index.js'] },
-      { mainFile: 'test', runtime: 'go', extension: '', srcFiles: ['test'] },
-      { mainFile: 'test.js', runtime: 'js', extension: '.js', srcFiles: ['test.js'] },
-      { mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFiles: ['test.zip'] },
-      { mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFiles: ['two/three.js', 'two/two.js'] },
+      { mainFile: 'one/index.js', runtime: 'js', extension: '.js' },
+      { mainFile: 'test', runtime: 'go', extension: '' },
+      { mainFile: 'test.js', runtime: 'js', extension: '.js' },
+      { mainFile: 'test.zip', runtime: 'js', extension: '.zip' },
+      { mainFile: 'two/two.js', runtime: 'js', extension: '.js' },
+    ].map(normalizeFiles.bind(null, fixtureDir)),
+  )
+})
+
+test('Can list all function files with listAll()', async t => {
+  const fixtureDir = `${FIXTURES_DIR}/list`
+  const functions = await listAll(fixtureDir)
+  t.deepEqual(
+    functions,
+    [
+      { mainFile: 'one/index.js', runtime: 'js', extension: '.js', srcFile: 'one/index.js' },
+      { mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
+      { mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
+      { mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
+      { mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/three.js' },
+      { mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
     ].map(normalizeFiles.bind(null, fixtureDir)),
   )
 })


### PR DESCRIPTION
This is a follow-up on similar issues to fix `utils.functions.list()` performance by making it use `listFunctions()` instead of `listFunctionsFiles()` which is much slower. This PR does it by adding `utils.functions.listAll()` which returns all Functions required files (much slower). This is useful for `neltify-plugin-inline-functions-env` for example (see https://github.com/bencao/netlify-plugin-inline-functions-env/pull/6).