### PR TITLE
Add `os-name` to list of dependencies not to upgrade

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,6 +25,7 @@
         'log-process-errors',
         'move-file',
         'nock',
+        'os-name',
         'p-locate',
         'prettier',
         'pretty-ms',


### PR DESCRIPTION
This adds `os-name` to the list of dependencies not to upgrade due to Node 8 incompatibility.