### PR TITLE
--buildbotServerSocket CLI flag

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -115,6 +115,11 @@ Default: automatically guessed`,
 Default: none`,
     hidden: true,
   },
+  buildbotServerSocket: {
+    string: true,
+    describe: `Path to the buildbot server socket. This is used to connect to the buildbot to trigger deploys.`,
+    hidden: true,
+  },
   telemetry: {
     boolean: true,
     describe: `Enable telemetry.

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -53,6 +53,7 @@ const build = async function(flags = {}) {
     errorMonitor,
     logs,
     buildTimer,
+    buildbotServerSocket,
     ...flagsA
   } = startBuild(flags)
 
@@ -85,6 +86,7 @@ const build = async function(flags = {}) {
       deployId,
       logs,
       testOpts,
+      buildbotServerSocket,
     })
     await handleBuildSuccess({
       commandsCount,
@@ -135,6 +137,7 @@ const runAndReportBuild = async function({
   childEnv,
   functionsDistDir,
   buildImagePluginsDir,
+  buildbotServerSocket,
   dry,
   siteInfo,
   mode,
@@ -161,6 +164,7 @@ const runAndReportBuild = async function({
       deployId,
       logs,
       testOpts,
+      buildbotServerSocket,
     })
     await reportStatuses({ statuses, childEnv, api, mode, netlifyConfig, errorMonitor, deployId, logs, testOpts })
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

`netlify-build` will need to communicate to the buildbot over a Unix socket server. The path to this Unix socket will be provided as a CLI argument.

**List other issues or pull requests related to this problem**

Part of https://github.com/netlify/build/pull/1659.

**Describe the solution you've chosen**

I've added a `--buildbotServerSocket` CLI flag.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
