### PR TITLE
Add `--timersFile` CLI flag

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -120,6 +120,12 @@ Default: none`,
     describe: `Path to the buildbot server socket. This is used to connect to the buildbot to trigger deploys.`,
     hidden: true,
   },
+  timersFile: {
+    string: true,
+    describe: `Path to the file recording timings.
+Default: none`,
+    hidden: true,
+  },
   telemetry: {
     boolean: true,
     describe: `Enable telemetry.

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -1,0 +1,33 @@
+const { appendFile } = require('fs')
+const { promisify } = require('util')
+
+const pAppendFile = promisify(appendFile)
+
+// Initialize the `timers` array
+const initTimers = function() {
+  return []
+}
+
+// Keep a specific timer duration in memory
+const addTimer = function(timers, name, durationMs) {
+  return [...timers, { name, durationMs }]
+}
+
+// Record the duration of a build phase, for monitoring.
+// We use a file for IPC.
+// This file is read by the buildbot at the end of the build, and the metrics
+// are sent.
+const reportTimers = async function(timers, timersFile) {
+  if (timersFile === undefined) {
+    return
+  }
+
+  const timersLines = timers.map(getTimerLine).join('')
+  await pAppendFile(timersFile, timersLines)
+}
+
+const getTimerLine = function({ name, durationMs }) {
+  return `${name} ${durationMs}ms\n`
+}
+
+module.exports = { initTimers, addTimer, reportTimers }

--- a/packages/build/tests/helpers/temp.js
+++ b/packages/build/tests/helpers/temp.js
@@ -24,4 +24,4 @@ const getTempName = async function() {
   return tempName
 }
 
-module.exports = { getTempDir }
+module.exports = { getTempDir, getTempName }

--- a/packages/build/tests/time/fixtures/plugin/manifest.yml
+++ b/packages/build/tests/time/fixtures/plugin/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/time/fixtures/plugin/netlify.toml
+++ b/packages/build/tests/time/fixtures/plugin/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin"

--- a/packages/build/tests/time/fixtures/plugin/plugin.js
+++ b/packages/build/tests/time/fixtures/plugin/plugin.js
@@ -1,0 +1,3 @@
+module.exports = {
+  onBuild() {},
+}

--- a/packages/build/tests/time/fixtures/simple/netlify.toml
+++ b/packages/build/tests/time/fixtures/simple/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+command = "node --version"

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -1,0 +1,54 @@
+const { readFile } = require('fs')
+const { promisify } = require('util')
+
+const test = require('ava')
+const del = require('del')
+
+const { runFixture } = require('../helpers/main')
+const { getTempName } = require('../helpers/temp')
+
+const pReadFile = promisify(readFile)
+
+test('Prints timings to --timersFile', async t => {
+  const timersFile = await getTempName()
+  try {
+    await runFixture(t, 'simple', { flags: { timersFile }, snapshot: false })
+
+    const timerLines = await getTimerLines(t, timersFile)
+    t.true(timerLines.every(isTimerLine))
+  } finally {
+    await del(timersFile, { force: true })
+  }
+})
+
+const getTimerLines = async function(t, timersFile) {
+  const timersFileContent = await pReadFile(timersFile, 'utf8')
+  return timersFileContent.trim().split('\n')
+}
+
+const isTimerLine = function(timerLine) {
+  const [name, durationMs] = timerLine.split(' ')
+  return [name, durationMs].every(isDefinedString) && DURATION_REGEXP.test(durationMs)
+}
+
+const isDefinedString = function(string) {
+  return typeof string === 'string' && string.trim() !== ''
+}
+
+const DURATION_REGEXP = /\d+ms/
+
+test('Prints all timings', async t => {
+  const timersFile = await getTempName()
+  try {
+    await runFixture(t, 'plugin', { flags: { timersFile }, snapshot: false })
+
+    const timersFileContent = await pReadFile(timersFile, 'utf8')
+    TIMINGS.forEach(timing => {
+      t.true(timersFileContent.includes(`${timing} `))
+    })
+  } finally {
+    await del(timersFile, { force: true })
+  }
+})
+
+const TIMINGS = ['buildbot.build.commands']


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/856

This adds a `--timersFile` CLI flag which allows measuring specific part of the build, and writing the durations to a `*.txt` file. That file is used by the buildbot, which sends the data to Datadog.

This PR also measures the whole build duration that way.