### PR TITLE
Fix `cwd` option of `cache` utility

### DIFF
--- a/packages/cache-utils/src/utils/cwd.js
+++ b/packages/cache-utils/src/utils/cwd.js
@@ -1,3 +1,4 @@
+const { normalize } = require('path')
 const process = require('process')
 
 const pathExists = require('path-exists')
@@ -18,7 +19,7 @@ const safeGetCwd = async function(cwdOpt) {
 }
 
 const getCwdValue = function(cwdOpt = process.cwd()) {
-  return cwdOpt
+  return normalize(cwdOpt)
 }
 
 module.exports = { safeGetCwd }


### PR DESCRIPTION
The `cwd` option passed to `utils.cache.*()` methods should be normalized, since it is compared with other file paths which are normalized too. 