### PR TITLE
Rename `tag` internal variable to `stageTag`

### DIFF
--- a/packages/build/src/time/aggregate.js
+++ b/packages/build/src/time/aggregate.js
@@ -15,8 +15,8 @@ const addAggregatedTimers = function(timers) {
 }
 
 // Check if a timer relates to a Build plugin
-const isPluginTimer = function({ tag }) {
-  return !tag.startsWith(NON_PLUGIN_PREFIX)
+const isPluginTimer = function({ stageTag }) {
+  return !stageTag.startsWith(NON_PLUGIN_PREFIX)
 }
 
 const NON_PLUGIN_PREFIX = 'run_netlify_build.'
@@ -40,15 +40,15 @@ const getWholePluginTimer = function(pluginPackage, pluginsTimers) {
   return wholePluginsTimer
 }
 
-const getPluginTimerPackage = function({ tag }) {
-  const [pluginPackage] = tag.split('.')
+const getPluginTimerPackage = function({ stageTag }) {
+  const [pluginPackage] = stageTag.split('.')
   return pluginPackage
 }
 
 // Creates a timer that sums up the duration of several others
-const createSumTimer = function(timers, tag, parentTag) {
+const createSumTimer = function(timers, stageTag, parentTag) {
   const durationMs = computeTimersDuration(timers)
-  const timer = createTimer(tag, durationMs, { parentTag })
+  const timer = createTimer(stageTag, durationMs, { parentTag })
   return timer
 }
 

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -14,12 +14,12 @@ const initTimers = function() {
 //   - return a plain object. This may or may not contain a modified `timers`.
 // The `durationMs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
-const kMeasureDuration = function(func, tag, parentTag) {
+const kMeasureDuration = function(func, stageTag, parentTag) {
   return async function({ timers, ...opts }, ...args) {
     const timerMs = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
     const durationMs = endTimer(timerMs)
-    const timer = createTimer(tag, durationMs, { parentTag })
+    const timer = createTimer(stageTag, durationMs, { parentTag })
     const timersB = [...timersA, timer]
     return { ...returnObject, timers: timersB, durationMs }
   }
@@ -29,8 +29,8 @@ const kMeasureDuration = function(func, tag, parentTag) {
 const measureDuration = keepFuncProps(kMeasureDuration)
 
 // Create a new object representing a completed timer
-const createTimer = function(tag, durationMs, { parentTag = DEFAULT_PARENT_TAG } = {}) {
-  return { tag, parentTag, durationMs }
+const createTimer = function(stageTag, durationMs, { parentTag = DEFAULT_PARENT_TAG } = {}) {
+  return { stageTag, parentTag, durationMs }
 }
 
 const DEFAULT_PARENT_TAG = 'run_netlify_build'

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -19,8 +19,8 @@ const reportTimers = async function(timers, timersFile) {
   await pAppendFile(timersFile, timersLines)
 }
 
-const getTimerLine = function({ tag, durationMs }) {
-  return `${tag} ${durationMs}ms\n`
+const getTimerLine = function({ stageTag, durationMs }) {
+  return `${stageTag} ${durationMs}ms\n`
 }
 
 module.exports = { reportTimers }

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -16,8 +16,8 @@ test('Prints timings to --timersFile', async t => {
 
     const timerLines = await getTimerLines(timersFile)
 
-    timerLines.forEach(({ tag, durationMs }) => {
-      t.true(isDefinedString(tag))
+    timerLines.forEach(({ stageTag, durationMs }) => {
+      t.true(isDefinedString(stageTag))
       t.true(isDefinedString(durationMs))
       t.true(DURATION_REGEXP.test(durationMs))
     })
@@ -38,8 +38,8 @@ test('Prints all timings', async t => {
     await runFixture(t, 'plugin', { flags: { timersFile }, snapshot: false })
 
     const timerLines = await getTimerLines(timersFile)
-    TIMINGS.forEach(tag => {
-      t.true(timerLines.some(timerLine => timerLine.tag === tag))
+    TIMINGS.forEach(stageTag => {
+      t.true(timerLines.some(timerLine => timerLine.stageTag === stageTag))
     })
   } finally {
     await del(timersFile, { force: true })
@@ -69,6 +69,6 @@ const getTimerLines = async function(timersFile) {
 }
 
 const parseTimerLine = function(timerLine) {
-  const [tag, durationMs] = timerLine.split(' ')
-  return { tag, durationMs }
+  const [stageTag, durationMs] = timerLine.split(' ')
+  return { stageTag, durationMs }
 }


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1738

This renames the internal-only variable `tag` to `stageTag` instead, since we know use several statsd tags (`stage` and `parent`).