### PR TITLE
Downgrade chalk

### DIFF
--- a/packages/config/package-lock.json
+++ b/packages/config/package-lock.json
@@ -1279,9 +1279,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "array-flat-polyfill": "^1.0.1",
-    "chalk": "^4.1.0",
+    "chalk": "^3.0.0",
     "deepmerge": "^4.2.2",
     "execa": "^3.4.0",
     "fast-safe-stringify": "^2.0.7",


### PR DESCRIPTION
`chalk@4` is not compatible with Node `8.3.0`, so we need to downgrade to `chalk@3`.