### PR TITLE
Move `childEnv`-related logic

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -186,6 +186,7 @@ const runCommand = async function({
       ? handleCommandSuccess({ event, package, newEnvChanges, newStatus, methodTimer, logs })
       : await handleCommandError({
           newError,
+          childEnv,
           api,
           errorMonitor,
           deployId,
@@ -382,6 +383,7 @@ const handleCommandSuccess = function({ event, package, newEnvChanges, newStatus
 //    handlers of that plugin. But do not stop build.
 const handleCommandError = async function({
   newError,
+  childEnv,
   api,
   errorMonitor,
   deployId,
@@ -404,14 +406,23 @@ const handleCommandError = async function({
   }
 
   if (type === 'failPlugin' || event === 'onSuccess') {
-    return handleFailPlugin({ newStatus, package, newError, errorMonitor, netlifyConfig, logs, testOpts })
+    return handleFailPlugin({ newStatus, package, newError, childEnv, errorMonitor, netlifyConfig, logs, testOpts })
   }
 
   return { newError, newStatus }
 }
-const handleFailPlugin = async function({ newStatus, package, newError, errorMonitor, netlifyConfig, logs, testOpts }) {
+const handleFailPlugin = async function({
+  newStatus,
+  package,
+  newError,
+  childEnv,
+  errorMonitor,
+  netlifyConfig,
+  logs,
+  testOpts,
+}) {
   logBuildError({ error: newError, netlifyConfig, logs })
-  await reportBuildError({ error: newError, errorMonitor, logs, testOpts })
+  await reportBuildError({ error: newError, errorMonitor, childEnv, logs, testOpts })
   return { failedPlugin: [package], newStatus }
 }
 

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -14,7 +14,7 @@ const { normalizeGroupingMessage } = require('./normalize')
 const { printEventForTest } = require('./print')
 
 // Report a build failure for monitoring purpose
-const reportBuildError = async function({ error, errorMonitor, logs, testOpts }) {
+const reportBuildError = async function({ error, errorMonitor, childEnv, logs, testOpts }) {
   if (errorMonitor === undefined) {
     return
   }
@@ -24,7 +24,7 @@ const reportBuildError = async function({ error, errorMonitor, logs, testOpts })
   const severityA = getSeverity(severity, errorInfo)
   const groupA = getGroup(group, errorInfo)
   const groupingHash = getGroupingHash(groupA, error, type)
-  const metadata = getMetadata(errorInfo, groupingHash)
+  const metadata = getMetadata(errorInfo, childEnv, groupingHash)
   const app = getApp()
   const eventProps = getEventProps({ severity: severityA, group: groupA, groupingHash, metadata, app })
 
@@ -60,7 +60,7 @@ const getGroupingHash = function(group, error, type) {
   return `${group}\n${messageA}`
 }
 
-const getMetadata = function({ location, plugin, childEnv }, groupingHash) {
+const getMetadata = function({ location, plugin }, childEnv, groupingHash) {
   const pluginMetadata = getPluginMetadata(plugin)
   const envMetadata = getEnvMetadata(childEnv)
   const locationMetadata = getLocationMetadata(location, envMetadata)

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -12,7 +12,6 @@ const parseError = function({ error, colors }) {
     message,
     stack,
     netlifyConfig,
-    childEnv,
     errorProps,
     errorInfo,
     errorInfo: { location = {}, plugin = {} },
@@ -39,7 +38,6 @@ const parseError = function({ error, colors }) {
     pluginInfo,
     locationInfo,
     netlifyConfig,
-    childEnv,
     errorProps: errorPropsA,
     isSuccess,
   }
@@ -47,14 +45,13 @@ const parseError = function({ error, colors }) {
 
 // Parse error instance into all the basic properties containing information
 const parseErrorInfo = function(error) {
-  const { message, stack, netlifyConfig, childEnv, ...errorProps } = normalizeError(error)
+  const { message, stack, netlifyConfig, ...errorProps } = normalizeError(error)
   const errorInfo = getErrorInfo(errorProps)
   const { state, title, isSuccess, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(errorInfo)
   return {
     message,
     stack,
     netlifyConfig,
-    childEnv,
     errorProps,
     errorInfo,
     state,


### PR DESCRIPTION
This moves the logic related to `childEnv` during build errors in order to avoid attaching it to the error instance, which was a temporary hack.