### PR TITLE
Move `netlifyConfig`-related logic

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -70,7 +70,7 @@ const build = async function(flags = {}) {
   }
 
   try {
-    const { commandsCount } = await runAndHandleBuild({
+    const { commandsCount } = await runAndReportBuild({
       netlifyConfig,
       configPath,
       buildDir,
@@ -100,7 +100,7 @@ const build = async function(flags = {}) {
     })
     return { success: true, logs }
   } catch (error) {
-    await handleBuildFailure({ error, errorMonitor, childEnv, mode, logs, testOpts })
+    await handleBuildFailure({ error, errorMonitor, netlifyConfig, childEnv, mode, logs, testOpts })
     return { success: false, logs }
   }
 }
@@ -124,48 +124,6 @@ const resolveConfig = async function(opts) {
     return await loadConfig(opts)
   } catch (error) {
     return { error }
-  }
-}
-
-// Runs a build and handle it on failure
-const runAndHandleBuild = async function({
-  netlifyConfig,
-  configPath,
-  buildDir,
-  nodePath,
-  childEnv,
-  functionsDistDir,
-  buildImagePluginsDir,
-  dry,
-  siteInfo,
-  mode,
-  api,
-  errorMonitor,
-  deployId,
-  logs,
-  testOpts,
-}) {
-  try {
-    return await runAndReportBuild({
-      netlifyConfig,
-      configPath,
-      buildDir,
-      nodePath,
-      childEnv,
-      functionsDistDir,
-      buildImagePluginsDir,
-      dry,
-      siteInfo,
-      mode,
-      api,
-      errorMonitor,
-      deployId,
-      logs,
-      testOpts,
-    })
-  } catch (error) {
-    Object.assign(error, { netlifyConfig })
-    throw error
   }
 }
 
@@ -340,10 +298,10 @@ const handleBuildSuccess = async function({
 }
 
 // Logs and reports that a build failed
-const handleBuildFailure = async function({ error, errorMonitor, childEnv, mode, logs, testOpts }) {
+const handleBuildFailure = async function({ error, errorMonitor, netlifyConfig, childEnv, mode, logs, testOpts }) {
   removeErrorColors(error)
   await reportBuildError({ error, errorMonitor, childEnv, logs, testOpts })
-  logBuildError({ error, logs })
+  logBuildError({ error, netlifyConfig, logs })
   logOldCliVersionError({ mode, testOpts })
 }
 

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -11,7 +11,6 @@ const parseError = function({ error, colors }) {
   const {
     message,
     stack,
-    netlifyConfig,
     errorProps,
     errorInfo,
     errorInfo: { location = {}, plugin = {} },
@@ -37,7 +36,6 @@ const parseError = function({ error, colors }) {
     message: messageA,
     pluginInfo,
     locationInfo,
-    netlifyConfig,
     errorProps: errorPropsA,
     isSuccess,
   }
@@ -45,13 +43,12 @@ const parseError = function({ error, colors }) {
 
 // Parse error instance into all the basic properties containing information
 const parseErrorInfo = function(error) {
-  const { message, stack, netlifyConfig, ...errorProps } = normalizeError(error)
+  const { message, stack, ...errorProps } = normalizeError(error)
   const errorInfo = getErrorInfo(errorProps)
   const { state, title, isSuccess, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(errorInfo)
   return {
     message,
     stack,
-    netlifyConfig,
     errorProps,
     errorInfo,
     state,

--- a/packages/build/src/error/parse/serialize_log.js
+++ b/packages/build/src/error/parse/serialize_log.js
@@ -4,12 +4,12 @@ const { parseError } = require('./parse')
 
 // Serialize an error object into a title|body string to print in logs
 const serializeLogError = function(error) {
-  const { title, message, pluginInfo, locationInfo, netlifyConfig, errorProps, isSuccess } = parseError({
+  const { title, message, pluginInfo, locationInfo, errorProps, isSuccess } = parseError({
     error,
     colors: true,
   })
   const body = getBody({ message, pluginInfo, locationInfo, errorProps, isSuccess })
-  return { title, body, isSuccess, netlifyConfig }
+  return { title, body, isSuccess }
 }
 
 const getBody = function({ message, pluginInfo, locationInfo, errorProps, isSuccess }) {

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -246,8 +246,8 @@ const logStatus = function(logs, { package, title = `Plugin ${package} ran succe
   logMessage(logs, body)
 }
 
-const logBuildError = function({ error, netlifyConfig: netlifyConfigArg, logs }) {
-  const { title, body, isSuccess, netlifyConfig = netlifyConfigArg } = serializeLogError(error)
+const logBuildError = function({ error, netlifyConfig, logs }) {
+  const { title, body, isSuccess } = serializeLogError(error)
   const logFunction = isSuccess ? logHeader : logErrorHeader
   logFunction(logs, title)
   logMessage(logs, `\n${body}\n`)


### PR DESCRIPTION
This moves how the `netlifyConfig` is passed to error handling code. This is refactoring only.