### PR TITLE
Improve constants path normalization

### DIFF
--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -61,7 +61,7 @@ const getConstants = async function({
 // Instead of passing absolute paths, we pass paths relative to `buildDir`, so
 // that logs are less verbose.
 const normalizePath = function(path, buildDir, key) {
-  if (path === undefined || NOT_PATHS.includes(key)) {
+  if (path === undefined || !CONSTANT_PATHS.includes(key)) {
     return path
   }
 
@@ -74,6 +74,6 @@ const normalizePath = function(path, buildDir, key) {
   return pathA
 }
 
-const NOT_PATHS = ['IS_LOCAL', 'NETLIFY_BUILD_VERSION', 'SITE_ID']
+const CONSTANT_PATHS = ['CONFIG_PATH', 'PUBLISH_DIR', 'FUNCTIONS_SRC', 'FUNCTIONS_DIST', 'CACHE_DIR']
 
 module.exports = { getConstants }


### PR DESCRIPTION
Some refactoring related to https://github.com/netlify/build/pull/1752

Some of the `constants` we pass to Build plugins are file paths. We normalize those from absolute paths to relative paths instead, so that they are less verbose when printed in logs. Since some `constants` are not file paths, we use a deny list to exclude those from that logic. We could also use a RegExp, but it would be slower and more error prone.

This PR changes the logic to use an allow list instead, so that adding a non-file-paths constant does not accidentally apply this logic on the new constants, which would be worse than not applying the logic on a new file path constant.