### PR TITLE
Fix Codecov CI failing

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,5 +7,7 @@ os="${os/-latest/}"
 node="$2"
 node="node_${node//./_}"
 
+# We don't use the -Z flag (which makes CI build fail on upload error) because
+# Codecov fails wait too often.
 curl -s https://codecov.io/bash | \
-  bash -s -- -Z -f coverage/coverage-final.json -F "$os" -F "$node"
+  bash -s -- -f coverage/coverage-final.json -F "$os" -F "$node"


### PR DESCRIPTION
Our CI is failing due to a Codecov bug. I have posted some information in their [repository](https://github.com/codecov/codecov-bash/issues/330).

However, Codecov just fails way too often. This PR ensures that CI still passes even when Codecov fails uploading test coverage reports.