### PR TITLE
Separate metrics and tags

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -184,8 +184,11 @@ const shouldSkipCommand = function({ event, package, error, failedPlugins }) {
 
 // Wrap command function to measure its time
 const getFireCommand = function({ package, event }) {
-  const tag = package === undefined ? 'run_netlify_build.command' : `${normalizeTimerName(package)}.${event}`
-  return measureDuration(tFireCommand, tag)
+  const [metric, tag] =
+    package === undefined
+      ? ['build.substage.duration', 'run_netlify_build.command']
+      : ['build.plugins', `${normalizeTimerName(package)}.${event}`]
+  return measureDuration(tFireCommand, metric, tag)
 }
 
 const tFireCommand = function({

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -64,7 +64,7 @@ const tLoadConfig = async function({
   return { netlifyConfig, configPath, buildDir, childEnv, api: apiA, siteInfo }
 }
 
-const loadConfig = measureDuration(tLoadConfig, 'run_netlify_build.resolve_config')
+const loadConfig = measureDuration(tLoadConfig, 'build.substage.duration', 'run_netlify_build.resolve_config')
 
 // Retrieve configuration file and related information
 // (path, build directory, etc.)

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -159,7 +159,7 @@ const tExecBuild = async function({
   return { netlifyConfig, siteInfo, commandsCount, timers: timersB }
 }
 
-const execBuild = measureDuration(tExecBuild, 'run_netlify_build.total')
+const execBuild = measureDuration(tExecBuild, 'build.substage.duration', 'run_netlify_build.total')
 
 // Runs a build then report any plugin statuses
 const runAndReportBuild = async function({

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -15,7 +15,7 @@ const tLoadPlugins = async function({ pluginsOptions, childProcesses, netlifyCon
   return { pluginsCommands: pluginsCommandsA }
 }
 
-const loadPlugins = measureDuration(tLoadPlugins, 'run_netlify_build.load_plugins')
+const loadPlugins = measureDuration(tLoadPlugins, 'build.substage.duration', 'run_netlify_build.load_plugins')
 
 // Retrieve plugin commands for one plugin.
 // Do it by executing the plugin `load` event handler.

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -29,7 +29,11 @@ const tGetPluginsOptions = async function({
   return { pluginsOptions: pluginsOptionsB }
 }
 
-const getPluginsOptions = measureDuration(tGetPluginsOptions, 'run_netlify_build.get_plugins_options')
+const getPluginsOptions = measureDuration(
+  tGetPluginsOptions,
+  'build.substage.duration',
+  'run_netlify_build.get_plugins_options',
+)
 
 const addCoreProperties = function(corePlugin) {
   return { ...corePlugin, loadedFrom: 'core', origin: 'core' }

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -41,7 +41,7 @@ const tStartPlugins = async function({ pluginsOptions, buildDir, nodePath, child
   return { childProcesses }
 }
 
-const startPlugins = measureDuration(tStartPlugins, 'run_netlify_build.start_plugins')
+const startPlugins = measureDuration(tStartPlugins, 'build.substage.duration', 'run_netlify_build.start_plugins')
 
 const startPlugin = async function({
   buildDir,

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -14,12 +14,12 @@ const initTimers = function() {
 //   - return a plain object. This may or may not contain a modified `timers`.
 // The `durationMs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
-const kMeasureDuration = function(func, tag) {
+const kMeasureDuration = function(func, metric, tag) {
   return async function({ timers, ...opts }, ...args) {
     const timer = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
     const durationMs = endTimer(timer)
-    const timersB = [...timersA, { tag, durationMs }]
+    const timersB = [...timersA, { metric, tag, durationMs }]
     return { ...returnObject, timers: timersB, durationMs }
   }
 }
@@ -27,7 +27,7 @@ const kMeasureDuration = function(func, tag) {
 // Ensure the wrapped function `name` is not `anonymous` in stack traces
 const measureDuration = keepFuncProps(kMeasureDuration)
 
-// Make sure the timer name does not include special characters.
+// Make sure the timer tag/metric name does not include special characters.
 // For example, the `package` of local plugins includes dots.
 const normalizeTimerName = function(name) {
   return slugify(name, { separator: '_' })

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -16,8 +16,8 @@ const reportTimers = async function(timers, timersFile) {
   await pAppendFile(timersFile, timersLines)
 }
 
-const getTimerLine = function({ tag, durationMs }) {
-  return `${tag} ${durationMs}ms\n`
+const getTimerLine = function({ metric, tag, durationMs }) {
+  return `${metric}\t${tag}\t${durationMs}ms\n`
 }
 
 module.exports = { reportTimers }

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -16,7 +16,8 @@ test('Prints timings to --timersFile', async t => {
 
     const timerLines = await getTimerLines(timersFile)
 
-    timerLines.forEach(({ tag, durationMs }) => {
+    timerLines.forEach(({ metric, tag, durationMs }) => {
+      t.true(isDefinedString(metric))
       t.true(isDefinedString(tag))
       t.true(isDefinedString(durationMs))
       t.true(DURATION_REGEXP.test(durationMs))
@@ -38,8 +39,8 @@ test('Prints all timings', async t => {
     await runFixture(t, 'plugin', { flags: { timersFile }, snapshot: false })
 
     const timerLines = await getTimerLines(timersFile)
-    TIMINGS.forEach(tag => {
-      t.true(timerLines.some(timerLine => timerLine.tag === tag))
+    TIMINGS.forEach(({ metric, tag }) => {
+      t.true(timerLines.some(timerLine => timerLine.metric === metric && timerLine.tag === tag))
     })
   } finally {
     await del(timersFile, { force: true })
@@ -47,13 +48,13 @@ test('Prints all timings', async t => {
 })
 
 const TIMINGS = [
-  'run_netlify_build.resolve_config',
-  'run_netlify_build.get_plugins_options',
-  'run_netlify_build.start_plugins',
-  'run_netlify_build.load_plugins',
-  'run_netlify_build.command',
-  'run_netlify_build.total',
-  'plugin.onBuild',
+  { metric: 'build.substage.duration', tag: 'run_netlify_build.resolve_config' },
+  { metric: 'build.substage.duration', tag: 'run_netlify_build.get_plugins_options' },
+  { metric: 'build.substage.duration', tag: 'run_netlify_build.start_plugins' },
+  { metric: 'build.substage.duration', tag: 'run_netlify_build.load_plugins' },
+  { metric: 'build.substage.duration', tag: 'run_netlify_build.command' },
+  { metric: 'build.substage.duration', tag: 'run_netlify_build.total' },
+  { metric: 'build.plugins', tag: 'plugin.onBuild' },
 ]
 
 const getTimerLines = async function(timersFile) {
@@ -65,6 +66,6 @@ const getTimerLines = async function(timersFile) {
 }
 
 const parseTimerLine = function(timerLine) {
-  const [tag, durationMs] = timerLine.split(' ')
-  return { tag, durationMs }
+  const [metric, tag, durationMs] = timerLine.split('\t')
+  return { metric, tag, durationMs }
 }


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/888

This separate Datadog metrics and tags in our performance monitoring.

This also changes the delimiter used in the monitoring file, from spaces to tabs.