### PR TITLE
Allow turning off plugin status sending with CLI arg

### DIFF
--- a/packages/build/src/core/flags.js
+++ b/packages/build/src/core/flags.js
@@ -28,7 +28,7 @@ const getDefaultFlags = function({ env: envOpt = {} }) {
     debug: Boolean(combinedEnv.NETLIFY_BUILD_DEBUG),
     bugsnagKey: combinedEnv.BUGSNAG_KEY,
     telemetry: !combinedEnv.BUILD_TELEMETRY_DISABLED,
-    testOpts: {},
+    testOpts: { sendStatus: true },
   }
 }
 

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -37,7 +37,7 @@ const logFlags = function(logs, flags, { debug }) {
 // Hidden because the value is security-sensitive
 const SECURE_FLAGS = ['token', 'bugsnagKey', 'env', 'cachedConfig', 'defaultConfig']
 // Hidden because those are used in tests
-const TEST_FLAGS = ['buffer', 'telemetry']
+const TEST_FLAGS = ['buffer', 'telemetry', 'testOpts']
 // Hidden because those are only used internally
 const INTERNAL_FLAGS = ['nodePath', 'functionsDistDir', 'buildImagePluginsDir']
 const HIDDEN_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, ...INTERNAL_FLAGS]

--- a/packages/build/src/status/report.js
+++ b/packages/build/src/status/report.js
@@ -66,7 +66,7 @@ const sendStatuses = async function({
   logs,
   testOpts,
 }) {
-  if ((mode !== 'buildbot' && !testOpts.sendStatus) || api === undefined || !deployId) {
+  if (mode !== 'buildbot' || !testOpts.sendStatus || api === undefined || !deployId) {
     return
   }
 

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -296,7 +296,12 @@ test('Print stack trace of validation errors', async t => {
 if (!version.startsWith('v8.')) {
   test('Redact API token on errors', async t => {
     await runFixture(t, 'api_token_redact', {
-      flags: { token: '0123456789abcdef', deployId: 'test', mode: 'buildbot', testOpts: { host: '...' } },
+      flags: {
+        token: '0123456789abcdef',
+        deployId: 'test',
+        mode: 'buildbot',
+        testOpts: { host: '...', sendStatus: true },
+      },
     })
   })
 }

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -13,7 +13,13 @@ const BUILD_BIN_DIR = normalize(`${ROOT_DIR}/node_modules/.bin`)
 
 const runFixture = async function(t, fixtureName, { flags = {}, env: envOption = {}, ...opts } = {}) {
   const binaryPath = await BINARY_PATH
-  const flagsA = { debug: true, telemetry: false, buffer: true, ...flags }
+  const flagsA = {
+    debug: true,
+    telemetry: false,
+    buffer: true,
+    testOpts: { sendStatus: false, ...flags.testOpts },
+    ...flags,
+  }
   const envOptionA = {
     // Ensure local environment variables aren't used during development
     BUILD_TELEMETRY_DISABLED: '',


### PR DESCRIPTION
**Which problem is this pull request solving?**

Allows turning off sending plugin status to API server for development.

**Describe the solution you've chosen**

Previously, `testOpts.sendStatus` only worked if the mode was not `buildbot`. This makes that CLI flag work regardless of whether `netlify-build` is running in `buildbot` mode.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
