### PR TITLE
Fix typo in `functions-utils` `README`

### DIFF
--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -13,7 +13,7 @@ This allows plugins to:
 ```js
 module.exports = {
   // Add a Netlify Functions file or directory to a build
-  async onPostBuild({ utils }) {
+  async onPreBuild({ utils }) {
     await utils.functions.add('./path/to/function')
   },
 }


### PR DESCRIPTION
This fixes a typo in the `functions-utils` `README`.