### PR TITLE
Add more documentation about --debug `@netlify/config` flag

### DIFF
--- a/packages/config/src/bin/flags.js
+++ b/packages/config/src/bin/flags.js
@@ -83,6 +83,11 @@ Default: true`,
   - 'require': through require('@netlify/config')`,
     hidden: true,
   },
+  debug: {
+    boolean: true,
+    describe: 'Print debugging information',
+    hidden: true,
+  },
 }
 
 const USAGE = `netlify-config [OPTIONS...]


### PR DESCRIPTION
This marks the `--debug` `@netlify/config` CLI flag as an undocumented flag.