### PR TITLE
Lint ESLint comments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,10 @@
     "eslint:recommended",
     "plugin:node/recommended",
     "prettier",
+    "plugin:eslint-comments/recommended",
     "plugin:fp/recommended"
   ],
+  "reportUnusedDisableDirectives": true,
   "rules": {
     "no-console": 0,
     "no-unused-vars": 2,
@@ -29,6 +31,11 @@
     "no-process-exit": 0,
     "require-atomic-updates": 0,
     "no-undef": [2, { "typeof": true }],
+    "eslint-comments/no-unused-disable": 0,
+    "eslint-comments/no-use": [
+      2,
+      { "allow": ["eslint-disable-next-line", "eslint-disable", "eslint-enable", "eslint-env"] }
+    ],
     "fp/no-rest-parameters": 0,
     "fp/no-unused-expression": 0,
     "fp/no-nil": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5250,6 +5250,24 @@
         }
       }
     },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-fp": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-fp/-/eslint-plugin-fp-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/build/src/plugins/child/error.js
+++ b/packages/build/src/plugins/child/error.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 const logProcessErrors = require('log-process-errors')
 
 const { errorToJson } = require('../../error/build')

--- a/packages/build/tests/install/fixtures/already/plugin/main.js
+++ b/packages/build/tests/install/fixtures/already/plugin/main.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const avg = require('math-avg')
 
 module.exports = {

--- a/packages/build/tests/install/fixtures/dir/functions/function/index.js
+++ b/packages/build/tests/install/fixtures/dir/functions/function/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/functions_error/functions/index.js
+++ b/packages/build/tests/install/fixtures/functions_error/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/functions_npm/functions/index.js
+++ b/packages/build/tests/install/fixtures/functions_npm/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/functions_yarn/functions/index.js
+++ b/packages/build/tests/install/fixtures/functions_yarn/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/functions_yarn_ci/functions/index.js
+++ b/packages/build/tests/install/fixtures/functions_yarn_ci/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/local_dep/functions/index.js
+++ b/packages/build/tests/install/fixtures/local_dep/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const missing = require('./missing')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/local_missing/plugin/main.js
+++ b/packages/build/tests/install/fixtures/local_missing/plugin/main.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const avg = require('math-avg')
 
 module.exports = {

--- a/packages/build/tests/install/fixtures/mispelled_dep/functions/index.js
+++ b/packages/build/tests/install/fixtures/mispelled_dep/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg-mispelled')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/no_package/plugin/main.js
+++ b/packages/build/tests/install/fixtures/no_package/plugin/main.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const avg = require('math-avg')
 
 module.exports = {

--- a/packages/build/tests/install/fixtures/npm/plugin/main.js
+++ b/packages/build/tests/install/fixtures/npm/plugin/main.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const avg = require('math-avg')
 
 module.exports = {

--- a/packages/build/tests/install/fixtures/optional/functions/index.js
+++ b/packages/build/tests/install/fixtures/optional/functions/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const mathAvg = require('math-avg')
 
 module.exports = () => {

--- a/packages/build/tests/install/fixtures/yarn/plugin/main.js
+++ b/packages/build/tests/install/fixtures/yarn/plugin/main.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const avg = require('math-avg')
 
 module.exports = {

--- a/packages/build/tests/install/fixtures/yarn_ci/plugin/main.js
+++ b/packages/build/tests/install/fixtures/yarn_ci/plugin/main.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-missing-require
 const avg = require('math-avg')
 
 module.exports = {


### PR DESCRIPTION
This adds an [ESLint plugin](https://github.com/mysticatea/eslint-plugin-eslint-comments) that ensures that are properly using ESLint comments like `// eslint-disable`. For example, it ensures we are not adding `// eslint-disable` when no ESLint rule was broken.

It also adds the `reportUnusedDisableDirectives` option which has similar goals.

Finally, it removes some `// eslint-disable` comments that were not needed.