### PR TITLE
Improve performance monitoring rounding

### DIFF
--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -129,7 +129,7 @@ const runCommand = async function({
   logCommand({ logs, event, buildCommandOrigin, package, index, error })
 
   const fireCommand = getFireCommand({ package, event })
-  const { newEnvChanges, newError, newStatus, timers: timersA, durationMs } = await fireCommand({
+  const { newEnvChanges, newError, newStatus, timers: timersA, durationNs } = await fireCommand({
     event,
     childProcess,
     package,
@@ -164,7 +164,7 @@ const runCommand = async function({
     netlifyConfig,
     logs,
     timers: timersA,
-    durationMs,
+    durationNs,
     testOpts,
   })
   return { ...newValues, newIndex: index + 1 }
@@ -252,7 +252,7 @@ const getNewValues = function({
   netlifyConfig,
   logs,
   timers,
-  durationMs,
+  durationNs,
   testOpts,
 }) {
   if (newError !== undefined) {
@@ -273,7 +273,7 @@ const getNewValues = function({
   logCommandSuccess(logs)
 
   const timerName = package === undefined ? 'build.command' : `${package} ${event}`
-  logTimer(logs, durationMs, timerName)
+  logTimer(logs, durationNs, timerName)
 
   return { newEnvChanges, newStatus, timers }
 }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -46,7 +46,7 @@ const build = async function(flags = {}) {
   const errorParams = { errorMonitor, mode, logs, testOpts }
 
   try {
-    const { netlifyConfig, siteInfo, commandsCount, timers, durationMs } = await execBuild({
+    const { netlifyConfig, siteInfo, commandsCount, timers, durationNs } = await execBuild({
       ...flagsA,
       dry,
       errorMonitor,
@@ -65,7 +65,7 @@ const build = async function(flags = {}) {
       logs,
       timers,
       timersFile,
-      durationMs,
+      durationNs,
       testOpts,
     })
     return { success: true, logs }
@@ -361,7 +361,7 @@ const handleBuildSuccess = async function({
   logs,
   timers,
   timersFile,
-  durationMs,
+  durationNs,
   testOpts,
 }) {
   if (dry) {
@@ -370,9 +370,9 @@ const handleBuildSuccess = async function({
 
   logBuildSuccess(logs)
 
-  logTimer(logs, durationMs, 'Netlify Build')
+  logTimer(logs, durationNs, 'Netlify Build')
   await reportTimers(timers, timersFile)
-  await trackBuildComplete({ commandsCount, netlifyConfig, durationMs, siteInfo, telemetry, mode, testOpts })
+  await trackBuildComplete({ commandsCount, netlifyConfig, durationNs, siteInfo, telemetry, mode, testOpts })
 }
 
 module.exports = build

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -5,6 +5,7 @@ const prettyMs = require('pretty-ms')
 const { name, version } = require('../../package.json')
 const { isSuccessException } = require('../error/cancel')
 const { serializeLogError } = require('../error/parse/serialize_log')
+const { roundTimerToMillisecs } = require('../time/measure')
 const { omit } = require('../utils/omit')
 
 const { getCommandDescription, getBuildCommandDescription, getPluginOrigin } = require('./description')
@@ -219,7 +220,8 @@ More information can be found at https://docs.netlify.com/configure-builds/troub
   )
 }
 
-const logTimer = function(logs, durationMs, timerName) {
+const logTimer = function(logs, durationNs, timerName) {
+  const durationMs = roundTimerToMillisecs(durationNs)
   const duration = prettyMs(durationMs)
   log(logs, THEME.dimWords(`(${timerName} completed in ${duration})`))
 }

--- a/packages/build/src/telemetry/complete.js
+++ b/packages/build/src/telemetry/complete.js
@@ -4,6 +4,7 @@ const isCI = require('is-ci')
 const osName = require('os-name')
 
 const { version } = require('../../package.json')
+const { roundTimerToMillisecs } = require('../time/measure')
 
 const { analytics } = require('./track')
 
@@ -11,18 +12,19 @@ const { analytics } = require('./track')
 const trackBuildComplete = async function({
   commandsCount,
   netlifyConfig,
-  durationMs,
+  durationNs,
   siteInfo,
   telemetry,
   mode,
   testOpts,
 }) {
-  const payload = getPayload({ commandsCount, netlifyConfig, durationMs, siteInfo, mode })
+  const payload = getPayload({ commandsCount, netlifyConfig, durationNs, siteInfo, mode })
   await analytics.track('netlifyCI:buildComplete', { payload, telemetry, testOpts })
 }
 
 // Retrieve telemetry information
-const getPayload = function({ commandsCount, netlifyConfig, durationMs, siteInfo: { id: siteId }, mode }) {
+const getPayload = function({ commandsCount, netlifyConfig, durationNs, siteInfo: { id: siteId }, mode }) {
+  const durationMs = roundTimerToMillisecs(durationNs)
   const plugins = Object.values(netlifyConfig.plugins).map(getPluginPackage)
   return {
     steps: commandsCount,

--- a/packages/build/src/time/aggregate.js
+++ b/packages/build/src/time/aggregate.js
@@ -29,10 +29,10 @@ const isTopTimer = function({ parentTag }) {
   return parentTag === TOP_PARENT_TAG
 }
 
-const createOthersTimer = function(topTimers, { durationMs: totalTimerDurationMs }) {
-  const topTimersDurationMs = computeTimersDuration(topTimers)
-  const otherTimersDurationMs = Math.max(0, totalTimerDurationMs - topTimersDurationMs)
-  const othersTimer = createTimer(OTHERS_STAGE_TAG, otherTimersDurationMs)
+const createOthersTimer = function(topTimers, { durationNs: totalTimerDurationNs }) {
+  const topTimersDurationNs = computeTimersDuration(topTimers)
+  const otherTimersDurationNs = Math.max(0, totalTimerDurationNs - topTimersDurationNs)
+  const othersTimer = createTimer(OTHERS_STAGE_TAG, otherTimersDurationNs)
   return othersTimer
 }
 
@@ -80,8 +80,8 @@ const getPluginTimerPackage = function({ parentTag }) {
 
 // Creates a timer that sums up the duration of several others
 const createSumTimer = function(timers, stageTag, parentTag) {
-  const durationMs = computeTimersDuration(timers)
-  const timer = createTimer(stageTag, durationMs, { parentTag })
+  const durationNs = computeTimersDuration(timers)
+  const timer = createTimer(stageTag, durationNs, { parentTag })
   return timer
 }
 
@@ -89,8 +89,8 @@ const computeTimersDuration = function(timers) {
   return timers.map(getTimerDuration).reduce(reduceSum, 0)
 }
 
-const getTimerDuration = function({ durationMs }) {
-  return durationMs
+const getTimerDuration = function({ durationNs }) {
+  return durationNs
 }
 
 const reduceSum = function(sum, number) {

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -12,16 +12,16 @@ const initTimers = function() {
 // The function must:
 //   - take a plain object as first argument. This must contain a `timers`.
 //   - return a plain object. This may or may not contain a modified `timers`.
-// The `durationMs` will be returned by the function. A new `timers` with the
+// The `durationNs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
 const kMeasureDuration = function(func, stageTag, { parentTag, category } = {}) {
   return async function({ timers, ...opts }, ...args) {
-    const timerMs = startTimer()
+    const timerNs = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
-    const durationMs = endTimer(timerMs)
-    const timer = createTimer(stageTag, durationMs, { parentTag, category })
+    const durationNs = endTimer(timerNs)
+    const timer = createTimer(stageTag, durationNs, { parentTag, category })
     const timersB = [...timersA, timer]
-    return { ...returnObject, timers: timersB, durationMs }
+    return { ...returnObject, timers: timersB, durationNs }
   }
 }
 
@@ -29,8 +29,8 @@ const kMeasureDuration = function(func, stageTag, { parentTag, category } = {}) 
 const measureDuration = keepFuncProps(kMeasureDuration)
 
 // Create a new object representing a completed timer
-const createTimer = function(stageTag, durationMs, { parentTag = TOP_PARENT_TAG, category } = {}) {
-  return { stageTag, parentTag, durationMs, category }
+const createTimer = function(stageTag, durationNs, { parentTag = TOP_PARENT_TAG, category } = {}) {
+  return { stageTag, parentTag, durationNs, category }
 }
 
 const TOP_PARENT_TAG = 'run_netlify_build'

--- a/packages/build/src/time/measure.js
+++ b/packages/build/src/time/measure.js
@@ -9,11 +9,16 @@ const startTimer = function() {
 const endTimer = function([startSecs, startNsecs]) {
   const [endSecs, endNsecs] = hrtime()
   const durationNs = (endSecs - startSecs) * NANOSECS_TO_SECS + endNsecs - startNsecs
-  const durationMs = Math.ceil(durationNs / NANOSECS_TO_MSECS)
-  return durationMs
+  return durationNs
+}
+
+// statsd expects milliseconds integers.
+// To prevent double rounding errors, rounding should only be applied once.
+const roundTimerToMillisecs = function(durationNs) {
+  return Math.round(durationNs / NANOSECS_TO_MSECS)
 }
 
 const NANOSECS_TO_SECS = 1e9
 const NANOSECS_TO_MSECS = 1e6
 
-module.exports = { startTimer, endTimer }
+module.exports = { startTimer, endTimer, roundTimerToMillisecs }

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -2,6 +2,7 @@ const { appendFile } = require('fs')
 const { promisify } = require('util')
 
 const { addAggregatedTimers } = require('./aggregate')
+const { roundTimerToMillisecs } = require('./measure')
 
 const pAppendFile = promisify(appendFile)
 
@@ -19,7 +20,8 @@ const reportTimers = async function(timers, timersFile) {
   await pAppendFile(timersFile, timersLines)
 }
 
-const getTimerLine = function({ stageTag, durationMs }) {
+const getTimerLine = function({ stageTag, durationNs }) {
+  const durationMs = roundTimerToMillisecs(durationNs)
   return `${stageTag} ${durationMs}ms\n`
 }
 

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -16,10 +16,10 @@ test('Prints timings to --timersFile', async t => {
 
     const timerLines = await getTimerLines(timersFile)
 
-    timerLines.forEach(({ stageTag, durationMs }) => {
+    timerLines.forEach(({ stageTag, durationNs }) => {
       t.true(isDefinedString(stageTag))
-      t.true(isDefinedString(durationMs))
-      t.true(DURATION_REGEXP.test(durationMs))
+      t.true(isDefinedString(durationNs))
+      t.true(DURATION_REGEXP.test(durationNs))
     })
   } finally {
     await del(timersFile, { force: true })
@@ -69,6 +69,6 @@ const getTimerLines = async function(timersFile) {
 }
 
 const parseTimerLine = function(timerLine) {
-  const [stageTag, durationMs] = timerLine.split(' ')
-  return { stageTag, durationMs }
+  const [stageTag, durationNs] = timerLine.split(' ')
+  return { stageTag, durationNs }
 }


### PR DESCRIPTION
Fixes #1748.

Some of the performance measurements we are sending are computing by adding/subtracting two measurements.

The measurements are done with nanoseconds precision. [statsd expects milliseconds](https://github.com/b/statsd_spec#metric-types--formats). At the moment, we round right after the measurement is being made, which introduces double rounding and [round-off errors](https://en.wikipedia.org/wiki/Round-off_error). We should instead keep the measurements as nanoseconds as long as possible, i.e. until they are sent to statsd.