### PR TITLE
Fix `commandsCount` used in analytics

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -288,7 +288,7 @@ const runBuild = async function({
     return {}
   }
 
-  const { error, statuses } = await runCommands({
+  const { commandsCount: commandsCountA, error, statuses } = await runCommands({
     commands,
     configPath,
     buildDir,
@@ -301,7 +301,7 @@ const runBuild = async function({
     logs,
     testOpts,
   })
-  return { commandsCount, error, statuses }
+  return { commandsCount: commandsCountA, error, statuses }
 }
 
 // Logs and reports that a build successfully ended


### PR DESCRIPTION
We count the number of commands (build command or plugin event handler) that get performed. We use this information for analytics only.

In dry run, this is estimated. However in real runs, this is the actual number of commands that got performed, excluding commands that got skipped (for example due to the plugin failing). 

Due to a missing variable, we were using the estimated count instead of the actual count.