### PR TITLE
Fix error message on missing Netlify Function dependency

### DIFF
--- a/packages/build/src/plugins_core/functions/error.js
+++ b/packages/build/src/plugins_core/functions/error.js
@@ -57,7 +57,7 @@ const getModuleName = function(error) {
   return result[1]
 }
 
-const MODULE_NOT_FOUND_REGEXP = /Cannot find module '(@[^'/]+\/[^'/]|[^.'/][^'/]*)/
+const MODULE_NOT_FOUND_REGEXP = /Cannot find module '(@[^'/]+\/[^'/]+|[^.'/][^'/]*)/
 
 const getWarning = function(moduleName) {
   return `A Netlify Function is using "${moduleName}" but that dependency has not been installed yet.


### PR DESCRIPTION
Fixes #1766.

When a Netlify Function is missing a dependency, an error message is shown to point to the problem. However, the error message is currently truncating the package name when the package starts with `@`. This PR fixes this.