### PR TITLE
Add `statsd` parent tags

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -184,8 +184,12 @@ const shouldSkipCommand = function({ event, package, error, failedPlugins }) {
 
 // Wrap command function to measure its time
 const getFireCommand = function({ package, event }) {
-  const tag = package === undefined ? 'run_netlify_build.command' : `${normalizeTimerName(package)}.${event}`
-  return measureDuration(tFireCommand, tag)
+  if (package === undefined) {
+    return measureDuration(tFireCommand, 'run_netlify_build.command')
+  }
+
+  const parentTag = normalizeTimerName(package)
+  return measureDuration(tFireCommand, `${parentTag}.${event}`, parentTag)
 }
 
 const tFireCommand = function({

--- a/packages/build/src/time/aggregate.js
+++ b/packages/build/src/time/aggregate.js
@@ -1,3 +1,5 @@
+const { createTimer } = require('./main')
+
 // Some timers are computed based on others:
 //   - `run_plugins` is the sum of all plugins
 //   - each plugin timer is the sum of its event handlers
@@ -34,7 +36,7 @@ const getPluginPackages = function(pluginsTimers) {
 
 const getWholePluginTimer = function(pluginPackage, pluginsTimers) {
   const pluginTimers = pluginsTimers.filter(pluginTimer => getPluginTimerPackage(pluginTimer) === pluginPackage)
-  const wholePluginsTimer = createSumTimer(pluginTimers, pluginPackage)
+  const wholePluginsTimer = createSumTimer(pluginTimers, pluginPackage, RUN_PLUGINS_TAG)
   return wholePluginsTimer
 }
 
@@ -44,9 +46,10 @@ const getPluginTimerPackage = function({ tag }) {
 }
 
 // Creates a timer that sums up the duration of several others
-const createSumTimer = function(timers, tag) {
+const createSumTimer = function(timers, tag, parentTag) {
   const durationMs = computeTimersDuration(timers)
-  return { tag, durationMs }
+  const timer = createTimer(tag, durationMs, { parentTag })
+  return timer
 }
 
 const computeTimersDuration = function(timers) {


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1738

This adds `parent` statsd tags. This allows for performance measurements to be nested within each other.