### PR TITLE
Add test for the `build.command` duration monitoring

### DIFF
--- a/packages/build/tests/time/fixtures/plugin/netlify.toml
+++ b/packages/build/tests/time/fixtures/plugin/netlify.toml
@@ -1,2 +1,5 @@
+[build]
+command = "node --version"
+
 [[plugins]]
 package = "./plugin"

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -56,6 +56,7 @@ const TIMINGS = [
   'run_netlify_build.get_plugins_options',
   'run_netlify_build.start_plugins',
   'run_netlify_build.load_plugins',
-  'plugin.onBuild',
+  'run_netlify_build.command',
   'run_netlify_build.total',
+  'plugin.onBuild',
 ]


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/888

This improves a test so that `build.command` duration monitoring is also tested.