### PR TITLE
Fix tests randomly failing

### DIFF
--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -13,7 +13,7 @@ const startErrorMonitor = function({ flags: { mode }, logs, bugsnagKey }) {
   }
 
   const releaseStage = getReleaseStage(mode)
-  const logger = getLogger(logs)
+  const logger = getLogger(logs, bugsnagKey)
   try {
     const errorMonitor = startBugsnag({
       apiKey: bugsnagKey,
@@ -49,9 +49,14 @@ const DEFAULT_RELEASE_STAGE = 'unknown'
 
 // We don't want Bugsnag logs except on warnings/errors.
 // We also want to use our own `log` utility, unprefixed.
-const getLogger = function(logs) {
-  const logFunc = log.bind(null, logs)
-  return { debug() {}, info() {}, warn: logFunc, error: logFunc }
+// In tests, we don't print Bugsnag because it sometimes randomly fails to
+// send sessions, which prints warning messags in test snapshots.
+const getLogger = function(logs, bugsnagKey) {
+  const logFunc = bugsnagKey === BUGSNAG_TEST_KEY ? noop : log.bind(null, logs)
+  return { debug: noop, info: noop, warn: logFunc, error: logFunc }
 }
+
+const BUGSNAG_TEST_KEY = '00000000000000000000000000000000'
+const noop = function() {}
 
 module.exports = { startErrorMonitor }

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -132,7 +132,8 @@ test('Do not log secret values on build errors', async t => {
   await runFixture(t, 'log_secret')
 })
 
-const flags = { testOpts: { errorMonitor: true }, bugsnagKey: '00000000000000000000000000000000' }
+const BUGSNAG_TEST_KEY = '00000000000000000000000000000000'
+const flags = { testOpts: { errorMonitor: true }, bugsnagKey: BUGSNAG_TEST_KEY }
 
 test('Report build.command failure', async t => {
   await runFixture(t, 'command', { flags })


### PR DESCRIPTION
In tests, Bugsnag sometimes randomly fails to send sessions. This prints warnings in test snapshots, which makes test fail.

This PR ensures this does not happen.