### PR TITLE
Trigger deploys with buildbot deploy server

### DIFF
--- a/packages/build/src/buildbot_client/main.js
+++ b/packages/build/src/buildbot_client/main.js
@@ -1,0 +1,68 @@
+const net = require('net')
+const { addErrorInfo } = require('../error/info')
+
+const getBuildbotClient = function(buildbotServerSocket) {
+  return new Promise((resolve, reject) => {
+    try {
+      const client = net.createConnection(buildbotServerSocket)
+      client.on('connect', () => resolve(client))
+    } catch (e) {
+      addErrorInfo(error, { type: 'buildbotServerClientStartup' })
+      reject(e)
+    }
+  })
+}
+
+const closeBuildbotClient = function(buildbotClient) {
+  client.end()
+  return
+}
+
+const writeDeployPayload = function(client, payload) {
+  return new Promise((resolve, reject) => {
+    try {
+      client.write(JSON.stringify(payload), resolve)
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+const getNextParsedResponsePromise = function(client) {
+  return new Promise(function(resolve, reject) {
+    try {
+      client.on('data', function(data) {
+        try {
+          resolve(JSON.parse(data))
+        } catch (e) {
+          reject(e)
+        }
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+const deploySiteWithBuildbotClient = async function(buildbotClient) {
+  try {
+    const nextResponsePromise = getNextParsedResponsePromise(client)
+    await writeDeployPayload(buildbotClient, { action: 'deploySite' })
+    const response = await nextResponsePromise
+
+    if (!response.succeeded) {
+      throw new Error(`Deploy did not succeed: ${response.values.error}`)
+    }
+  } catch (error) {
+    addErrorInfo(error, { type: 'buildbotServer' })
+    throw error
+  }
+
+  return
+}
+
+module.exports = {
+  getBuildbotClient,
+  closeBuildbotClient,
+  deploySiteWithBuildbotClient,
+}

--- a/packages/build/src/buildbot_client/main.js
+++ b/packages/build/src/buildbot_client/main.js
@@ -1,4 +1,5 @@
 const net = require('net')
+
 const { addErrorInfo } = require('../error/info')
 
 const startBuildbotClient = function(buildbotServerSocket) {
@@ -6,12 +7,12 @@ const startBuildbotClient = function(buildbotServerSocket) {
     try {
       const client = net.createConnection(buildbotServerSocket)
       client.on('connect', () => resolve(client))
-    } catch (e) {
+    } catch (error) {
       addErrorInfo(error, {
         type: 'buildbotClientStartup',
         location: { buildbotServerSocket },
       })
-      reject(e)
+      reject(error)
     }
   })
 }

--- a/packages/build/src/commands/deploy_site_command.js
+++ b/packages/build/src/commands/deploy_site_command.js
@@ -2,7 +2,7 @@ const net = require('net')
 
 const { addErrorInfo } = require('../error/info')
 
-const connectToBuildbotServer = function({ buildbotServerSocket }) {
+const connectToBuildbotServer = function(buildbotServerSocket) {
   return new Promise((resolve, reject) => {
     try {
       const client = net.createConnection(buildbotServerSocket)
@@ -16,7 +16,7 @@ const connectToBuildbotServer = function({ buildbotServerSocket }) {
 const writeDeployPayload = function(client, payload) {
   return new Promise((resolve, reject) => {
     try {
-      client.write(JSON.stringify(payload), (...args) => resolve(...args))
+      client.write(JSON.stringify(payload), resolve)
     } catch (e) {
       reject(e)
     }
@@ -39,11 +39,11 @@ const getNextParsedResponsePromise = function(client) {
   })
 }
 
-const deploySite = async function({ buildbotServerSocket }) {
+const deploySite = async function(buildbotServerSocket) {
   const client = await connectToBuildbotServer(buildbotServerSocket)
 
   const nextResponsePromise = getNextParsedResponsePromise(client)
-  await writeDeployPayload({ action: 'deploySite' })
+  await writeDeployPayload(client, { action: 'deploySite' })
   const response = await nextResponsePromise
 
   if (!response.succeeded) {
@@ -59,6 +59,7 @@ const fireDeploySiteCommand = async function() {
   const buildbotServerSocket = '/tmp/netlify-buildbot-socket'
   try {
     await deploySite(buildbotServerSocket)
+    return {}
   } catch (newError) {
     addErrorInfo(newError, { type: 'deploySiteCommand' })
     return { newError }

--- a/packages/build/src/commands/deploy_site_command.js
+++ b/packages/build/src/commands/deploy_site_command.js
@@ -1,5 +1,7 @@
 const net = require('net')
 
+const { addErrorInfo } = require('../error/info')
+
 const connectToBuildbotServer = function({ buildbotServerSocket }) {
   return new Promise((resolve, reject) => {
     try {
@@ -41,11 +43,7 @@ const deploySite = async function({ buildbotServerSocket }) {
   const client = await connectToBuildbotServer(buildbotServerSocket)
 
   const nextResponsePromise = getNextParsedResponsePromise(client)
-
-  await writeDeployPayload({
-    action: 'deploySite',
-  })
-
+  await writeDeployPayload({ action: 'deploySite' })
   const response = await nextResponsePromise
 
   if (!response.succeeded) {
@@ -57,6 +55,16 @@ const deploySite = async function({ buildbotServerSocket }) {
   return
 }
 
+const fireDeploySiteCommand = async function() {
+  const buildbotServerSocket = '/tmp/netlify-buildbot-socket'
+  try {
+    await deploySite(buildbotServerSocket)
+  } catch (newError) {
+    addErrorInfo(newError, { type: 'deploySiteCommand' })
+    return { newError }
+  }
+}
+
 module.exports = {
-  deploySite,
+  fireDeploySiteCommand,
 }

--- a/packages/build/src/commands/deploy_site_command.js
+++ b/packages/build/src/commands/deploy_site_command.js
@@ -2,13 +2,8 @@ const { deploySiteWithBuildbotClient } = require('../buildbot_client/main')
 const { addErrorInfo } = require('../error/info')
 
 const fireDeploySiteCommand = async function(buildbotClient) {
-  try {
-    await deploySiteWithBuildbotClient(buildbotClient)
-    return {}
-  } catch (newError) {
-    addErrorInfo(newError, { type: 'buildbotServer' })
-    return { newError }
-  }
+  await deploySiteWithBuildbotClient(buildbotClient)
+  return {}
 }
 
 module.exports = {

--- a/packages/build/src/commands/deploy_site_command.js
+++ b/packages/build/src/commands/deploy_site_command.js
@@ -1,66 +1,12 @@
-const net = require('net')
-
+const { deploySiteWithBuildbotClient } = require('../buildbot_client/main')
 const { addErrorInfo } = require('../error/info')
 
-const connectToBuildbotServer = function(buildbotServerSocket) {
-  return new Promise((resolve, reject) => {
-    try {
-      const client = net.createConnection(buildbotServerSocket)
-      client.on('connect', () => resolve(client))
-    } catch (e) {
-      reject(e)
-    }
-  })
-}
-
-const writeDeployPayload = function(client, payload) {
-  return new Promise((resolve, reject) => {
-    try {
-      client.write(JSON.stringify(payload), resolve)
-    } catch (e) {
-      reject(e)
-    }
-  })
-}
-
-const getNextParsedResponsePromise = function(client) {
-  return new Promise(function(resolve, reject) {
-    try {
-      client.on('data', function(data) {
-        try {
-          resolve(JSON.parse(data))
-        } catch (e) {
-          reject(e)
-        }
-      })
-    } catch (e) {
-      reject(e)
-    }
-  })
-}
-
-const deploySite = async function(buildbotServerSocket) {
-  const client = await connectToBuildbotServer(buildbotServerSocket)
-
-  const nextResponsePromise = getNextParsedResponsePromise(client)
-  await writeDeployPayload(client, { action: 'deploySite' })
-  const response = await nextResponsePromise
-
-  if (!response.succeeded) {
-    throw new Error(`Deploy did not succeed: ${response.values.error}`)
-  }
-
-  client.end()
-
-  return
-}
-
-const fireDeploySiteCommand = async function(buildbotServerSocket) {
+const fireDeploySiteCommand = async function(buildbotClient) {
   try {
-    await deploySite(buildbotServerSocket)
+    await deploySiteWithBuildbotClient(buildbotClient)
     return {}
   } catch (newError) {
-    addErrorInfo(newError, { type: 'deploySiteCommand' })
+    addErrorInfo(newError, { type: 'buildbotServer' })
     return { newError }
   }
 }

--- a/packages/build/src/commands/deploy_site_command.js
+++ b/packages/build/src/commands/deploy_site_command.js
@@ -1,5 +1,4 @@
 const { deploySiteWithBuildbotClient } = require('../buildbot_client/main')
-const { addErrorInfo } = require('../error/info')
 
 const fireDeploySiteCommand = async function(buildbotClient) {
   await deploySiteWithBuildbotClient(buildbotClient)

--- a/packages/build/src/commands/deploy_site_command.js
+++ b/packages/build/src/commands/deploy_site_command.js
@@ -55,8 +55,7 @@ const deploySite = async function(buildbotServerSocket) {
   return
 }
 
-const fireDeploySiteCommand = async function() {
-  const buildbotServerSocket = '/tmp/netlify-buildbot-socket'
+const fireDeploySiteCommand = async function(buildbotServerSocket) {
   try {
     await deploySite(buildbotServerSocket)
     return {}

--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -1,14 +1,17 @@
 const { EVENTS } = require('../plugins/events')
 
 // Get commands for all events
-const getCommands = function(pluginsCommands, netlifyConfig) {
-  const commands = sortCommands(addBuiltInCommands(pluginsCommands, netlifyConfig))
+const getCommands = function(pluginsCommands, netlifyConfig, triggerDeployWithBuildbotServer) {
+  const commands = sortCommands(addBuiltInCommands(pluginsCommands, netlifyConfig, triggerDeployWithBuildbotServer))
   const commandsCount = commands.filter(isSuccessCommand).length
   return { commands, commandsCount }
 }
 
-const addBuiltInCommands = function(pluginsCommands, netlifyConfig) {
-  return addBuildCommand(addDeployCommand(pluginsCommands), netlifyConfig)
+const addBuiltInCommands = function(pluginsCommands, netlifyConfig, triggerDeployWithBuildbotServer) {
+  return addBuildCommand(
+    triggerDeployWithBuildbotServer ? addDeployCommand(pluginsCommands) : pluginsCommands,
+    netlifyConfig,
+  )
 }
 
 // Merge `build.command` with plugin event handlers

--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -58,4 +58,4 @@ const isSuccessCommand = function({ event }) {
   return isMainCommand({ event }) || isEndCommand({ event })
 }
 
-module.exports = { getCommands, isMainCommand, isErrorCommand, isSuccessCommand }
+module.exports = { getCommands, isMainCommand, isErrorCommand, isSuccessCommand, isDeployCommand }

--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -2,10 +2,13 @@ const { EVENTS } = require('../plugins/events')
 
 // Get commands for all events
 const getCommands = function(pluginsCommands, netlifyConfig) {
-  const commands = addBuildCommand(pluginsCommands, netlifyConfig)
-  const commandsA = sortCommands(commands)
-  const commandsCount = commandsA.filter(isSuccessCommand).length
-  return { commands: commandsA, commandsCount }
+  const commands = sortCommands(addBuiltInCommands(pluginsCommands, netlifyConfig))
+  const commandsCount = commands.filter(isSuccessCommand).length
+  return { commands, commandsCount }
+}
+
+const addBuiltInCommands = function(pluginsCommands, netlifyConfig) {
+  return addBuildCommand(addDeployCommand(pluginsCommands), netlifyConfig)
 }
 
 // Merge `build.command` with plugin event handlers
@@ -20,13 +23,27 @@ const addBuildCommand = function(
   return [{ event: 'onBuild', buildCommand, buildCommandOrigin }, ...pluginsCommands]
 }
 
+// Schedule the deploy command as the first 'onDeploy' action
+const addDeployCommand = function(pluginsCommands) {
+  return [{ event: 'onDeploy', isDeploySiteCommand: true }, ...pluginsCommands]
+}
+
 // Sort plugin commands by event order.
 const sortCommands = function(commands) {
   return EVENTS.flatMap(event => commands.filter(command => command.event === event))
 }
 
-const isMainCommand = function({ event }) {
-  return event !== 'onEnd' && event !== 'onError'
+const isDeployEvent = function(event) {
+  return event === 'onDeploy'
+}
+
+const isDeployCommand = function({ event, isDeploySiteCommand }) {
+  return isDeploySiteCommand || isDeployEvent(event)
+}
+
+const isMainCommand = function(command) {
+  const { event } = command
+  return event !== 'onEnd' && event !== 'onError' && !isDeployCommand(command)
 }
 
 const isEndCommand = function({ event }) {

--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -34,7 +34,7 @@ const runCommands = async function({
     commands,
     async (
       { index, error, failedPlugins, envChanges, statuses },
-      { event, childProcess, package, pluginPackageJson, loadedFrom, origin, buildCommand, buildCommandOrigin },
+      { event, childProcess, package, pluginPackageJson, loadedFrom, origin, buildCommand, buildCommandOrigin, isDeploySiteCommand },
     ) => {
       const { newIndex = index, newError = error, failedPlugin = [], newEnvChanges = {}, newStatus } = await runCommand(
         {
@@ -46,6 +46,7 @@ const runCommands = async function({
           origin,
           buildCommand,
           buildCommandOrigin,
+          isDeploySiteCommand,
           configPath,
           buildDir,
           nodePath,
@@ -96,6 +97,7 @@ const runCommand = async function({
   origin,
   buildCommand,
   buildCommandOrigin,
+  isDeploySiteCommand,
   configPath,
   buildDir,
   nodePath,
@@ -130,6 +132,7 @@ const runCommand = async function({
     origin,
     buildCommand,
     buildCommandOrigin,
+    isDeploySiteCommand,
     configPath,
     buildDir,
     nodePath,

--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -29,6 +29,7 @@ const runCommands = async function({
   netlifyConfig,
   logs,
   testOpts,
+  buildbotServerSocket,
 }) {
   const { index: commandsCount, error: errorA, statuses: statusesB } = await pReduce(
     commands,
@@ -63,6 +64,7 @@ const runCommands = async function({
           netlifyConfig,
           logs,
           testOpts,
+          buildbotServerSocket,
         },
       )
       const statusesA = addStatus({ newStatus, statuses, event, package, pluginPackageJson })
@@ -98,6 +100,7 @@ const runCommand = async function({
   buildCommand,
   buildCommandOrigin,
   isDeploySiteCommand,
+  buildbotServerSocket,
   configPath,
   buildDir,
   nodePath,
@@ -133,6 +136,7 @@ const runCommand = async function({
     buildCommand,
     buildCommandOrigin,
     isDeploySiteCommand,
+    buildbotServerSocket,
     configPath,
     buildDir,
     nodePath,
@@ -189,6 +193,7 @@ const fireCommand = function({
   buildCommand,
   buildCommandOrigin,
   isDeploySiteCommand,
+  buildbotServerSocket,
   configPath,
   buildDir,
   nodePath,
@@ -212,7 +217,7 @@ const fireCommand = function({
   }
 
   if (isDeploySiteCommand) {
-    return fireDeploySiteCommand()
+    return fireDeploySiteCommand(buildbotServerSocket)
   }
 
   return firePluginCommand({

--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -35,7 +35,17 @@ const runCommands = async function({
     commands,
     async (
       { index, error, failedPlugins, envChanges, statuses },
-      { event, childProcess, package, pluginPackageJson, loadedFrom, origin, buildCommand, buildCommandOrigin, isDeploySiteCommand },
+      {
+        event,
+        childProcess,
+        package,
+        pluginPackageJson,
+        loadedFrom,
+        origin,
+        buildCommand,
+        buildCommandOrigin,
+        isDeploySiteCommand,
+      },
     ) => {
       const { newIndex = index, newError = error, failedPlugin = [], newEnvChanges = {}, newStatus } = await runCommand(
         {
@@ -124,7 +134,7 @@ const runCommand = async function({
 
   const methodTimer = startTimer()
 
-  logCommand({ logs, event, buildCommandOrigin, package, index, error })
+  logCommand({ logs, event, buildCommandOrigin, package, index, error, isDeploySiteCommand })
 
   const { newEnvChanges, newError, newStatus } = await fireCommand({
     event,

--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -29,7 +29,7 @@ const runCommands = async function({
   netlifyConfig,
   logs,
   testOpts,
-  buildbotServerSocket,
+  buildbotClient,
 }) {
   const { index: commandsCount, error: errorA, statuses: statusesB } = await pReduce(
     commands,
@@ -48,6 +48,7 @@ const runCommands = async function({
           buildCommand,
           buildCommandOrigin,
           isDeploySiteCommand,
+          buildbotClient,
           configPath,
           buildDir,
           nodePath,
@@ -64,7 +65,6 @@ const runCommands = async function({
           netlifyConfig,
           logs,
           testOpts,
-          buildbotServerSocket,
         },
       )
       const statusesA = addStatus({ newStatus, statuses, event, package, pluginPackageJson })
@@ -100,7 +100,7 @@ const runCommand = async function({
   buildCommand,
   buildCommandOrigin,
   isDeploySiteCommand,
-  buildbotServerSocket,
+  buildbotClient,
   configPath,
   buildDir,
   nodePath,
@@ -136,7 +136,7 @@ const runCommand = async function({
     buildCommand,
     buildCommandOrigin,
     isDeploySiteCommand,
-    buildbotServerSocket,
+    buildbotClient,
     configPath,
     buildDir,
     nodePath,
@@ -193,7 +193,7 @@ const fireCommand = function({
   buildCommand,
   buildCommandOrigin,
   isDeploySiteCommand,
-  buildbotServerSocket,
+  buildbotClient,
   configPath,
   buildDir,
   nodePath,
@@ -217,7 +217,7 @@ const fireCommand = function({
   }
 
   if (isDeploySiteCommand) {
-    return fireDeploySiteCommand(buildbotServerSocket)
+    return fireDeploySiteCommand(buildbotClient)
   }
 
   return firePluginCommand({

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -115,6 +115,11 @@ Default: automatically guessed`,
 Default: none`,
     hidden: true,
   },
+  buildbotServerSocket: {
+    string: true,
+    describe: `Path to the buildbot server socket. This is used to connect to the buildbot to trigger deploys.`,
+    hidden: true,
+  },
   telemetry: {
     boolean: true,
     describe: `Enable telemetry.

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -115,6 +115,15 @@ Default: automatically guessed`,
 Default: none`,
     hidden: true,
   },
+  triggerDeployWithBuildbotServer: {
+    boolean: true,
+    describe: `Feature flag.
+When enabled, triggers a deploy by connecting to the buildbot deploy server and
+passing it a "deploySite" command. After the deploy is finished, it triggers the events
+"onDeploySuccess", "onDeployError", and "onPostDeploy" as appropriate.
+Default: false`,
+    hidden: true,
+  },
   buildbotServerSocket: {
     string: true,
     describe: `Path to the buildbot server socket. This is used to connect to the buildbot to trigger deploys.`,

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -119,8 +119,8 @@ Default: none`,
     boolean: true,
     describe: `Feature flag.
 When enabled, triggers a deploy by connecting to the buildbot deploy server and
-passing it a "deploySite" command. After the deploy is finished, it triggers the events
-"onDeploySuccess", "onDeployError", and "onPostDeploy" as appropriate.
+passing it a "deploySite" command. After the deploy is finished, it triggers the
+"onDeploy" event.
 Default: false`,
     hidden: true,
   },

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -245,7 +245,9 @@ const initAndRunBuild = async function({
     })
   } finally {
     await stopPlugins(childProcesses)
-    closeBuildbotClient(buildbotClient)
+    if (buildbotClient) {
+      closeBuildbotClient(buildbotClient)
+    }
   }
 }
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -53,6 +53,8 @@ const build = async function(flags = {}) {
     errorMonitor,
     logs,
     buildTimer,
+    triggerDeployWithBuildbotServer,
+    buildbotServerSocket,
     ...flagsA
   } = startBuild(flags)
 
@@ -85,6 +87,8 @@ const build = async function(flags = {}) {
       deployId,
       logs,
       testOpts,
+      triggerDeployWithBuildbotServer,
+      buildbotServerSocket,
     })
     await handleBuildSuccess({
       commandsCount,
@@ -143,6 +147,8 @@ const runAndReportBuild = async function({
   deployId,
   logs,
   testOpts,
+  triggerDeployWithBuildbotServer,
+  buildbotServerSocket,
 }) {
   try {
     const { commandsCount, statuses } = await initAndRunBuild({
@@ -161,6 +167,8 @@ const runAndReportBuild = async function({
       deployId,
       logs,
       testOpts,
+      triggerDeployWithBuildbotServer,
+      buildbotServerSocket,
     })
     await reportStatuses({ statuses, childEnv, api, mode, netlifyConfig, errorMonitor, deployId, logs, testOpts })
 
@@ -189,6 +197,8 @@ const initAndRunBuild = async function({
   deployId,
   logs,
   testOpts,
+  triggerDeployWithBuildbotServer,
+  buildbotServerSocket,
 }) {
   const constants = await getConstants({ configPath, buildDir, functionsDistDir, netlifyConfig, siteInfo, mode })
   const pluginsOptions = await getPluginsOptions({
@@ -219,6 +229,8 @@ const initAndRunBuild = async function({
       deployId,
       logs,
       testOpts,
+      triggerDeployWithBuildbotServer,
+      buildbotServerSocket,
     })
   } finally {
     await stopPlugins(childProcesses)
@@ -243,10 +255,12 @@ const runBuild = async function({
   deployId,
   logs,
   testOpts,
+  triggerDeployWithBuildbotServer,
+  buildbotServerSocket,
 }) {
   const pluginsCommands = await loadPlugins({ pluginsOptions, childProcesses, netlifyConfig, constants })
 
-  const { commands, commandsCount } = getCommands(pluginsCommands, netlifyConfig)
+  const { commands, commandsCount } = getCommands(pluginsCommands, netlifyConfig, triggerDeployWithBuildbotServer)
 
   if (dry) {
     doDryRun({ commands, commandsCount, logs })
@@ -266,6 +280,7 @@ const runBuild = async function({
     netlifyConfig,
     logs,
     testOpts,
+    buildbotServerSocket,
   })
   return { commandsCount: commandsCountA, statuses }
 }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -1,5 +1,6 @@
 require('../utils/polyfills')
 
+const { startBuildbotClient, closeBuildbotClient } = require('../buildbot_client/main')
 const { getCommands } = require('../commands/get')
 const { runCommands } = require('../commands/run')
 const { handleBuildError } = require('../error/handle')
@@ -13,7 +14,6 @@ const { getPluginsOptions } = require('../plugins/options')
 const { startPlugins, stopPlugins } = require('../plugins/spawn')
 const { reportStatuses } = require('../status/report')
 const { trackBuildComplete } = require('../telemetry/complete')
-const { startBuildbotClient, closeBuildbotClient } = require('../buildbot_client/main')
 
 const { loadConfig } = require('./config')
 const { getConstants } = require('./constants')
@@ -268,7 +268,7 @@ const runBuild = async function({
   logs,
   testOpts,
   triggerDeployWithBuildbotServer,
-  buildbotClient
+  buildbotClient,
 }) {
   const pluginsCommands = await loadPlugins({ pluginsOptions, childProcesses, netlifyConfig, constants })
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -3,7 +3,7 @@ require('../utils/polyfills')
 const { getCommands } = require('../commands/get')
 const { runCommands } = require('../commands/run')
 const { handleBuildError } = require('../error/handle')
-const { getErrorInfo } = require('../error/info')
+const { addErrorInfo, getErrorInfo } = require('../error/info')
 const { startErrorMonitor } = require('../error/monitor/start')
 const { getBufferLogs } = require('../log/logger')
 const { logBuildStart, logBuildSuccess } = require('../log/main')
@@ -214,9 +214,9 @@ const initAndRunBuild = async function({
   var buildbotClient
   if (triggerDeployWithBuildbotServer) {
     try {
-      buildbotClient = startBuildbotClient(buildbotServerSocket)
+      buildbotClient = await startBuildbotClient(buildbotServerSocket)
     } catch (error) {
-      addErrorInfo(error, { type: 'buildbotServerClientStartup' })
+      addErrorInfo(error, { type: 'buildbotClientStartup' })
       throw error
     }
   }
@@ -268,7 +268,7 @@ const runBuild = async function({
   logs,
   testOpts,
   triggerDeployWithBuildbotServer,
-  buildbotServerSocket,
+  buildbotClient
 }) {
   const pluginsCommands = await loadPlugins({ pluginsOptions, childProcesses, netlifyConfig, constants })
 
@@ -292,7 +292,7 @@ const runBuild = async function({
     netlifyConfig,
     logs,
     testOpts,
-    buildbotServerSocket,
+    buildbotClient,
   })
   return { commandsCount: commandsCountA, statuses }
 }

--- a/packages/build/src/deploy/main.js
+++ b/packages/build/src/deploy/main.js
@@ -1,0 +1,60 @@
+const net = require('net')
+
+const connectToBuildbotServer = function({ buildbotServerSocket }) {
+  return new Promise((resolve, reject) => {
+    try {
+      const client = net.createConnection(buildbotServerSocket)
+      client.on('connect', () => resolve(client))
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+const writeDeployPayload = function(client, payload) {
+  return new Promise((resolve, reject) => {
+    try {
+      client.write(JSON.stringify(payload), (...args) => resolve(...args))
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+const getNextParsedResponsePromise = function(client) {
+  return new Promise(function(resolve, reject) {
+    try {
+      client.on('data', function(data) {
+        try {
+          resolve(JSON.parse(data))
+        } catch (e) {
+          reject(e)
+        }
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+const deploySite = async function({ buildbotServerSocket }) {
+  const client = await connectToBuildbotServer(buildbotServerSocket)
+
+  const nextResponsePromise = getNextParsedResponsePromise(client)
+
+  await writeDeployPayload({
+    action: 'deployFiles',
+  })
+
+  const response = await nextResponsePromise
+
+  if (!response.succeeded) {
+    throw new Error(`Deploy did not succeed: ${response.values.error}`)
+  }
+
+  return
+}
+
+module.exports = {
+  deploySite,
+}

--- a/packages/build/src/deploy/main.js
+++ b/packages/build/src/deploy/main.js
@@ -43,7 +43,7 @@ const deploySite = async function({ buildbotServerSocket }) {
   const nextResponsePromise = getNextParsedResponsePromise(client)
 
   await writeDeployPayload({
-    action: 'deployFiles',
+    action: 'deploySite',
   })
 
   const response = await nextResponsePromise

--- a/packages/build/src/deploy/main.js
+++ b/packages/build/src/deploy/main.js
@@ -52,6 +52,8 @@ const deploySite = async function({ buildbotServerSocket }) {
     throw new Error(`Deploy did not succeed: ${response.values.error}`)
   }
 
+  client.end()
+
   return
 }
 

--- a/packages/build/src/error/parse/location.js
+++ b/packages/build/src/error/parse/location.js
@@ -42,7 +42,7 @@ const getApiLocation = function({ endpoint, parameters }) {
 }
 
 const getBuildbotClientStartupLocation = function() {
-  return "While starting the client for the buildbot helper server."
+  return 'While starting the client for the buildbot helper server.'
 }
 
 const getBuildbotClientMessageLocation = function({ payload: { action } }) {

--- a/packages/build/src/error/parse/location.js
+++ b/packages/build/src/error/parse/location.js
@@ -41,10 +41,20 @@ const getApiLocation = function({ endpoint, parameters }) {
   return `While calling the Netlify API endpoint '${endpoint}' with:\n${JSON.stringify(parameters, null, 2)}`
 }
 
+const getBuildbotClientStartupLocation = function() {
+  return "While starting the client for the buildbot helper server."
+}
+
+const getBuildbotClientMessageLocation = function({ payload: { action } }) {
+  return `While sending the action "${action}" to the buildbot server.`
+}
+
 const LOCATIONS = {
   buildCommand: getBuildCommandLocation,
   buildFail: getBuildFailLocation,
   api: getApiLocation,
+  buildbotClientStartup: getBuildbotClientStartupLocation,
+  buildbotClientMessage: getBuildbotClientMessageLocation,
 }
 
 module.exports = { getLocationInfo }

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -124,6 +124,22 @@ const TYPES = {
     severity: 'error',
   },
 
+  // Error while communicating to the buildbot via its socket
+  buildbotServerClientStartup: {
+    title: 'Buildbot server client startup error',
+    stackType: 'message',
+    locationType: 'buildbot',
+    severity: 'error',
+  },
+
+  // Error while communicating to the buildbot via its socket
+  buildbotServer: {
+    title: 'Buildbot server communication error',
+    stackType: 'message',
+    locationType: 'buildbot',
+    severity: 'error',
+  },
+
   // `@netlify/build` threw an uncaught exception
   exception: {
     title: 'Core internal error',

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -125,18 +125,18 @@ const TYPES = {
   },
 
   // Error while communicating to the buildbot via its socket
-  buildbotServerClientStartup: {
+  buildbotClientStartup: {
     title: 'Buildbot server client startup error',
     stackType: 'message',
-    locationType: 'buildbot',
+    locationType: 'buildbotClientStartup',
     severity: 'error',
   },
 
   // Error while communicating to the buildbot via its socket
-  buildbotServer: {
-    title: 'Buildbot server communication error',
+  buildbotClient: {
+    title: 'Buildbot communication error',
     stackType: 'message',
-    locationType: 'buildbot',
+    locationType: 'buildbotClientMessage',
     severity: 'error',
   },
 

--- a/packages/build/src/log/description.js
+++ b/packages/build/src/log/description.js
@@ -1,7 +1,11 @@
 // Retrieve description of `build.command` or of an event handler
-const getCommandDescription = function({ event, buildCommandOrigin, package }) {
+const getCommandDescription = function({ event, buildCommandOrigin, isDeploySiteCommand, package }) {
   if (buildCommandOrigin !== undefined) {
     return getBuildCommandDescription(buildCommandOrigin)
+  }
+
+  if (isDeploySiteCommand) {
+    return `${event} command from core`
   }
 
   return `${event} command from ${package}`

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -257,7 +257,7 @@ const logBuildError = function({ error, netlifyConfig, mode, logs, testOpts }) {
 }
 
 const logBuildSuccess = function(logs) {
-  logHeader(logs, 'Netlify Build Complete')
+  logHeader(logs, 'Build Script Complete')
   logMessage(logs, '')
 }
 

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -193,8 +193,8 @@ const logDryRunEnd = function(logs) {
   logMessage(logs, `\nIf this looks good to you, run \`netlify build\` to execute the build\n`)
 }
 
-const logCommand = function({ logs, event, buildCommandOrigin, package, index, error }) {
-  const description = getCommandDescription({ event, buildCommandOrigin, package })
+const logCommand = function({ logs, event, buildCommandOrigin, isDeploySiteCommand, package, index, error }) {
+  const description = getCommandDescription({ event, buildCommandOrigin, isDeploySiteCommand, package })
   const logHeaderFunc = error && !isSuccessException(error) ? logErrorHeader : logHeader
   logHeaderFunc(logs, `${index + 1}. ${description}`)
   logMessage(logs, '')

--- a/packages/build/src/plugins/events.js
+++ b/packages/build/src/plugins/events.js
@@ -24,6 +24,19 @@ const EVENTS = [
    * `onEnd` - Runs on build error or success
    */
   'onEnd',
+
+  /**
+   * `onDeploySuccess` - Runs on deploy error
+   */
+  'onDeploySuccess',
+  /**
+   * `onDeployError` - Runs on deploy error
+   */
+  'onDeployError',
+  /**
+   * `onDeployEnd` - Runs on deploy error or success
+   */
+  'onDeployEnd',
 ]
 
 module.exports = { EVENTS }

--- a/packages/build/src/plugins/events.js
+++ b/packages/build/src/plugins/events.js
@@ -20,23 +20,16 @@ const EVENTS = [
    * `onError` - Runs on build error
    */
   'onError',
+
+  /**
+   * `onDeploy` - Runs after site has been deployed
+   */
+  'onDeploy',
+
   /**
    * `onEnd` - Runs on build error or success
    */
   'onEnd',
-
-  /**
-   * `onDeploySuccess` - Runs on deploy error
-   */
-  'onDeploySuccess',
-  /**
-   * `onDeployError` - Runs on deploy error
-   */
-  'onDeployError',
-  /**
-   * `onDeployEnd` - Runs on deploy error or success
-   */
-  'onDeployEnd',
 ]
 
 module.exports = { EVENTS }

--- a/packages/build/src/plugins/events.js
+++ b/packages/build/src/plugins/events.js
@@ -20,16 +20,15 @@ const EVENTS = [
    * `onError` - Runs on build error
    */
   'onError',
-
-  /**
-   * `onDeploy` - Runs after site has been deployed
-   */
-  'onDeploy',
-
   /**
    * `onEnd` - Runs on build error or success
    */
   'onEnd',
+
+  /**
+   * `onDeploy` - Runs after build has finished and site has been deployed
+   */
+  'onDeploy',
 ]
 
 module.exports = { EVENTS }

--- a/packages/build/src/status/report.js
+++ b/packages/build/src/status/report.js
@@ -66,7 +66,7 @@ const sendStatuses = async function({
   logs,
   testOpts,
 }) {
-  if ((mode !== 'buildbot' && !testOpts.sendStatus) || api === undefined || !deployId) {
+  if (mode !== 'buildbot' || !testOpts.sendStatus || api === undefined || !deployId) {
     return
   }
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

This allows `netlify-build` to run `onDeploy` hooks after a deploy has completed, by talking to the buildbot which performs the deploy over a local Unix socket.

**List other issues or pull requests related to this problem**

This is the netlify-build side of https://github.com/netlify/buildbot/pull/566.

**Describe the solution you've chosen**

I've created two more CLI flags, `--triggerDeployWithBuildbotServer` and `--buildbotServerSocker`. `--triggerDeployWithBuildbotServer` is a boolean flag that enables the `onDeploy` event and the connection to the buildbot server. `--buildbotServerSocket` is a string flag that takes the path to the Unix socket the buildbot server is listening on.

The buildbot client is created at the beginning of the build lifecycle, and passed to the deploy command when `--triggerDeployWithBuildbotServer` is run.

TODO:

- [ ] What should we do with `onDeploy` hooks when `netlify-build` is running on a developer's local machine? They are currently always run at the end of the build, with the actual deploy command only being run when `--triggerDeployWithBuildbotServer` is passed in.
- [ ] Should the event continue to be named `onDeploy` or would `onPostDeploy` make more sense? Should we even split it into separate events that fire before and after the deploy (e.g., `onPreDeploy` and `onPostDeploy`)? This doesn't seem necessary to me, so it wasn't added yet, but I can rework the PR to do so. `onPreDeploy` would be equivalent to a post-build hook, and `onPostDeploy` is what is already implemented as `onDeploy`.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
