### PR TITLE
Add `eslint-plugin-fp`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
-  "plugins": ["node", "prettier"],
+  "plugins": ["node", "prettier", "fp"],
   "env": {
     "node": true,
     "es6": true
@@ -10,7 +10,8 @@
     "plugin:import/warnings",
     "eslint:recommended",
     "plugin:node/recommended",
-    "prettier"
+    "prettier",
+    "plugin:fp/recommended"
   ],
   "rules": {
     "no-console": 0,
@@ -27,14 +28,42 @@
     ],
     "no-process-exit": 0,
     "require-atomic-updates": 0,
-    "no-undef": [2, { "typeof": true }]
+    "no-undef": [2, { "typeof": true }],
+    "fp/no-rest-parameters": 0,
+    "fp/no-unused-expression": 0,
+    "fp/no-nil": 0,
+    "fp/no-throw": 0,
+    "fp/no-mutating-methods": [
+      2,
+      { "allowedObjects": ["error", "errorA", "res", "state", "runState", "logs", "logsArray", "currentEnv"] }
+    ],
+    "fp/no-mutation": [
+      2,
+      {
+        "commonjs": true,
+        "exceptions": [
+          { "object": "error" },
+          { "object": "errorA" },
+          { "object": "res" },
+          { "object": "state" },
+          { "object": "runState" },
+          { "object": "logs" },
+          { "object": "logsArray" },
+          { "object": "currentEnv" },
+          { "object": "process", "property": "exitCode" }
+        ]
+      }
+    ]
   },
   "overrides": [
     {
-      "files": ["**/*.test.js"],
+      "files": ["**/tests.js", "**/tests/**/*.js"],
       "rules": {
         "node/no-unpublished-require": 0,
-        "node/no-missing-require": 0
+        "node/no-missing-require": 0,
+        "fp/no-mutating-methods": 0,
+        "fp/no-mutation": 0,
+        "fp/no-delete": 0
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4460,6 +4460,15 @@
         }
       }
     },
+    "create-eslint-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/create-eslint-index/-/create-eslint-index-1.0.0.tgz",
+      "integrity": "sha1-2VQ3LYbVeS/NZ+nyt5GxqxYkEbs=",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.3.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -5083,6 +5092,16 @@
         }
       }
     },
+    "eslint-ast-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz",
+      "integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.zip": "^4.2.0"
+      }
+    },
     "eslint-config-prettier": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
@@ -5229,6 +5248,18 @@
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-fp": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-fp/-/eslint-plugin-fp-2.3.0.tgz",
+      "integrity": "sha1-N20qEIcQ6YGYC9w4deO5kg2gSJw=",
+      "dev": true,
+      "requires": {
+        "create-eslint-index": "^1.0.0",
+        "eslint-ast-utils": "^1.0.0",
+        "lodash": "^4.13.1",
+        "req-all": "^0.1.0"
       }
     },
     "eslint-plugin-import": {
@@ -7871,6 +7902,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -9798,6 +9835,12 @@
       "requires": {
         "is-finite": "^1.0.0"
       }
+    },
+    "req-all": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/req-all/-/req-all-0.1.0.tgz",
+      "integrity": "sha1-EwBR4qzligLqy/ydRIV3pzapJzo=",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.2",

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -102,6 +102,8 @@ const resolveFullConfig = async function({
     })
   } catch (error) {
     if (error.type === 'userError') {
+      // We need to mutate the `error` directly to preserve its `name`, `stack`, etc.
+      // eslint-disable-next-line fp/no-delete
       delete error.type
       addErrorInfo(error, { type: 'resolveConfig' })
     }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -148,6 +148,8 @@ const tExecBuild = async function({
     testOpts,
     timers,
   })
+  // `errorParams` is purposely stateful
+  // eslint-disable-next-line fp/no-mutating-assign
   Object.assign(errorParams, { netlifyConfig, childEnv })
 
   const { commandsCount, timers: timersB } = await runAndReportBuild({

--- a/packages/build/src/env/changes.js
+++ b/packages/build/src/env/changes.js
@@ -34,6 +34,8 @@ const setEnvChange = function(name, value, currentEnv) {
   }
 
   if (value === null) {
+    // `currentEnv` is a mutable variable
+    // eslint-disable-next-line fp/no-delete
     delete currentEnv[name]
     return
   }

--- a/packages/build/src/error/build.js
+++ b/packages/build/src/error/build.js
@@ -9,6 +9,8 @@ const jsonToError = function({ name, message, stack, info = {}, errorProps = {} 
 
   assignErrorProps(error, { name, message, stack })
   // Assign static error properties (if any)
+  // We need to mutate the `error` directly to preserve its `name`, `stack`, etc.
+  // eslint-disable-next-line fp/no-mutating-assign
   Object.assign(error, errorProps)
 
   // Distinguish between utils.build.*() errors and uncaught exceptions / bugs
@@ -27,6 +29,8 @@ const assignErrorProps = function(error, values) {
 const ERROR_PROPS = ['name', 'message', 'stack']
 
 const assignErrorProp = function(error, name, value) {
+  // `Object.defineProperty()` requires direct mutation
+  // eslint-disable-next-line fp/no-mutating-methods
   Object.defineProperty(error, name, { value, enumerable: false, writable: true, configurable: true })
 }
 

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -120,6 +120,8 @@ const getEventProps = function({ severity, group, groupingHash, metadata, app })
 
 // Add more information to Bugsnag events
 const onError = function(event, eventProps) {
+  // Bugsnag client requires directly mutating the `event`
+  // eslint-disable-next-line fp/no-mutating-assign
   Object.assign(event, {
     ...eventProps,
     unhandled: event.unhandled || eventProps.unhandled,

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -26,6 +26,8 @@ const setInspectColors = function() {
     return
   }
 
+  // `inspect.defaultOptions` requires direct mutation
+  // eslint-disable-next-line fp/no-mutation
   defaultOptions.colors = true
 }
 

--- a/packages/build/src/log/logger.js
+++ b/packages/build/src/log/logger.js
@@ -20,6 +20,8 @@ const log = function(logs, string) {
   const stringA = String(string).replace(EMPTY_LINES_REGEXP, EMPTY_LINE)
 
   if (logs !== undefined) {
+    // `logs` is a stateful variable
+    // eslint-disable-next-line fp/no-mutating-methods
     logs.stdout.push(stringA)
     return
   }

--- a/packages/build/src/log/old_version.js
+++ b/packages/build/src/log/old_version.js
@@ -26,6 +26,8 @@ const getCorePackageJson = function(testOpts) {
   if (testOpts.oldCliLogs) {
     // `update-notifier` does not do anything if not in a TTY.
     // In tests, we need to monkey patch this
+    // Mutation is required due to how `stdout.isTTY` works
+    // eslint-disable-next-line fp/no-mutation
     stdout.isTTY = true
 
     return { ...corePackageJson, version: '0.0.1' }

--- a/packages/build/src/plugins/child/lazy.js
+++ b/packages/build/src/plugins/child/lazy.js
@@ -4,6 +4,8 @@ const memoizeOne = require('memoize-one')
 // is only retrieved when accessed.
 const addLazyProp = function(object, propName, getFunc) {
   const mGetFunc = memoizeOne(getFunc, returnTrue)
+  // Mutation is required due to the usage of `Object.defineProperty()`
+  // eslint-disable-next-line fp/no-mutating-methods
   Object.defineProperty(object, propName, {
     get: mGetFunc,
     enumerable: true,

--- a/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
+++ b/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
@@ -9,6 +9,8 @@ module.exports = {
     process.kill(process.env.TEST_PID)
 
     // Signals are async, so we need to wait for the child process to exit
+    // The while loop is required due to `await`
+    // eslint-disable-next-line fp/no-loops
     while (await processExists(process.env.TEST_PID)) {
       await pSetTimeout(1e2)
     }

--- a/packages/build/tests/helpers/server.js
+++ b/packages/build/tests/helpers/server.js
@@ -21,6 +21,8 @@ const getHost = function(server) {
 }
 
 const requestHandler = function({ req, res, requests, response, status, path }) {
+  // A stateful variable is required due to `http` using events
+  // eslint-disable-next-line fp/no-let
   let rawBody = ''
   req.on('data', data => {
     rawBody += data.toString()

--- a/packages/build/tests/plugins/fixtures/error_argument/plugin.js
+++ b/packages/build/tests/plugins/fixtures/error_argument/plugin.js
@@ -1,14 +1,9 @@
-class TestError extends Error {
-  constructor(...args) {
-    super(...args)
-    this.name = 'TestError'
-  }
-}
-
 module.exports = {
   onBuild() {
     console.log('test')
-    throw new TestError('test')
+    const error = new Error('test')
+    error.name = 'TestError'
+    throw error
   },
   onError({ error: { name, message, stack } }) {
     console.log(name)

--- a/packages/config/src/log/logger.js
+++ b/packages/config/src/log/logger.js
@@ -19,6 +19,8 @@ const log = function(logs, string) {
   const stringA = String(string).replace(EMPTY_LINES_REGEXP, EMPTY_LINE)
 
   if (logs !== undefined) {
+    // `logs` is a stateful variable
+    // eslint-disable-next-line fp/no-mutating-methods
     logs.stderr.push(stringA)
     return
   }

--- a/packages/config/src/validate/example.js
+++ b/packages/config/src/validate/example.js
@@ -17,7 +17,12 @@ ${indentString(serializeToml(exampleA), 2)}`
 }
 
 const getInvalidValue = function(value, prevPath) {
-  const invalidValue = prevPath.reverse().reduce(setInvalidValuePart, value)
+  // slice() is temporary, so it does not mutate
+  // eslint-disable-next-line fp/no-mutating-methods
+  const invalidValue = prevPath
+    .slice()
+    .reverse()
+    .reduce(setInvalidValuePart, value)
   const invalidValueA = serializeToml(invalidValue)
   return invalidValueA
 }

--- a/packages/functions-utils/package-lock.json
+++ b/packages/functions-utils/package-lock.json
@@ -504,6 +504,51 @@
 			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
 			"dev": true
 		},
+		"@sinonjs/commons": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"@sinonjs/formatio": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+			"integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^5.0.2"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+			"integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.6.0",
+				"lodash.get": "^4.4.2",
+				"type-detect": "^4.0.8"
+			}
+		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+			"dev": true
+		},
 		"@szmarczak/http-timer": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -2270,6 +2315,12 @@
 				"typescript": "^3.8.3"
 			}
 		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true
+		},
 		"dir-glob": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
@@ -3376,6 +3427,12 @@
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
 			"integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ=="
 		},
+		"just-extend": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+			"dev": true
+		},
 		"keyv": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -3490,6 +3547,12 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
 		"lodash.islength": {
@@ -3791,6 +3854,19 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
 			"integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
+		},
+		"nise": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+			"integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0",
+				"@sinonjs/fake-timers": "^6.0.0",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"path-to-regexp": "^1.7.0"
+			}
 		},
 		"node-source-walk": {
 			"version": "4.2.0",
@@ -4220,6 +4296,23 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"path-to-regexp": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
 		},
 		"path-type": {
 			"version": "3.0.0",
@@ -4852,6 +4945,38 @@
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
+		"sinon": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+			"integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.2",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@sinonjs/formatio": "^5.0.1",
+				"@sinonjs/samsam": "^5.1.0",
+				"diff": "^4.0.2",
+				"nise": "^4.0.4",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -5390,6 +5515,12 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-fest": {
 			"version": "0.11.0",

--- a/packages/functions-utils/package.json
+++ b/packages/functions-utils/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "ava": "^2.4.0",
     "del": "^5.1.0",
+    "sinon": "^9.0.3",
     "tmp-promise": "^3.0.0"
   },
   "engines": {

--- a/packages/functions-utils/tests/main.js
+++ b/packages/functions-utils/tests/main.js
@@ -2,6 +2,7 @@ const { normalize } = require('path')
 
 const test = require('ava')
 const pathExists = require('path-exists')
+const { spy } = require('sinon')
 
 const { add, list, listAll } = require('..')
 
@@ -72,12 +73,10 @@ test('Should throw if dist file already exists', async t => {
 })
 
 test('Should allow "fail" option to customize failures', async t => {
-  let failMessage
-  const fail = message => {
-    failMessage = message
-  }
+  const fail = spy()
   await add(undefined, undefined, { fail })
-  t.is(typeof failMessage, 'string')
+  t.true(fail.calledOnce)
+  t.is(typeof fail.firstCall.firstArg, 'string')
 })
 
 const normalizeFiles = function(fixtureDir, { mainFile, runtime, extension, srcFile }) {

--- a/packages/run-utils/src/main.js
+++ b/packages/run-utils/src/main.js
@@ -43,6 +43,8 @@ const redirectOutput = function(childProcess, { stdio, stdout, stderr }) {
   childProcess.stderr.pipe(process.stderr)
 }
 
+// Needed to add a property to the function
+// eslint-disable-next-line fp/no-mutation
 run.command = runCommand
 
 module.exports = run


### PR DESCRIPTION
State can make a codebase hard to follow. Following variables whose values change across different files and modules requires a higher cognitive load than following pure functions. I personally find it difficult.

This monorepo mostly follows that principle, and tries to only mutate variable where it is strictly necessary.  State mutation is still required in many instances, such as when shallow cloning an object would lose the prototype (e.g. in `Error`s), when several functions run in parallel need to communicate to each other, or when optimizing for performance.

This goes into the functional vs imperative topic, which is rather subjective. 

This PR's main intention is to maintain consistency with the existing code base programming style (which is functional) by adding a [ESLint plugin](https://github.com/jfmengels/eslint-plugin-fp). Some variables that are known to be stateful in the codebase (such as `error`, `state` or `logs`) are explicitly allowed. Also, some rules conflicting with throwing errors are disabled. Finally, tests have looser requirements because they tend to be "hackier" by nature than production code.

@erezrokah What are your thoughts on this? Also, do you think this might be something that other projects might benefit from?