### PR TITLE
Do not print `@netlify/config` CLI flags twice

### DIFF
--- a/packages/config/src/log/main.js
+++ b/packages/config/src/log/main.js
@@ -2,8 +2,10 @@ const { cleanupConfig } = require('./cleanup')
 const { cleanupConfigOpts } = require('./options')
 
 // Log options in debug mode.
-const logOpts = function(opts, { debug }) {
-  if (!debug) {
+const logOpts = function(opts, { debug, cachedConfig }) {
+  // In production, print those in the first call to `@netlify/config`, not the
+  // second one done inside `@netlify/build`
+  if (!debug || cachedConfig !== undefined) {
     return
   }
 


### PR DESCRIPTION
In debug mode, the CLI flags of `@netlify/config` are printed. 

However, in production, `@netlify/config` is called twice: first directly (so that buildbot can use the result) and then inside `@netlify/build` itself. To prevent doing the logic twice, we use a `cachedConfig` CLI flag to re-use the result of the first call.

On the second call, we should not print the CLI flags again. This PR fixes this.