### PR TITLE
Move logic to retrieve `constants`

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -9,8 +9,6 @@ const { logFlags, logBuildDir, logConfigPath, logConfig, logContext } = require(
 const { getPackageJson } = require('../utils/package')
 const { removeFalsy } = require('../utils/remove_falsy')
 
-const { getConstants } = require('./constants')
-
 // Normalize CLI flags
 const normalizeFlags = function(flags, logs) {
   const rawFlags = removeFalsy(flags)
@@ -49,7 +47,6 @@ const loadConfig = async function({
   cachedConfig,
   cwd,
   repositoryRoot,
-  functionsDistDir,
   token,
   siteId,
   context,
@@ -88,13 +85,12 @@ const loadConfig = async function({
   logConfigInfo({ logs, configPath, buildDir, netlifyConfig, context: contextA, debug })
 
   const apiA = addApiErrorHandlers(api)
-  const [constants, childEnv, { packageJson: sitePackageJson }] = await Promise.all([
-    getConstants({ configPath, buildDir, functionsDistDir, netlifyConfig, siteInfo, mode }),
+  const [childEnv, { packageJson: sitePackageJson }] = await Promise.all([
     getChildEnv({ netlifyConfig, buildDir, context: contextA, branch: branchA, siteInfo, deployId, envOpt, mode }),
     getPackageJson(buildDir, { normalize: false }),
   ])
 
-  return { netlifyConfig, configPath, buildDir, childEnv, sitePackageJson, api: apiA, siteInfo, constants }
+  return { netlifyConfig, configPath, buildDir, childEnv, sitePackageJson, api: apiA, siteInfo }
 }
 
 const logConfigInfo = function({ logs, configPath, buildDir, netlifyConfig, context, debug }) {

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -17,6 +17,7 @@ const { trackBuildComplete } = require('../telemetry/complete')
 
 const { getCommands, runCommands } = require('./commands')
 const { normalizeFlags, loadConfig } = require('./config')
+const { getConstants } = require('./constants')
 const { doDryRun } = require('./dry')
 
 /**
@@ -43,6 +44,7 @@ const { doDryRun } = require('./dry')
 const build = async function(flags = {}) {
   const {
     nodePath,
+    functionsDistDir,
     buildImagePluginsDir,
     dry,
     mode,
@@ -56,16 +58,13 @@ const build = async function(flags = {}) {
   } = startBuild(flags)
 
   try {
-    const {
-      netlifyConfig,
-      configPath,
-      buildDir,
-      childEnv,
-      sitePackageJson,
-      api,
-      siteInfo,
-      constants,
-    } = await loadConfig({ ...flagsA, mode, deployId, logs, testOpts })
+    const { netlifyConfig, configPath, buildDir, childEnv, sitePackageJson, api, siteInfo } = await loadConfig({
+      ...flagsA,
+      mode,
+      deployId,
+      logs,
+      testOpts,
+    })
 
     try {
       const { commandsCount } = await runAndReportBuild({
@@ -75,9 +74,10 @@ const build = async function(flags = {}) {
         nodePath,
         childEnv,
         sitePackageJson,
+        functionsDistDir,
         buildImagePluginsDir,
         dry,
-        constants,
+        siteInfo,
         mode,
         api,
         errorMonitor,
@@ -134,9 +134,10 @@ const runAndReportBuild = async function({
   nodePath,
   childEnv,
   sitePackageJson,
+  functionsDistDir,
   buildImagePluginsDir,
   dry,
-  constants,
+  siteInfo,
   mode,
   api,
   errorMonitor,
@@ -152,9 +153,10 @@ const runAndReportBuild = async function({
       nodePath,
       childEnv,
       sitePackageJson,
+      functionsDistDir,
       buildImagePluginsDir,
       dry,
-      constants,
+      siteInfo,
       mode,
       errorMonitor,
       logs,
@@ -184,14 +186,16 @@ const initAndRunBuild = async function({
   nodePath,
   childEnv,
   sitePackageJson,
+  functionsDistDir,
   buildImagePluginsDir,
   dry,
-  constants,
+  siteInfo,
   mode,
   errorMonitor,
   logs,
   testOpts,
 }) {
+  const constants = await getConstants({ configPath, buildDir, functionsDistDir, netlifyConfig, siteInfo, mode })
   const pluginsOptions = await getPluginsOptions({
     netlifyConfig,
     buildDir,


### PR DESCRIPTION
This moves the function that retrieves `constants` later in the logic, closer to where it is actually used. This is refactoring only.