### PR TITLE
Move logic related to plugin statuses reporting

### DIFF
--- a/packages/build/src/core/commands.js
+++ b/packages/build/src/core/commands.js
@@ -125,7 +125,15 @@ const runCommands = async function({
     },
     { index: 0, failedPlugins: [], envChanges: {}, statuses: [] },
   )
-  return { commandsCount, error: errorA, statuses: statusesB }
+
+  // Instead of throwing any build failure right away, we wait for `onError`,
+  // etc. to complete. This is why we are throwing only now.
+  if (errorA !== undefined) {
+    addErrorInfo(errorA, { statuses: statusesB })
+    throw errorA
+  }
+
+  return { commandsCount, statuses: statusesB }
 }
 
 // Run a command (shell or plugin)

--- a/packages/build/src/status/add.js
+++ b/packages/build/src/status/add.js
@@ -1,4 +1,4 @@
-const { addErrorInfo, getErrorInfo } = require('../error/info')
+const { addErrorInfo } = require('../error/info')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 
 // The last event handler of a plugin (except for `onError` and `onEnd`)
@@ -64,9 +64,4 @@ const addPluginLoadErrorStatus = function({ error, package, version }) {
   return error
 }
 
-const getErrorStatuses = function(error) {
-  const { statuses } = getErrorInfo(error)
-  return statuses
-}
-
-module.exports = { getSuccessStatus, addStatus, addPluginLoadErrorStatus, getErrorStatuses }
+module.exports = { getSuccessStatus, addStatus, addPluginLoadErrorStatus }


### PR DESCRIPTION
This moves some of the logic related to how plugin statuses are being reported when the build fails. This is refactoring only.