### PR TITLE
Split a file into two

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -1,44 +1,10 @@
-const { env, execPath } = require('process')
-
 const resolveConfig = require('@netlify/config')
 
 const { getChildEnv } = require('../env/main')
 const { addApiErrorHandlers } = require('../error/api')
 const { addErrorInfo } = require('../error/info')
-const { logFlags, logBuildDir, logConfigPath, logConfig, logContext } = require('../log/main')
+const { logBuildDir, logConfigPath, logConfig, logContext } = require('../log/main')
 const { getPackageJson } = require('../utils/package')
-const { removeFalsy } = require('../utils/remove_falsy')
-
-// Normalize CLI flags
-const normalizeFlags = function(flags, logs) {
-  const rawFlags = removeFalsy(flags)
-  const defaultFlags = getDefaultFlags(rawFlags)
-  const mergedFlags = { ...defaultFlags, ...rawFlags }
-  const normalizedFlags = removeFalsy(mergedFlags)
-
-  logFlags(logs, rawFlags, normalizedFlags)
-
-  return normalizedFlags
-}
-
-// Default values of CLI flags
-const getDefaultFlags = function({ env: envOpt = {} }) {
-  const combinedEnv = { ...env, ...envOpt }
-  return {
-    env: envOpt,
-    nodePath: execPath,
-    token: combinedEnv.NETLIFY_AUTH_TOKEN,
-    mode: 'require',
-    functionsDistDir: DEFAULT_FUNCTIONS_DIST,
-    deployId: combinedEnv.DEPLOY_ID,
-    debug: Boolean(combinedEnv.NETLIFY_BUILD_DEBUG),
-    bugsnagKey: combinedEnv.BUGSNAG_KEY,
-    telemetry: !combinedEnv.BUILD_TELEMETRY_DISABLED,
-    testOpts: {},
-  }
-}
-
-const DEFAULT_FUNCTIONS_DIST = '.netlify/functions/'
 
 // Retrieve configuration object
 const loadConfig = async function({
@@ -142,4 +108,4 @@ const resolveFullConfig = async function({
   }
 }
 
-module.exports = { normalizeFlags, loadConfig }
+module.exports = { loadConfig }

--- a/packages/build/src/core/flags.js
+++ b/packages/build/src/core/flags.js
@@ -1,0 +1,37 @@
+const { env, execPath } = require('process')
+
+const { logFlags } = require('../log/main')
+const { removeFalsy } = require('../utils/remove_falsy')
+
+// Normalize CLI flags
+const normalizeFlags = function(flags, logs) {
+  const rawFlags = removeFalsy(flags)
+  const defaultFlags = getDefaultFlags(rawFlags)
+  const mergedFlags = { ...defaultFlags, ...rawFlags }
+  const normalizedFlags = removeFalsy(mergedFlags)
+
+  logFlags(logs, rawFlags, normalizedFlags)
+
+  return normalizedFlags
+}
+
+// Default values of CLI flags
+const getDefaultFlags = function({ env: envOpt = {} }) {
+  const combinedEnv = { ...env, ...envOpt }
+  return {
+    env: envOpt,
+    nodePath: execPath,
+    token: combinedEnv.NETLIFY_AUTH_TOKEN,
+    mode: 'require',
+    functionsDistDir: DEFAULT_FUNCTIONS_DIST,
+    deployId: combinedEnv.DEPLOY_ID,
+    debug: Boolean(combinedEnv.NETLIFY_BUILD_DEBUG),
+    bugsnagKey: combinedEnv.BUGSNAG_KEY,
+    telemetry: !combinedEnv.BUILD_TELEMETRY_DISABLED,
+    testOpts: {},
+  }
+}
+
+const DEFAULT_FUNCTIONS_DIST = '.netlify/functions/'
+
+module.exports = { normalizeFlags }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -16,9 +16,10 @@ const { reportStatuses } = require('../status/report')
 const { trackBuildComplete } = require('../telemetry/complete')
 
 const { getCommands, runCommands } = require('./commands')
-const { normalizeFlags, loadConfig } = require('./config')
+const { loadConfig } = require('./config')
 const { getConstants } = require('./constants')
 const { doDryRun } = require('./dry')
+const { normalizeFlags } = require('./flags')
 
 /**
  * Main entry point of Netlify Build.


### PR DESCRIPTION
This splits a file into two: one for the flags parsing, and one for the configuration parsing.