### PR TITLE
Rename the monitoring tag name of Build plugins

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -184,8 +184,8 @@ const shouldSkipCommand = function({ event, package, error, failedPlugins }) {
 
 // Wrap command function to measure its time
 const getFireCommand = function({ package, event }) {
-  const metricName = package === undefined ? 'command' : `${normalizeTimerName(package)}.${event}`
-  return measureDuration(tFireCommand, `run_netlify_build.${metricName}`)
+  const metricName = package === undefined ? 'run_netlify_build.command' : `${normalizeTimerName(package)}.${event}`
+  return measureDuration(tFireCommand, metricName)
 }
 
 const tFireCommand = function({

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -56,6 +56,6 @@ const TIMINGS = [
   'run_netlify_build.get_plugins_options',
   'run_netlify_build.start_plugins',
   'run_netlify_build.load_plugins',
-  'run_netlify_build.plugin.onBuild',
+  'plugin.onBuild',
   'run_netlify_build.total',
 ]


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/888

This renames the tag name used in Datadog to monitor the duration of Build plugins.

This will make it easier to separate those from the other metrics.