### PR TITLE
Move CLI warning on build failures

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -74,6 +74,7 @@ const runCommands = async function({
   buildDir,
   nodePath,
   childEnv,
+  mode,
   api,
   errorMonitor,
   deployId,
@@ -104,6 +105,7 @@ const runCommands = async function({
           childEnv,
           envChanges,
           commands,
+          mode,
           api,
           errorMonitor,
           deployId,
@@ -153,6 +155,7 @@ const runCommand = async function({
   childEnv,
   envChanges,
   commands,
+  mode,
   api,
   errorMonitor,
   deployId,
@@ -195,6 +198,7 @@ const runCommand = async function({
       : await handleCommandError({
           newError,
           childEnv,
+          mode,
           api,
           errorMonitor,
           deployId,
@@ -392,6 +396,7 @@ const handleCommandSuccess = function({ event, package, newEnvChanges, newStatus
 const handleCommandError = async function({
   newError,
   childEnv,
+  mode,
   api,
   errorMonitor,
   deployId,
@@ -414,7 +419,17 @@ const handleCommandError = async function({
   }
 
   if (type === 'failPlugin' || event === 'onSuccess') {
-    return handleFailPlugin({ newStatus, package, newError, childEnv, errorMonitor, netlifyConfig, logs, testOpts })
+    return handleFailPlugin({
+      newStatus,
+      package,
+      newError,
+      childEnv,
+      mode,
+      errorMonitor,
+      netlifyConfig,
+      logs,
+      testOpts,
+    })
   }
 
   return { newError, newStatus }
@@ -424,12 +439,13 @@ const handleFailPlugin = async function({
   package,
   newError,
   childEnv,
+  mode,
   errorMonitor,
   netlifyConfig,
   logs,
   testOpts,
 }) {
-  logBuildError({ error: newError, netlifyConfig, logs })
+  logBuildError({ error: newError, mode, netlifyConfig, logs, testOpts })
   await reportBuildError({ error: newError, errorMonitor, childEnv, logs, testOpts })
   return { failedPlugin: [package], newStatus }
 }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -6,7 +6,6 @@ const { reportBuildError } = require('../error/monitor/report')
 const { startErrorMonitor } = require('../error/monitor/start')
 const { getBufferLogs } = require('../log/logger')
 const { logBuildStart, logBuildError, logBuildSuccess } = require('../log/main')
-const { logOldCliVersionError } = require('../log/old_version')
 const { startTimer, endTimer } = require('../log/timer')
 const { loadPlugins } = require('../plugins/load')
 const { getPluginsOptions } = require('../plugins/options')
@@ -214,6 +213,7 @@ const initAndRunBuild = async function({
       childEnv,
       dry,
       constants,
+      mode,
       api,
       errorMonitor,
       deployId,
@@ -237,6 +237,7 @@ const runBuild = async function({
   childEnv,
   dry,
   constants,
+  mode,
   api,
   errorMonitor,
   deployId,
@@ -258,6 +259,7 @@ const runBuild = async function({
     buildDir,
     nodePath,
     childEnv,
+    mode,
     api,
     errorMonitor,
     deployId,
@@ -293,8 +295,7 @@ const handleBuildSuccess = async function({
 // Logs and reports that a build failed
 const handleBuildFailure = async function({ error, errorMonitor, netlifyConfig, childEnv, mode, logs, testOpts }) {
   removeErrorColors(error)
-  logBuildError({ error, netlifyConfig, logs })
-  logOldCliVersionError({ mode, testOpts })
+  logBuildError({ error, netlifyConfig, mode, logs, testOpts })
   await reportBuildError({ error, errorMonitor, childEnv, logs, testOpts })
 }
 

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -18,6 +18,7 @@ const {
   logSubHeader,
   logErrorSubHeader,
 } = require('./logger')
+const { logOldCliVersionError } = require('./old_version')
 const { THEME } = require('./theme')
 
 const logBuildStart = function(logs) {
@@ -246,12 +247,13 @@ const logStatus = function(logs, { package, title = `Plugin ${package} ran succe
   logMessage(logs, body)
 }
 
-const logBuildError = function({ error, netlifyConfig, logs }) {
+const logBuildError = function({ error, netlifyConfig, mode, logs, testOpts }) {
   const { title, body, isSuccess } = serializeLogError(error)
   const logFunction = isSuccess ? logHeader : logErrorHeader
   logFunction(logs, title)
   logMessage(logs, `\n${body}\n`)
   logConfigOnError({ logs, error, netlifyConfig })
+  logOldCliVersionError({ mode, testOpts })
 }
 
 const logBuildSuccess = function(logs) {

--- a/packages/build/src/status/report.js
+++ b/packages/build/src/status/report.js
@@ -72,15 +72,16 @@ const sendStatuses = async function({
 
   await Promise.all(
     statuses.map(status =>
-      sendStatus({ childEnv, api, status, netlifyConfig, errorMonitor, deployId, logs, testOpts }),
+      sendStatus({ api, status, childEnv, mode, netlifyConfig, errorMonitor, deployId, logs, testOpts }),
     ),
   )
 }
 
 const sendStatus = async function({
-  childEnv,
   api,
   status: { package, version, state, event, title, summary, text },
+  childEnv,
+  mode,
   netlifyConfig,
   errorMonitor,
   deployId,
@@ -96,7 +97,7 @@ const sendStatus = async function({
     // Builds should be successful when this API call fails, but we still want
     // to report the error both in logs and in error monitoring.
   } catch (error) {
-    logBuildError({ error, netlifyConfig, logs })
+    logBuildError({ error, mode, netlifyConfig, logs, testOpts })
     await reportBuildError({ error, errorMonitor, childEnv, logs, testOpts })
   }
 }


### PR DESCRIPTION
This moves the warning printed on build failures when Netlify CLI was used and it is not the latest version. Moving it ensures that every code that prints build failure logs uses that logic.