### PR TITLE
Fix `utils.cache.list()` crashing builds

### DIFF
--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -104,7 +104,7 @@ module.exports = {
 #### cwd
 
 _Type_: `string` \
-_Default_:`process.cwd()`
+_Default_: `process.cwd()`
 
 Current directory used to resolve relative paths.
 
@@ -126,7 +126,7 @@ Returns `false` if the file/directory was not cached yet. Returns `true` otherwi
 #### cwd
 
 _Type_: `string` \
-_Default_:`process.cwd()`
+_Default_: `process.cwd()`
 
 Current directory used to resolve relative paths.
 
@@ -152,7 +152,7 @@ module.exports = {
 #### cwd
 
 _Type_: `string` \
-_Default_:`process.cwd()`
+_Default_: `process.cwd()`
 
 Current directory used to resolve relative paths.
 
@@ -193,7 +193,7 @@ module.exports = {
 #### cwd
 
 _Type_: `string` \
-_Default_:`process.cwd()`
+_Default_: `process.cwd()`
 
 Current directory used to resolve relative paths.
 
@@ -218,6 +218,13 @@ module.exports = {
 #### cwd
 
 _Type_: `string` \
-_Default_:`process.cwd()`
+_Default_: `process.cwd()`
 
 Current directory used to resolve relative paths.
+
+#### depth
+
+_Type_: `number` \
+_Default_: `1`
+
+Number of subdirectories to include. `0` means only top-level directories will be included.

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -7,17 +7,19 @@ const { isManifest } = require('./manifest')
 const { getBases } = require('./path')
 
 // List all cached files/directories, at the top-level
-const list = async function({ cacheDir, cwd: cwdOpt, mode } = {}) {
+const list = async function({ cacheDir, cwd: cwdOpt, mode, depth = DEFAULT_DEPTH } = {}) {
   const bases = await getBases(cwdOpt)
   const cacheDirA = await getCacheDir({ cacheDir, mode })
-  const files = await Promise.all(bases.map(baseInfo => listBase(baseInfo, cacheDirA)))
+  const files = await Promise.all(bases.map(({ name, base }) => listBase({ name, base, cacheDir: cacheDirA, depth })))
   const filesA = files.flat()
   return filesA
 }
 
+const DEFAULT_DEPTH = 1
+
 // TODO: the returned paths are missing the Windows drive
-const listBase = async function({ name, base }, cacheDir) {
-  const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter, depth: 1, type: 'all' })
+const listBase = async function({ name, base, cacheDir, depth }) {
+  const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter, depth, type: 'all' })
   const filesA = files.map(({ path }) => join(base, path))
   return filesA
 }

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -19,7 +19,7 @@ const DEFAULT_DEPTH = 1
 
 // TODO: the returned paths are missing the Windows drive
 const listBase = async function({ name, base, cacheDir, depth }) {
-  const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter, depth, type: 'all' })
+  const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter, depth, type: 'files_directories' })
   const filesA = files.map(({ path }) => join(base, path))
   return filesA
 }

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -6,7 +6,7 @@ const { getCacheDir } = require('./dir')
 const { isManifest } = require('./manifest')
 const { getBases } = require('./path')
 
-// List all cached files
+// List all cached files/directories, at the top-level
 const list = async function({ cacheDir, cwd: cwdOpt, mode } = {}) {
   const bases = await getBases(cwdOpt)
   const cacheDirA = await getCacheDir({ cacheDir, mode })
@@ -17,7 +17,7 @@ const list = async function({ cacheDir, cwd: cwdOpt, mode } = {}) {
 
 // TODO: the returned paths are missing the Windows drive
 const listBase = async function({ name, base }, cacheDir) {
-  const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter })
+  const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter, depth: 1, type: 'all' })
   const filesA = files.map(({ path }) => join(base, path))
   return filesA
 }

--- a/packages/cache-utils/tests/list.js
+++ b/packages/cache-utils/tests/list.js
@@ -19,6 +19,19 @@ test('Should allow listing cached files', async t => {
   }
 })
 
+test('Should allow changing the listing depth', async t => {
+  const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
+  try {
+    t.deepEqual(await cacheUtils.list({ cacheDir }), [])
+    t.true(await cacheUtils.save(srcFile, { cacheDir }))
+    const files = await cacheUtils.list({ cacheDir, depth: 0 })
+    t.is(files.length, 1)
+    t.true(files.every(file => srcFile.replace(/^[a-zA-Z]:\\/, '\\').startsWith(file)))
+  } finally {
+    await removeFiles([cacheDir, srcDir])
+  }
+})
+
 test('Should allow listing cached files without an options object', async t => {
   t.true(Array.isArray(await cacheUtils.list()))
 })

--- a/packages/cache-utils/tests/list.js
+++ b/packages/cache-utils/tests/list.js
@@ -11,7 +11,9 @@ test('Should allow listing cached files', async t => {
   try {
     t.deepEqual(await cacheUtils.list({ cacheDir }), [])
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
-    t.deepEqual(await cacheUtils.list({ cacheDir }), [srcFile.replace(/^[a-zA-Z]:\\/, '\\')])
+    const files = await cacheUtils.list({ cacheDir })
+    t.is(files.length, 2)
+    t.true(files.every(file => srcFile.replace(/^[a-zA-Z]:\\/, '\\').startsWith(file)))
   } finally {
     await removeFiles([cacheDir, srcDir])
   }


### PR DESCRIPTION
Part of #1362.

`utils.cache.list()` crashes some builds when there are too many files cached. This PR fixes this by only returning the first 2 depth levels of directories/files being cached.

This PR also makes `utils.cache.list()` return directories, not only files, as described in #1362.