### PR TITLE
Do not log `timersFile` in production

### DIFF
--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -39,7 +39,7 @@ const SECURE_FLAGS = ['token', 'bugsnagKey', 'env', 'cachedConfig', 'defaultConf
 // Hidden because those are used in tests
 const TEST_FLAGS = ['buffer', 'telemetry']
 // Hidden because those are only used internally
-const INTERNAL_FLAGS = ['nodePath', 'functionsDistDir', 'buildImagePluginsDir', 'sendStatus']
+const INTERNAL_FLAGS = ['nodePath', 'functionsDistDir', 'buildImagePluginsDir', 'sendStatus', 'timersFile']
 const HIDDEN_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, ...INTERNAL_FLAGS]
 const HIDDEN_DEBUG_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS]
 


### PR DESCRIPTION
`timersFile` is an internal CLI flag that should not be shown in the build logs.