### PR TITLE
Replace `total` duration measurement by `others`

### DIFF
--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -159,7 +159,7 @@ const tExecBuild = async function({
   return { netlifyConfig, siteInfo, commandsCount, timers: timersB }
 }
 
-const execBuild = measureDuration(tExecBuild, 'total')
+const execBuild = measureDuration(tExecBuild, 'total', { parentTag: 'build_site' })
 
 // Runs a build then report any plugin statuses
 const runAndReportBuild = async function({

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -29,11 +29,11 @@ const kMeasureDuration = function(func, stageTag, { parentTag, category } = {}) 
 const measureDuration = keepFuncProps(kMeasureDuration)
 
 // Create a new object representing a completed timer
-const createTimer = function(stageTag, durationMs, { parentTag = DEFAULT_PARENT_TAG, category } = {}) {
+const createTimer = function(stageTag, durationMs, { parentTag = TOP_PARENT_TAG, category } = {}) {
   return { stageTag, parentTag, durationMs, category }
 }
 
-const DEFAULT_PARENT_TAG = 'run_netlify_build'
+const TOP_PARENT_TAG = 'run_netlify_build'
 
 // Make sure the timer name does not include special characters.
 // For example, the `package` of local plugins includes dots.
@@ -41,4 +41,4 @@ const normalizeTimerName = function(name) {
   return slugify(name, { separator: '_' })
 }
 
-module.exports = { initTimers, measureDuration, normalizeTimerName, createTimer }
+module.exports = { initTimers, measureDuration, normalizeTimerName, createTimer, TOP_PARENT_TAG }

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -53,7 +53,7 @@ const TIMINGS = [
   'load_plugins',
   'run_plugins',
   'build_command',
-  'total',
+  'others',
   'one',
   'two',
   'onBuild',


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1738

The `total` duration measurement is redundant with the buildbot one (which is better since it includes Node.js load time).

This PR replaces it by another one `others`, which counts all the durations that are not taken into account by other measurements. It does hits by using the `total` duration, and subtracting all the others. That measurement should ideally be very small. If it is big, it means there are some slow parts we are not measuring. Detecting those is the purpose of that measurement.