### PR TITLE
Improve handling of invalid errors

### DIFF
--- a/packages/build/src/error/info.js
+++ b/packages/build/src/error/info.js
@@ -1,14 +1,28 @@
 // Add information related to an error without colliding with existing properties
 const addErrorInfo = function(error, info) {
+  if (!canHaveErrorInfo(error)) {
+    return
+  }
+
   error[INFO_SYM] = { ...error[INFO_SYM], ...info }
 }
 
 const getErrorInfo = function(error) {
-  return error[INFO_SYM] || {}
+  if (!isBuildError(error)) {
+    return {}
+  }
+
+  return error[INFO_SYM]
 }
 
 const isBuildError = function(error) {
-  return error instanceof Error && error[INFO_SYM] !== undefined
+  return canHaveErrorInfo(error) && error[INFO_SYM] !== undefined
+}
+
+// Exceptions that are not objects (including `Error` instances) cannot have an
+// `INFO_SYM` property
+const canHaveErrorInfo = function(error) {
+  return error != null
 }
 
 const INFO_SYM = Symbol('info')


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/939#issuecomment-686542767

This improves handling errors that are not `Error` instances. In the previous code, `error[INFO_SYM]` would crash if `error` is not an `Error` instance.