### PR TITLE
Send metrics about plugins options loading

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -206,6 +206,8 @@ const initAndRunBuild = async function({
   testOpts,
 }) {
   const constants = await getConstants({ configPath, buildDir, functionsDistDir, netlifyConfig, siteInfo, mode })
+
+  const pluginsOptionsTimer = startTimer()
   const pluginsOptions = await getPluginsOptions({
     netlifyConfig,
     buildDir,
@@ -214,11 +216,13 @@ const initAndRunBuild = async function({
     buildImagePluginsDir,
     logs,
   })
+  const pluginsOptionsDurationMs = endTimer(pluginsOptionsTimer)
+  const timersA = addTimer(timers, 'buildbot.build.commands.getPluginsOptions', pluginsOptionsDurationMs)
 
   const startPluginsTimer = startTimer()
   const childProcesses = await startPlugins({ pluginsOptions, buildDir, nodePath, childEnv, mode, logs })
   const startPluginsDurationMs = endTimer(startPluginsTimer)
-  const timersA = addTimer(timers, 'buildbot.build.commands.startPlugins', startPluginsDurationMs)
+  const timersB = addTimer(timersA, 'buildbot.build.commands.startPlugins', startPluginsDurationMs)
 
   try {
     return await runBuild({
@@ -236,7 +240,7 @@ const initAndRunBuild = async function({
       errorMonitor,
       deployId,
       logs,
-      timers: timersA,
+      timers: timersB,
       testOpts,
     })
   } finally {

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -102,7 +102,11 @@ const build = async function(flags = {}) {
       telemetry,
       mode,
       logs,
+<<<<<<< HEAD
       timers: timersA,
+=======
+      timers,
+>>>>>>> Add `--timersFile` CLI flag
       timersFile,
       testOpts,
     })

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -102,11 +102,7 @@ const build = async function(flags = {}) {
       telemetry,
       mode,
       logs,
-<<<<<<< HEAD
       timers: timersA,
-=======
-      timers,
->>>>>>> Add `--timersFile` CLI flag
       timersFile,
       testOpts,
     })

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -52,6 +52,7 @@ test('Prints all timings', async t => {
 })
 
 const TIMINGS = [
+  'buildbot.build.commands.getPluginsOptions',
   'buildbot.build.commands.startPlugins',
   'buildbot.build.commands.loadPlugins',
   'buildbot.build.commands.plugin.onBuild',


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/856

This adds metrics about how long it takes to load the options and `manifest.yml` of plugins.