### PR TITLE
Measure how long it takes for plugins processes to start

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -215,7 +215,10 @@ const initAndRunBuild = async function({
     logs,
   })
 
+  const startPluginsTimer = startTimer()
   const childProcesses = await startPlugins({ pluginsOptions, buildDir, nodePath, childEnv, mode, logs })
+  const startPluginsDurationMs = endTimer(startPluginsTimer)
+  const timersA = addTimer(timers, 'buildbot.build.commands.startPlugins', startPluginsDurationMs)
 
   try {
     return await runBuild({
@@ -233,7 +236,7 @@ const initAndRunBuild = async function({
       errorMonitor,
       deployId,
       logs,
-      timers,
+      timers: timersA,
       testOpts,
     })
   } finally {

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -52,6 +52,7 @@ test('Prints all timings', async t => {
 })
 
 const TIMINGS = [
+  'buildbot.build.commands.startPlugins',
   'buildbot.build.commands.loadPlugins',
   'buildbot.build.commands.plugin.onBuild',
   'buildbot.build.commands',


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/856

This adds metrics about how long it takes to start plugins child processes.