### PR TITLE
Refactor core plugins logic

### DIFF
--- a/packages/build/src/install/local.js
+++ b/packages/build/src/install/local.js
@@ -32,10 +32,10 @@ const installLocalPluginsDependencies = async function({ plugins, pluginsOptions
 }
 
 const isLocalInstallOptIn = function({ package }) {
-  return package === LOCAL_INSTALL_NAME
+  return package === LOCAL_INSTALL_PLUGIN_NAME
 }
 
-const LOCAL_INSTALL_NAME = '@netlify/plugin-local-install-core'
+const LOCAL_INSTALL_PLUGIN_NAME = '@netlify/plugin-local-install-core'
 
 // Core plugins and non-local plugins already have their dependencies installed
 const getLocalPluginsOptions = function(pluginsOptions) {
@@ -64,4 +64,4 @@ const removeMainRoot = async function(localPluginsOptions, buildDir) {
   return localPluginsOptions.filter(({ packageDir }) => packageDir !== mainPackageDir)
 }
 
-module.exports = { installLocalPluginsDependencies, LOCAL_INSTALL_NAME }
+module.exports = { installLocalPluginsDependencies, LOCAL_INSTALL_PLUGIN_NAME }

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -2,7 +2,7 @@ const { dirname } = require('path')
 
 const corePackageJson = require('../../package.json')
 const { installLocalPluginsDependencies } = require('../install/local')
-const { getCorePlugins, CORE_PLUGINS, EARLY_CORE_PLUGINS } = require('../plugins_core/main')
+const { getCorePlugins, isCorePlugin } = require('../plugins_core/main')
 const { measureDuration } = require('../time/main')
 const { getPackageJson } = require('../utils/package')
 
@@ -14,12 +14,12 @@ const { resolvePluginsPath } = require('./resolve')
 const tGetPluginsOptions = async function({
   netlifyConfig: { plugins },
   buildDir,
-  constants: { FUNCTIONS_SRC },
+  constants,
   mode,
   buildImagePluginsDir,
   logs,
 }) {
-  const corePlugins = getCorePlugins(FUNCTIONS_SRC).map(addCoreProperties)
+  const corePlugins = getCorePlugins({ constants }).map(addCoreProperties)
   const allCorePlugins = corePlugins.filter(corePlugin => !isOptionalCore(corePlugin, plugins))
   const userPlugins = plugins.filter(isUserPlugin)
   const pluginsOptions = [...allCorePlugins, ...userPlugins].map(normalizePluginOptions)
@@ -41,7 +41,7 @@ const isOptionalCore = function({ package, optional }, plugins) {
 }
 
 const isUserPlugin = function({ package }) {
-  return !CORE_PLUGINS.includes(package) && !EARLY_CORE_PLUGINS.includes(package)
+  return !isCorePlugin(package)
 }
 
 const normalizePluginOptions = function({ package, pluginPath, loadedFrom, origin, inputs }) {

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -1,25 +1,43 @@
+const { LOCAL_INSTALL_PLUGIN_NAME } = require('../install/local')
+
 const FUNCTIONS_INSTALL_PLUGIN = `${__dirname}/functions_install/plugin.js`
 const FUNCTIONS_PLUGIN = `${__dirname}/functions/plugin.js`
 
-const { LOCAL_INSTALL_NAME } = require('../install/local')
+// List of core plugin names
+const FUNCTIONS_PLUGIN_NAME = '@netlify/plugin-functions-core'
+const FUNCTIONS_INSTALL_PLUGIN_NAME = '@netlify/plugin-functions-install-core'
+const CORE_PLUGINS = [FUNCTIONS_PLUGIN_NAME, FUNCTIONS_INSTALL_PLUGIN_NAME, LOCAL_INSTALL_PLUGIN_NAME]
 
 // Plugins that are installed and enabled by default
-const getCorePlugins = FUNCTIONS_SRC => [
-  // When no "Functions directory" is defined, it means users does not use
-  // Netlify Functions.
-  // However when it is defined but points to a non-existing directory, this
-  // might mean the directory is created later one, so we cannot do that check
-  // yet.
-  ...(FUNCTIONS_SRC === undefined
-    ? []
-    : [{ package: '@netlify/plugin-functions-install-core', pluginPath: FUNCTIONS_INSTALL_PLUGIN, optional: true }]),
-  ...(FUNCTIONS_SRC === undefined ? [] : [{ package: '@netlify/plugin-functions-core', pluginPath: FUNCTIONS_PLUGIN }]),
-]
+const getCorePlugins = function({ constants: { FUNCTIONS_SRC } }) {
+  const functionsPlugin = getFunctionsPlugin(FUNCTIONS_SRC)
+  const functionsInstallPlugin = getFunctionsInstallPlugin(FUNCTIONS_SRC)
+  return [functionsPlugin, functionsInstallPlugin].filter(Boolean)
+}
 
-const CORE_PLUGINS = ['@netlify/plugin-functions-install-core', '@netlify/plugin-functions-core']
+// When no "Functions directory" is defined, it means users does not use
+// Netlify Functions.
+// However when it is defined but points to a non-existing directory, this
+// might mean the directory is created later one, so we cannot do that check
+// yet.
+const getFunctionsPlugin = function(FUNCTIONS_SRC) {
+  if (FUNCTIONS_SRC === undefined) {
+    return
+  }
 
-// Those core plugins cannot be handled like regular plugins because they must
-// be run before plugin child processes start
-const EARLY_CORE_PLUGINS = [LOCAL_INSTALL_NAME]
+  return { package: FUNCTIONS_PLUGIN_NAME, pluginPath: FUNCTIONS_PLUGIN }
+}
 
-module.exports = { getCorePlugins, CORE_PLUGINS, EARLY_CORE_PLUGINS }
+const getFunctionsInstallPlugin = function(FUNCTIONS_SRC) {
+  if (FUNCTIONS_SRC === undefined) {
+    return
+  }
+
+  return { package: FUNCTIONS_INSTALL_PLUGIN_NAME, pluginPath: FUNCTIONS_INSTALL_PLUGIN, optional: true }
+}
+
+const isCorePlugin = function(package) {
+  return CORE_PLUGINS.includes(package)
+}
+
+module.exports = { getCorePlugins, isCorePlugin }


### PR DESCRIPTION
This refactors the logic used to load core plugins.
This does not change the logic, just refactor its code.
This will make it easier to add the Edge handlers plugin as a core plugin.