### PR TITLE
Fix cache utility bug

### DIFF
--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -53,13 +53,13 @@
     "global-cache-dir": "^1.0.1",
     "globby": "^10.0.2",
     "locate-path": "^5.0.0",
+    "make-dir": "^3.1.0",
     "move-file": "^1.2.0",
     "path-exists": "^4.0.0",
     "readdirp": "^3.4.0"
   },
   "devDependencies": {
     "ava": "^2.4.0",
-    "make-dir": "^3.1.0",
     "tmp-promise": "^3.0.0"
   },
   "engines": {

--- a/packages/cache-utils/src/manifest.js
+++ b/packages/cache-utils/src/manifest.js
@@ -1,7 +1,9 @@
 const { writeFile, readFile } = require('fs')
+const { dirname } = require('path')
 const { promisify } = require('util')
 
 const del = require('del')
+const makeDir = require('make-dir')
 const pathExists = require('path-exists')
 
 const { getExpires, checkExpires } = require('./expire')
@@ -34,6 +36,7 @@ const isIdentical = async function({ hash, manifestPath, manifestString }) {
 
 // Persist the cache manifest to filesystem
 const writeManifest = async function({ manifestPath, manifestString }) {
+  await makeDir(dirname(manifestPath))
   await pWriteFile(manifestPath, manifestString)
 }
 


### PR DESCRIPTION
Fixes #1411. 

This fixes a bug with the `cache` utility happening when trying to cache empty directories.

I can reproduce this bug in production, but not locally, which makes it unfortunately hard to create a regression test.