### PR TITLE
Add comment on CLI entry point

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -9,7 +9,11 @@ require('../utils/polyfills')
 
 const build = require('./main')
 
-// CLI entry point
+// CLI entry point.
+// Before adding logic to this file, please consider adding it to the main
+// programmatic command instead, so that the new logic is available when run
+// programmatically as well. This file should only contain logic that makes
+// sense only in CLI, such as CLI flags parsing and exit code.
 const runCli = async function() {
   const flags = parseFlags()
   const flagsA = filterObj(flags, isUserFlag)


### PR DESCRIPTION
This adds a code comment on the CLI entry point with some recommendations on where to place code.