### PR TITLE
Remove `babel-eslint`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "parser": "babel-eslint",
   "plugins": ["node", "prettier", "fp"],
   "env": {
     "node": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3003,20 +3003,6 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "dependencies": {},
   "devDependencies": {
     "ava": "^2.4.0",
-    "babel-eslint": "^10.1.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-fp": "^2.3.0",


### PR DESCRIPTION
This removes `babel-eslint`. ESLint uses `espree` instead of `@babel/parser` by default, which is just fine for our use case. `babel-eslint` is only required when using new ES features added by `@babel/parser` but not `espree`.

Also, `babel-eslint` was deprecated and replaced by `@babel/eslint-parser`.