### PR TITLE
Refactor error information parsing

### DIFF
--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -5,9 +5,8 @@ const osName = require('os-name')
 
 const { getEnvMetadata } = require('../../env/metadata')
 const { log } = require('../../log/logger.js')
-const { getErrorInfo } = require('../info')
+const { parseErrorInfo } = require('../parse/parse')
 const { getHomepage } = require('../parse/plugin')
-const { getTypeInfo } = require('../type')
 
 const { getLocationMetadata } = require('./location')
 const { normalizeGroupingMessage } = require('./normalize')
@@ -19,8 +18,7 @@ const reportBuildError = async function({ error, errorMonitor, childEnv, logs, t
     return
   }
 
-  const errorInfo = getErrorInfo(error)
-  const { type, severity, title, group = title } = getTypeInfo(errorInfo)
+  const { errorInfo, type, severity, title, group = title } = parseErrorInfo(error)
   const severityA = getSeverity(severity, errorInfo)
   const groupA = getGroup(group, errorInfo)
   const groupingHash = getGroupingHash(groupA, error, type)

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -46,14 +46,28 @@ const parseError = function({ error, colors, debug }) {
 const parseErrorInfo = function(error) {
   const { message, stack, ...errorProps } = normalizeError(error)
   const errorInfo = getErrorInfo(errorProps)
-  const { state, title, isSuccess, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(errorInfo)
+  const {
+    type,
+    state,
+    severity,
+    title,
+    group,
+    isSuccess,
+    stackType,
+    locationType,
+    showErrorProps,
+    rawStack,
+  } = getTypeInfo(errorInfo)
   return {
     message,
     stack,
     errorProps,
     errorInfo,
+    type,
     state,
+    severity,
     title,
+    group,
     isSuccess,
     stackType,
     locationType,
@@ -71,4 +85,4 @@ const getTitle = function(title, errorInfo) {
   return title(errorInfo)
 }
 
-module.exports = { parseError }
+module.exports = { parseError, parseErrorInfo }


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/939#issuecomment-686542767

This is a small refactoring of the logic used to retrieve/parse error information. It makes two different functions re-use the same underlying logic instead of duplicating it. This does not change behavior, except it handles better the case where the thrown exception is not an `Error` instance.