### PR TITLE
Refactor duration logging

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -2,6 +2,7 @@ const pReduce = require('p-reduce')
 
 const { addErrorInfo } = require('../error/info')
 const { logCommand, logCommandSuccess } = require('../log/main')
+const { logTimer } = require('../log/main')
 const { startTimer, endTimer } = require('../log/timer')
 const { addStatus } = require('../status/add')
 
@@ -250,8 +251,9 @@ const getNewValues = function({
 
   logCommandSuccess(logs)
 
+  const durationMs = endTimer(methodTimer)
   const timerName = package === undefined ? 'build.command' : `${package} ${event}`
-  endTimer(logs, methodTimer, timerName)
+  logTimer(logs, durationMs, timerName)
 
   return { newEnvChanges, newStatus }
 }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -7,6 +7,7 @@ const { getErrorInfo } = require('../error/info')
 const { startErrorMonitor } = require('../error/monitor/start')
 const { getBufferLogs } = require('../log/logger')
 const { logBuildStart, logBuildSuccess } = require('../log/main')
+const { logTimer } = require('../log/main')
 const { startTimer, endTimer } = require('../log/timer')
 const { loadPlugins } = require('../plugins/load')
 const { getPluginsOptions } = require('../plugins/options')
@@ -288,8 +289,9 @@ const handleBuildSuccess = async function({
 
   logBuildSuccess(logs)
 
-  const duration = endTimer(logs, buildTimer, 'Netlify Build')
-  await trackBuildComplete({ commandsCount, netlifyConfig, duration, siteInfo, telemetry, mode, testOpts })
+  const durationMs = endTimer(buildTimer)
+  logTimer(logs, durationMs, 'Netlify Build')
+  await trackBuildComplete({ commandsCount, netlifyConfig, durationMs, siteInfo, telemetry, mode, testOpts })
 }
 
 module.exports = build

--- a/packages/build/src/log/timer.js
+++ b/packages/build/src/log/timer.js
@@ -1,24 +1,15 @@
 const { hrtime } = require('process')
 
-const { logTimer } = require('./main')
-
 // Starts a timer
 const startTimer = function() {
   return hrtime()
 }
 
 // Stops a timer
-const endTimerDuration = function([startSecs, startNsecs]) {
+const endTimer = function([startSecs, startNsecs]) {
   const [endSecs, endNsecs] = hrtime()
   const durationNs = (endSecs - startSecs) * NANOSECS_TO_SECS + endNsecs - startNsecs
   const durationMs = Math.ceil(durationNs / NANOSECS_TO_MSECS)
-  return durationMs
-}
-
-// Ends a timer and prints the result on console
-const endTimer = function(logs, hrTime, timerName) {
-  const durationMs = endTimerDuration(hrTime)
-  logTimer(logs, durationMs, timerName)
   return durationMs
 }
 

--- a/packages/build/src/telemetry/complete.js
+++ b/packages/build/src/telemetry/complete.js
@@ -11,22 +11,22 @@ const { analytics } = require('./track')
 const trackBuildComplete = async function({
   commandsCount,
   netlifyConfig,
-  duration,
+  durationMs,
   siteInfo,
   telemetry,
   mode,
   testOpts,
 }) {
-  const payload = getPayload({ commandsCount, netlifyConfig, duration, siteInfo, mode })
+  const payload = getPayload({ commandsCount, netlifyConfig, durationMs, siteInfo, mode })
   await analytics.track('netlifyCI:buildComplete', { payload, telemetry, testOpts })
 }
 
 // Retrieve telemetry information
-const getPayload = function({ commandsCount, netlifyConfig, duration, siteInfo: { id: siteId }, mode }) {
+const getPayload = function({ commandsCount, netlifyConfig, durationMs, siteInfo: { id: siteId }, mode }) {
   const plugins = Object.values(netlifyConfig.plugins).map(getPluginPackage)
   return {
     steps: commandsCount,
-    duration,
+    duration: durationMs,
     pluginCount: plugins.length,
     plugins,
     siteId,


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/856

This refactors how we log durations, to accommodate for future work to send that information to Datadog.