### PR TITLE
Improve error message normalization

### DIFF
--- a/packages/build/src/error/monitor/normalize.js
+++ b/packages/build/src/error/monitor/normalize.js
@@ -48,7 +48,7 @@ const NORMALIZE_REGEXPS = [
   // Numbers, e.g. number of issues/problems
   [/\d+/g, '0'],
   // Hexadecimal strings
-  [/[0-9a-fA-F]{6,}/, 'hex'],
+  [/[0-9a-fA-F]{6,}/g, 'hex'],
   // On unknown inputs, we print the inputs
   [/(does not accept any inputs but you specified: ).*/, '$1'],
   [/(Unknown inputs for plugin).*/, '$1'],


### PR DESCRIPTION
This fixes a missing `g` flag on a regular expression used to normalize error keys passed to Bugsnag.