### PR TITLE
@netlify/config: Add support for _headers file

### DIFF
--- a/packages/config/src/headers.js
+++ b/packages/config/src/headers.js
@@ -37,7 +37,7 @@ function matchPaths(rulePath, targetPath) {
 function objectForPath(rules, pathname) {
   return Object.entries(rules).reduce(
     (prev, [rulePath, pathHeaders]) => Object.assign({}, prev, matchPaths(rulePath, pathname) && pathHeaders),
-    {}
+    {},
   )
 }
 

--- a/packages/config/src/headers.js
+++ b/packages/config/src/headers.js
@@ -1,0 +1,97 @@
+const fs = require('fs')
+
+const TOKEN_COMMENT = '#'
+const TOKEN_PATH = '/'
+
+function matchPaths(rulePath, targetPath) {
+  const rulePathParts = rulePath.split('/').filter(Boolean)
+  const targetPathParts = targetPath.split('/').filter(Boolean)
+
+  if (rulePathParts.length < 1 && targetPathParts.length < 1) {
+    return true
+  }
+
+  for (let i = 0; i < rulePathParts.length; i++) {
+    if (i >= targetPathParts.length) return false
+
+    const rulePart = rulePathParts[i]
+    const target = targetPathParts[i]
+
+    if (rulePart === '*') return true
+
+    if (rulePart.startsWith(':')) {
+      if (i === rulePathParts.length - 1) {
+        return i === targetPathParts.length - 1
+      }
+      if (i === targetPathParts.length - 1) {
+        return false
+      }
+    } else {
+      return rulePart === target
+    }
+  }
+
+  return false
+}
+
+function objectForPath(rules, pathname) {
+  return Object.entries(rules).reduce(
+    (prev, [rulePath, pathHeaders]) => Object.assign({}, prev, matchPaths(rulePath, pathname) && pathHeaders),
+    {}
+  )
+}
+
+function parseHeadersFile(filePath) {
+  const rules = {}
+  if (!fs.existsSync(filePath)) return rules
+  if (fs.statSync(filePath).isDirectory()) {
+    console.warn('expected _headers file but found a directory at:', filePath)
+    return rules
+  }
+
+  const lines = fs.readFileSync(filePath, { encoding: 'utf8' }).split('\n')
+  if (lines.length < 1) return rules
+
+  let path
+  for (let i = 0; i <= lines.length; i++) {
+    if (!lines[i]) continue
+
+    const line = lines[i].trim()
+
+    if (line.startsWith(TOKEN_COMMENT) || line.length < 1) continue
+    if (line.startsWith(TOKEN_PATH)) {
+      if (line.includes('*') && line.indexOf('*') !== line.length - 1) {
+        throw new Error(`invalid rule (A path rule cannot contain anything after * token) at line: ${i}\n${lines[i]}\n`)
+      }
+      path = line
+      continue
+    }
+
+    if (!path) throw new Error('path should come before headers')
+
+    if (line.includes(':')) {
+      const sepIndex = line.indexOf(':')
+      if (sepIndex < 1) throw new Error(`invalid header at line: ${i}\n${lines[i]}\n`)
+
+      const key = line.substr(0, sepIndex).trim()
+      const value = line.substr(sepIndex + 1).trim()
+
+      if ({}.hasOwnProperty.call(rules, path)) {
+        if ({}.hasOwnProperty.call(rules[path], key)) {
+          rules[path][key].push(value)
+        } else {
+          rules[path][key] = [value]
+        }
+      } else {
+        rules[path] = { [key]: [value] }
+      }
+    }
+  }
+
+  return rules
+}
+
+module.exports = {
+  objectForPath,
+  parseHeadersFile,
+}

--- a/packages/config/src/headers.test.js
+++ b/packages/config/src/headers.test.js
@@ -1,0 +1,45 @@
+const test = require('ava')
+const path = require('path')
+const { parseHeadersFile, objectForPath } = require('./headers.js')
+const sitePath = path.join(__dirname, '..', '..', 'tests', 'dummy-site')
+
+test('_headers: validate correct parsing', t => {
+  const rules = parseHeadersFile(path.resolve(sitePath, '_headers'))
+
+  t.deepEqual(rules, {
+    '/': {
+      'X-Frame-Options': ['SAMEORIGIN'],
+    },
+    '/*': {
+      'X-Frame-Thing': ['SAMEORIGIN'],
+    },
+    '/something/*': {
+      'X-Frame-Options': ['DENY'],
+      'X-XSS-Protection': ['1; mode=block'],
+      'cache-control': ['max-age=0', 'no-cache', 'no-store', 'must-revalidate'],
+    },
+    '/:ding/index.html': {
+      'X-Frame-Options': ['SAMEORIGIN'],
+    },
+  })
+})
+
+test('_headers: rulesForPath testing', t => {
+  const rules = parseHeadersFile(path.resolve(sitePath, '_headers'))
+  t.deepEqual(objectForPath(rules, '/'), {
+    'X-Frame-Options': ['SAMEORIGIN'],
+  })
+  t.deepEqual(objectForPath(rules, '/ding'), {
+    'X-Frame-Thing': ['SAMEORIGIN'],
+  })
+  t.deepEqual(objectForPath(rules, '/something/ding'), {
+    'X-Frame-Thing': ['SAMEORIGIN'],
+    'X-Frame-Options': ['DENY'],
+    'X-XSS-Protection': ['1; mode=block'],
+    'cache-control': ['max-age=0', 'no-cache', 'no-store', 'must-revalidate'],
+  })
+  t.deepEqual(objectForPath(rules, '/ding/index.html'), {
+    'X-Frame-Options': ['SAMEORIGIN'],
+    'X-Frame-Thing': ['SAMEORIGIN'],
+  })
+})

--- a/packages/config/src/headers.test.js
+++ b/packages/config/src/headers.test.js
@@ -1,5 +1,7 @@
-const test = require('ava')
 const path = require('path')
+
+const test = require('ava')
+
 const { parseHeadersFile, objectForPath } = require('./headers.js')
 const sitePath = path.join(__dirname, '..', '..', 'tests', 'dummy-site')
 

--- a/packages/config/src/parse.js
+++ b/packages/config/src/parse.js
@@ -23,12 +23,12 @@ const parseConfig = async function(configPath) {
   const configString = await readConfig(configPath)
 
   try {
-    const config =  parseToml(configString)
+    const config = parseToml(configString)
 
     const headersFilePath = path.join(path.dirname(configPath), '_headers')
     if (!(await pathExists(headersFilePath))) {
       const headers = parseHeadersFile(headersFilePath)
-      config.headers = { ...config.headers, ...headers, }
+      config.headers = { ...config.headers, ...headers }
     }
 
     return config

--- a/packages/config/src/parse.js
+++ b/packages/config/src/parse.js
@@ -27,8 +27,10 @@ const parseConfig = async function(configPath) {
 
     const headersFilePath = path.join(path.dirname(configPath), '_headers')
     if (!(await pathExists(headersFilePath))) {
-      const headers = parseHeadersFile(headersFilePath)
-      config.headers = { ...config.headers, ...headers }
+      const fileHeaders = parseHeadersFile(headersFilePath)
+      const configHeaders = config.headers || {}
+      const paths = Array.from(new Set(Object.keys(configHeaders).concat(Object.keys(fileHeaders))))
+      config.headers = paths.reduce((prev, k) => ({ ...prev, [k]: [...configHeaders[k], ...fileHeaders[k]] }), {})
     }
 
     return config


### PR DESCRIPTION
**Which problem is this pull request solving?**

Parsing `_headers` file along with `netlif.toml`

**List other issues or pull requests related to this problem**

Fixes: https://github.com/netlify/build/issues/1679

**Describe the solution you've chosen**

* Look for `_headers` file in the same directory as `netlify.toml`
* Parse its contents and merge them with existing rules defined in `netlify.toml`

**Describe alternatives you've considered**

* Keeping _headers files parsing in a different package
* Providing a separate interface in @netlify/config to parse _headers file manually

**Checklist**

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
