### PR TITLE
Move build error handling logic to its own function

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -105,9 +105,7 @@ const build = async function(flags = {}) {
       throw error
     }
   } catch (error) {
-    removeErrorColors(error)
-    await reportBuildError({ error, errorMonitor, logs, testOpts })
-    logBuildError({ error, logs })
+    await handleBuildFailure({ error, errorMonitor, logs, testOpts })
     return { success: false, logs }
   }
 }
@@ -272,6 +270,13 @@ const handleBuildSuccess = async function({
 
   const duration = endTimer(logs, buildTimer, 'Netlify Build')
   await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, telemetry, mode, testOpts })
+}
+
+// Logs and reports that a build failed
+const handleBuildFailure = async function({ error, errorMonitor, logs, testOpts }) {
+  removeErrorColors(error)
+  await reportBuildError({ error, errorMonitor, logs, testOpts })
+  logBuildError({ error, logs })
 }
 
 module.exports = build


### PR DESCRIPTION
This moves the main logic handling build failures into its own function. This is refactoring only.