### PR TITLE
Refactor build error parsing

### DIFF
--- a/packages/build/src/commands/error.js
+++ b/packages/build/src/commands/error.js
@@ -1,6 +1,6 @@
 const { cancelBuild } = require('../error/cancel')
 const { handleBuildError } = require('../error/handle')
-const { getErrorInfo } = require('../error/info')
+const { parseErrorInfo } = require('../error/parse/parse')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 
 const { isSoftFailEvent } = require('./get')
@@ -30,7 +30,10 @@ const handleCommandError = async function({
     return { newError }
   }
 
-  const { type, location: { package } = {} } = getErrorInfo(newError)
+  const {
+    type,
+    errorInfo: { location: { package } = {} },
+  } = parseErrorInfo(newError)
   const newStatus = serializeErrorStatus(newError, { debug })
 
   if (type === 'failPlugin' || isSoftFailEvent(event)) {


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/939#issuecomment-686542767

This improves handling build errors by using a higher-level error parsing function. This does not change the code behavior.