### PR TITLE
Rename `metricName` to `tag`

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -184,8 +184,8 @@ const shouldSkipCommand = function({ event, package, error, failedPlugins }) {
 
 // Wrap command function to measure its time
 const getFireCommand = function({ package, event }) {
-  const metricName = package === undefined ? 'run_netlify_build.command' : `${normalizeTimerName(package)}.${event}`
-  return measureDuration(tFireCommand, metricName)
+  const tag = package === undefined ? 'run_netlify_build.command' : `${normalizeTimerName(package)}.${event}`
+  return measureDuration(tFireCommand, tag)
 }
 
 const tFireCommand = function({

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -14,12 +14,12 @@ const initTimers = function() {
 //   - return a plain object. This may or may not contain a modified `timers`.
 // The `durationMs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
-const kMeasureDuration = function(func, name) {
+const kMeasureDuration = function(func, tag) {
   return async function({ timers, ...opts }, ...args) {
     const timer = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
     const durationMs = endTimer(timer)
-    const timersB = [...timersA, { name, durationMs }]
+    const timersB = [...timersA, { tag, durationMs }]
     return { ...returnObject, timers: timersB, durationMs }
   }
 }

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -16,8 +16,8 @@ const reportTimers = async function(timers, timersFile) {
   await pAppendFile(timersFile, timersLines)
 }
 
-const getTimerLine = function({ name, durationMs }) {
-  return `${name} ${durationMs}ms\n`
+const getTimerLine = function({ tag, durationMs }) {
+  return `${tag} ${durationMs}ms\n`
 }
 
 module.exports = { reportTimers }

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -27,8 +27,8 @@ const getTimerLines = async function(t, timersFile) {
 }
 
 const isTimerLine = function(timerLine) {
-  const [name, durationMs] = timerLine.split(' ')
-  return [name, durationMs].every(isDefinedString) && DURATION_REGEXP.test(durationMs)
+  const [tag, durationMs] = timerLine.split(' ')
+  return [tag, durationMs].every(isDefinedString) && DURATION_REGEXP.test(durationMs)
 }
 
 const isDefinedString = function(string) {
@@ -43,8 +43,8 @@ test('Prints all timings', async t => {
     await runFixture(t, 'plugin', { flags: { timersFile }, snapshot: false })
 
     const timersFileContent = await pReadFile(timersFile, 'utf8')
-    TIMINGS.forEach(timing => {
-      t.true(timersFileContent.includes(`${timing} `))
+    TIMINGS.forEach(tag => {
+      t.true(timersFileContent.includes(`${tag} `))
     })
   } finally {
     await del(timersFile, { force: true })


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/888

This renames some internal variables that are Datadog tags, but are currently named metrics instead.