### PR TITLE
Remove logos from `README`

### DIFF
--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -1,5 +1,3 @@
-<img src="../../static/logo.png" width="400"/><br>
-
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 

--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -1,5 +1,3 @@
-<img src="../../static/logo.png" width="400"/><br>
-
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 

--- a/packages/git-utils/README.md
+++ b/packages/git-utils/README.md
@@ -1,5 +1,3 @@
-<img src="../../static/logo.png" width="400"/><br>
-
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 

--- a/packages/run-utils/README.md
+++ b/packages/run-utils/README.md
@@ -1,5 +1,3 @@
-<img src="static/logo.png" width="400"/><br>
-
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 


### PR DESCRIPTION
Fixes #1635.

Logos were removed by #989. However some were still present in individual packages `README`. This PR removes them.