### PR TITLE
Rename all statsd `stage` tags

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -185,11 +185,11 @@ const shouldSkipCommand = function({ event, package, error, failedPlugins }) {
 // Wrap command function to measure its time
 const getFireCommand = function({ package, event }) {
   if (package === undefined) {
-    return measureDuration(tFireCommand, 'run_netlify_build.command')
+    return measureDuration(tFireCommand, 'build_command')
   }
 
   const parentTag = normalizeTimerName(package)
-  return measureDuration(tFireCommand, `${parentTag}.${event}`, parentTag)
+  return measureDuration(tFireCommand, event, { parentTag, category: 'pluginEvent' })
 }
 
 const tFireCommand = function({

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -64,7 +64,7 @@ const tLoadConfig = async function({
   return { netlifyConfig, configPath, buildDir, childEnv, api: apiA, siteInfo }
 }
 
-const loadConfig = measureDuration(tLoadConfig, 'run_netlify_build.resolve_config')
+const loadConfig = measureDuration(tLoadConfig, 'resolve_config')
 
 // Retrieve configuration file and related information
 // (path, build directory, etc.)

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -159,7 +159,7 @@ const tExecBuild = async function({
   return { netlifyConfig, siteInfo, commandsCount, timers: timersB }
 }
 
-const execBuild = measureDuration(tExecBuild, 'run_netlify_build.total')
+const execBuild = measureDuration(tExecBuild, 'total')
 
 // Runs a build then report any plugin statuses
 const runAndReportBuild = async function({

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -15,7 +15,7 @@ const tLoadPlugins = async function({ pluginsOptions, childProcesses, netlifyCon
   return { pluginsCommands: pluginsCommandsA }
 }
 
-const loadPlugins = measureDuration(tLoadPlugins, 'run_netlify_build.load_plugins')
+const loadPlugins = measureDuration(tLoadPlugins, 'load_plugins')
 
 // Retrieve plugin commands for one plugin.
 // Do it by executing the plugin `load` event handler.

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -29,7 +29,7 @@ const tGetPluginsOptions = async function({
   return { pluginsOptions: pluginsOptionsB }
 }
 
-const getPluginsOptions = measureDuration(tGetPluginsOptions, 'run_netlify_build.get_plugins_options')
+const getPluginsOptions = measureDuration(tGetPluginsOptions, 'get_plugins_options')
 
 const addCoreProperties = function(corePlugin) {
   return { ...corePlugin, loadedFrom: 'core', origin: 'core' }

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -41,7 +41,7 @@ const tStartPlugins = async function({ pluginsOptions, buildDir, nodePath, child
   return { childProcesses }
 }
 
-const startPlugins = measureDuration(tStartPlugins, 'run_netlify_build.start_plugins')
+const startPlugins = measureDuration(tStartPlugins, 'start_plugins')
 
 const startPlugin = async function({
   buildDir,

--- a/packages/build/src/time/aggregate.js
+++ b/packages/build/src/time/aggregate.js
@@ -15,12 +15,11 @@ const addAggregatedTimers = function(timers) {
 }
 
 // Check if a timer relates to a Build plugin
-const isPluginTimer = function({ stageTag }) {
-  return !stageTag.startsWith(NON_PLUGIN_PREFIX)
+const isPluginTimer = function({ category }) {
+  return category === 'pluginEvent'
 }
 
-const NON_PLUGIN_PREFIX = 'run_netlify_build.'
-const RUN_PLUGINS_TAG = `${NON_PLUGIN_PREFIX}run_plugins`
+const RUN_PLUGINS_TAG = 'run_plugins'
 
 // Retrieve one timer for each plugin, summing all its individual timers
 // (one per event handler)
@@ -40,9 +39,8 @@ const getWholePluginTimer = function(pluginPackage, pluginsTimers) {
   return wholePluginsTimer
 }
 
-const getPluginTimerPackage = function({ stageTag }) {
-  const [pluginPackage] = stageTag.split('.')
-  return pluginPackage
+const getPluginTimerPackage = function({ parentTag }) {
+  return parentTag
 }
 
 // Creates a timer that sums up the duration of several others

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -14,12 +14,12 @@ const initTimers = function() {
 //   - return a plain object. This may or may not contain a modified `timers`.
 // The `durationMs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
-const kMeasureDuration = function(func, stageTag, parentTag) {
+const kMeasureDuration = function(func, stageTag, { parentTag, category } = {}) {
   return async function({ timers, ...opts }, ...args) {
     const timerMs = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
     const durationMs = endTimer(timerMs)
-    const timer = createTimer(stageTag, durationMs, { parentTag })
+    const timer = createTimer(stageTag, durationMs, { parentTag, category })
     const timersB = [...timersA, timer]
     return { ...returnObject, timers: timersB, durationMs }
   }
@@ -29,8 +29,8 @@ const kMeasureDuration = function(func, stageTag, parentTag) {
 const measureDuration = keepFuncProps(kMeasureDuration)
 
 // Create a new object representing a completed timer
-const createTimer = function(stageTag, durationMs, { parentTag = DEFAULT_PARENT_TAG } = {}) {
-  return { stageTag, parentTag, durationMs }
+const createTimer = function(stageTag, durationMs, { parentTag = DEFAULT_PARENT_TAG, category } = {}) {
+  return { stageTag, parentTag, durationMs, category }
 }
 
 const DEFAULT_PARENT_TAG = 'run_netlify_build'

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -47,17 +47,17 @@ test('Prints all timings', async t => {
 })
 
 const TIMINGS = [
-  'run_netlify_build.resolve_config',
-  'run_netlify_build.get_plugins_options',
-  'run_netlify_build.start_plugins',
-  'run_netlify_build.load_plugins',
-  'run_netlify_build.run_plugins',
-  'run_netlify_build.command',
-  'run_netlify_build.total',
+  'resolve_config',
+  'get_plugins_options',
+  'start_plugins',
+  'load_plugins',
+  'run_plugins',
+  'build_command',
+  'total',
   'one',
-  'one.onBuild',
-  'two.onBuild',
-  'two.onPostBuild',
+  'two',
+  'onBuild',
+  'onPostBuild',
 ]
 
 const getTimerLines = async function(timersFile) {


### PR DESCRIPTION
Background at https://github.com/netlify/buildbot/issues/898

This rename all statsd `stage` tags to match the pattern described in https://github.com/netlify/build/issues/1738
_
In particular, this removes the namespace prefixing, and rename `command` to `build_command`.