### PR TITLE
Refactor events filtering

### DIFF
--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -4,7 +4,7 @@ const { EVENTS } = require('../plugins/events')
 const getCommands = function(pluginsCommands, netlifyConfig) {
   const commands = addBuildCommand(pluginsCommands, netlifyConfig)
   const commandsA = sortCommands(commands)
-  const commandsCount = commandsA.filter(isSuccessCommand).length
+  const commandsCount = commandsA.filter(({ event }) => !isErrorOnlyEvent(event)).length
   return { commands: commandsA, commandsCount }
 }
 
@@ -25,20 +25,14 @@ const sortCommands = function(commands) {
   return EVENTS.flatMap(event => commands.filter(command => command.event === event))
 }
 
-const isMainCommand = function({ event }) {
-  return event !== 'onEnd' && event !== 'onError'
+const isAmongEvents = function(events, event) {
+  return events.includes(event)
 }
 
-const isEndCommand = function({ event }) {
-  return event === 'onEnd'
-}
+// Check if the event is triggered even when an error happens
+const isErrorEvent = isAmongEvents.bind(null, ['onError', 'onEnd'])
 
-const isErrorCommand = function({ event }) {
-  return event === 'onError'
-}
+// Check if the event is only triggered when an error happens
+const isErrorOnlyEvent = isAmongEvents.bind(null, ['onError'])
 
-const isSuccessCommand = function({ event }) {
-  return isMainCommand({ event }) || isEndCommand({ event })
-}
-
-module.exports = { getCommands, isMainCommand, isErrorCommand, isSuccessCommand }
+module.exports = { getCommands, isErrorEvent, isErrorOnlyEvent }

--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -8,7 +8,7 @@ const { measureDuration, normalizeTimerName } = require('../time/main')
 
 const { fireBuildCommand } = require('./build_command')
 const { handleCommandError } = require('./error')
-const { isMainCommand, isErrorCommand } = require('./get')
+const { isErrorEvent, isErrorOnlyEvent } = require('./get')
 const { firePluginCommand } = require('./plugin')
 
 // Run all commands.
@@ -125,7 +125,7 @@ const runCommand = async function({
   timers,
   testOpts,
 }) {
-  if (shouldSkipCommand({ event, package, error, failedPlugins })) {
+  if (!shouldRunCommand({ event, package, error, failedPlugins })) {
     return {}
   }
 
@@ -187,9 +187,13 @@ const runCommand = async function({
 // `onError()` is not run otherwise.
 // `onEnd()` is always run, regardless of whether the current or other plugins
 // failed.
-const shouldSkipCommand = function({ event, package, error, failedPlugins }) {
+const shouldRunCommand = function({ event, package, error, failedPlugins }) {
   const isError = error !== undefined || failedPlugins.includes(package)
-  return (isMainCommand({ event }) && isError) || (isErrorCommand({ event }) && !isError)
+  if (isError) {
+    return isErrorEvent(event)
+  }
+
+  return !isErrorOnlyEvent(event)
 }
 
 // Wrap command function to measure its time

--- a/packages/build/src/core/dry.js
+++ b/packages/build/src/core/dry.js
@@ -1,9 +1,9 @@
-const { isSuccessCommand } = require('../commands/get')
+const { isErrorOnlyEvent } = require('../commands/get')
 const { logDryRunStart, logDryRunCommand, logDryRunEnd } = require('../log/main')
 
 // If the `dry` flag is specified, do a dry run
 const doDryRun = function({ commands, commandsCount, logs }) {
-  const successCommands = commands.filter(isSuccessCommand)
+  const successCommands = commands.filter(({ event }) => !isErrorOnlyEvent(event))
   const eventWidth = Math.max(...successCommands.map(getEventLength))
 
   logDryRunStart({ logs, eventWidth, commandsCount })

--- a/packages/build/src/status/add.js
+++ b/packages/build/src/status/add.js
@@ -1,23 +1,20 @@
+const { isErrorEvent } = require('../commands/get')
 const { addErrorInfo } = require('../error/info')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 
 // The last event handler of a plugin (except for `onError` and `onEnd`)
 // defaults to `utils.status.show({ state: 'success' })` without any `summary`.
 const getSuccessStatus = function(newStatus, { commands, event, package }) {
-  if (newStatus === undefined && isLastMainCommand({ commands, event, package })) {
+  if (newStatus === undefined && isLastNonErrorCommand({ commands, event, package })) {
     return IMPLICIT_STATUS
   }
 
   return newStatus
 }
 
-const isLastMainCommand = function({ commands, event, package }) {
-  const mainCommands = commands.filter(command => command.package === package && isMainCommand(command))
-  return mainCommands.length === 0 || mainCommands[mainCommands.length - 1].event === event
-}
-
-const isMainCommand = function({ event }) {
-  return event !== 'onEnd' && event !== 'onError'
+const isLastNonErrorCommand = function({ commands, event, package }) {
+  const nonErrorCommands = commands.filter(command => command.package === package && !isErrorEvent(command.event))
+  return nonErrorCommands.length === 0 || nonErrorCommands[nonErrorCommands.length - 1].event === event
 }
 
 const IMPLICIT_STATUS = { state: 'success', implicit: true }


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1787, from the `onSuccess` current feature initiative.

`onEnd` and `onError` are handled slightly different from other events:
  - `onError` only happens when an error happened
  - `onError` is not shown in the number of commands about to be executed when in dry run
  - `onEnd` happens regardless of whether an error happened or not
  - the last event handler of any plugin, excluding `onError` and `onEnd`, defaults to implicitly calling `utils.status.show({ state: 'success' })`

This PR refactors the logic around the above, to make it clearer. It does not change any behavior.