### PR TITLE
Move `package.json` retrieval

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -4,7 +4,6 @@ const { getChildEnv } = require('../env/main')
 const { addApiErrorHandlers } = require('../error/api')
 const { addErrorInfo } = require('../error/info')
 const { logBuildDir, logConfigPath, logConfig, logContext } = require('../log/main')
-const { getPackageJson } = require('../utils/package')
 
 // Retrieve configuration object
 const loadConfig = async function({
@@ -51,12 +50,17 @@ const loadConfig = async function({
   logConfigInfo({ logs, configPath, buildDir, netlifyConfig, context: contextA, debug })
 
   const apiA = addApiErrorHandlers(api)
-  const [childEnv, { packageJson: sitePackageJson }] = await Promise.all([
-    getChildEnv({ netlifyConfig, buildDir, context: contextA, branch: branchA, siteInfo, deployId, envOpt, mode }),
-    getPackageJson(buildDir, { normalize: false }),
-  ])
-
-  return { netlifyConfig, configPath, buildDir, childEnv, sitePackageJson, api: apiA, siteInfo }
+  const childEnv = await getChildEnv({
+    netlifyConfig,
+    buildDir,
+    context: contextA,
+    branch: branchA,
+    siteInfo,
+    deployId,
+    envOpt,
+    mode,
+  })
+  return { netlifyConfig, configPath, buildDir, childEnv, api: apiA, siteInfo }
 }
 
 const logConfigInfo = function({ logs, configPath, buildDir, netlifyConfig, context, debug }) {

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -59,7 +59,7 @@ const build = async function(flags = {}) {
   } = startBuild(flags)
 
   try {
-    const { netlifyConfig, configPath, buildDir, childEnv, sitePackageJson, api, siteInfo } = await loadConfig({
+    const { netlifyConfig, configPath, buildDir, childEnv, api, siteInfo } = await loadConfig({
       ...flagsA,
       mode,
       deployId,
@@ -74,7 +74,6 @@ const build = async function(flags = {}) {
         buildDir,
         nodePath,
         childEnv,
-        sitePackageJson,
         functionsDistDir,
         buildImagePluginsDir,
         dry,
@@ -134,7 +133,6 @@ const runAndReportBuild = async function({
   buildDir,
   nodePath,
   childEnv,
-  sitePackageJson,
   functionsDistDir,
   buildImagePluginsDir,
   dry,
@@ -153,7 +151,6 @@ const runAndReportBuild = async function({
       buildDir,
       nodePath,
       childEnv,
-      sitePackageJson,
       functionsDistDir,
       buildImagePluginsDir,
       dry,
@@ -186,7 +183,6 @@ const initAndRunBuild = async function({
   buildDir,
   nodePath,
   childEnv,
-  sitePackageJson,
   functionsDistDir,
   buildImagePluginsDir,
   dry,
@@ -217,7 +213,6 @@ const initAndRunBuild = async function({
       buildDir,
       nodePath,
       childEnv,
-      sitePackageJson,
       dry,
       constants,
       errorMonitor,
@@ -240,7 +235,6 @@ const runBuild = async function({
   buildDir,
   nodePath,
   childEnv,
-  sitePackageJson,
   dry,
   constants,
   errorMonitor,
@@ -262,7 +256,6 @@ const runBuild = async function({
     buildDir,
     nodePath,
     childEnv,
-    sitePackageJson,
     errorMonitor,
     netlifyConfig,
     logs,


### PR DESCRIPTION
We retrieve the site's `package.json` in order to print a warning related to the `CI=true` issues. 
At the moment, we always retrieve it, top-level. Instead, we should only retrieve it when that warning is about to be printed. This is faster.