### PR TITLE
Improve packages `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "description": "Netlify build module",
   "main": "index.js",
+  "author": "Netlify Inc.",
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap",
@@ -21,11 +22,34 @@
     }
   },
   "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
     "netlify-plugin",
     "netlify"
   ],
-  "author": "",
+  "homepage": "https://github.com/netlify/build",
+  "repository": "https://github.com/netlify/build",
+  "bugs": {
+    "url": "https://github.com/netlify/build/issues"
+  },
   "license": "MIT",
+  "dependencies": {},
   "devDependencies": {
     "ava": "^2.4.0",
     "babel-eslint": "^10.1.0",
@@ -40,7 +64,6 @@
     "nyc": "^15.0.0",
     "prettier": "^1.19.1"
   },
-  "dependencies": {},
   "engines": {
     "node": ">=8.3.0"
   }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,34 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"
   },
-  "repository": "https://github.com/netlify/build",
+  "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
+    "netlify-plugin",
+    "netlify"
+  ],
+  "homepage": "https://github.com/netlify/build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/build"
+  },
   "bugs": {
     "url": "https://github.com/netlify/build/issues"
   },

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -13,6 +13,37 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"
   },
+  "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
+    "netlify-plugin",
+    "netlify"
+  ],
+  "homepage": "https://github.com/netlify/build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/cache-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/build/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "array-flat-polyfill": "^1.0.1",
@@ -30,10 +61,6 @@
     "ava": "^2.4.0",
     "make-dir": "^3.1.0",
     "tmp-promise": "^3.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/netlify/build"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,6 +19,37 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"
   },
+  "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
+    "netlify-plugin",
+    "netlify"
+  ],
+  "homepage": "https://github.com/netlify/build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/config"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/build/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "array-flat-polyfill": "^1.0.1",

--- a/packages/functions-utils/package.json
+++ b/packages/functions-utils/package.json
@@ -13,6 +13,37 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"
   },
+  "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
+    "netlify-plugin",
+    "netlify"
+  ],
+  "homepage": "https://github.com/netlify/build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/functions-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/build/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "@netlify/zip-it-and-ship-it": "^1.3.10",
@@ -23,10 +54,6 @@
     "ava": "^2.4.0",
     "del": "^5.1.0",
     "tmp-promise": "^3.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/netlify/build"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -14,6 +14,37 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"
   },
+  "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
+    "netlify-plugin",
+    "netlify"
+  ],
+  "homepage": "https://github.com/netlify/build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/git-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/build/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "execa": "^3.4.0",
@@ -24,10 +55,6 @@
   },
   "devDependencies": {
     "ava": "^2.4.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/netlify/build"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -13,6 +13,37 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish"
   },
+  "keywords": [
+    "nodejs",
+    "javascript",
+    "windows",
+    "macos",
+    "linux",
+    "shell",
+    "bash",
+    "build",
+    "terminal",
+    "deployment",
+    "es6",
+    "serverless",
+    "continuous-integration",
+    "continuous-delivery",
+    "ci",
+    "continuous-deployment",
+    "plugins",
+    "continuous-testing",
+    "netlify-plugin",
+    "netlify"
+  ],
+  "homepage": "https://github.com/netlify/build",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/run-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/build/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "execa": "^3.4.0"
@@ -20,10 +51,6 @@
   "devDependencies": {
     "ava": "^2.4.0",
     "semver": "^7.3.2"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/netlify/build"
   },
   "engines": {
     "node": ">=8.3.0"


### PR DESCRIPTION
Fixes #993.

The `package.json` of our packages are missing some fields. For example, they have no `repository` field, which means the link to GitHub does not show up in npm.