### PR TITLE
Improve error information parsing

### DIFF
--- a/packages/build/src/commands/error.js
+++ b/packages/build/src/commands/error.js
@@ -1,6 +1,6 @@
 const { cancelBuild } = require('../error/cancel')
 const { handleBuildError } = require('../error/handle')
-const { parseErrorInfo } = require('../error/parse/parse')
+const { getFullErrorInfo } = require('../error/parse/parse')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 
 const { isSoftFailEvent } = require('./get')
@@ -30,11 +30,12 @@ const handleCommandError = async function({
     return { newError }
   }
 
+  const fullErrorInfo = getFullErrorInfo({ error: newError, colors: false, debug })
   const {
     type,
     errorInfo: { location: { package } = {} },
-  } = parseErrorInfo(newError)
-  const newStatus = serializeErrorStatus(newError, { debug })
+  } = fullErrorInfo
+  const newStatus = serializeErrorStatus({ fullErrorInfo })
 
   if (type === 'failPlugin' || isSoftFailEvent(event)) {
     return handleFailPlugin({

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -7,22 +7,22 @@ const { getPluginInfo } = require('./plugin')
 const { getErrorProps } = require('./properties')
 const { getStackInfo } = require('./stack')
 
-// Parse all error information into a normalized sets of properties
-const parseError = function({ error, colors, debug }) {
+// Add additional type-specific error information
+const getFullErrorInfo = function({ error, colors, debug }) {
+  const basicErrorInfo = parseErrorInfo(error)
   const {
     message,
     stack,
     errorProps,
     errorInfo,
     errorInfo: { location = {}, plugin = {} },
-    state,
     title,
     isSuccess,
     stackType,
     locationType,
     showErrorProps,
     rawStack,
-  } = parseErrorInfo(error)
+  } = basicErrorInfo
 
   const titleA = getTitle(title, errorInfo)
 
@@ -31,15 +31,8 @@ const parseError = function({ error, colors, debug }) {
   const pluginInfo = getPluginInfo(plugin, location)
   const locationInfo = getLocationInfo({ stack: stackA, location, locationType })
   const errorPropsA = getErrorProps({ errorProps, showErrorProps, colors })
-  return {
-    state,
-    title: titleA,
-    message: messageA,
-    pluginInfo,
-    locationInfo,
-    errorProps: errorPropsA,
-    isSuccess,
-  }
+
+  return { ...basicErrorInfo, title: titleA, message: messageA, pluginInfo, locationInfo, errorProps: errorPropsA }
 }
 
 // Parse error instance into all the basic properties containing information
@@ -58,7 +51,7 @@ const parseErrorInfo = function(error) {
     showErrorProps,
     rawStack,
   } = getTypeInfo(errorInfo)
-  return {
+  const basicErrorInfo = {
     message,
     stack,
     errorProps,
@@ -74,6 +67,7 @@ const parseErrorInfo = function(error) {
     showErrorProps,
     rawStack,
   }
+  return basicErrorInfo
 }
 
 // Retrieve title to print in logs
@@ -85,4 +79,4 @@ const getTitle = function(title, errorInfo) {
   return title(errorInfo)
 }
 
-module.exports = { parseError, parseErrorInfo }
+module.exports = { getFullErrorInfo, parseErrorInfo }

--- a/packages/build/src/error/parse/serialize_log.js
+++ b/packages/build/src/error/parse/serialize_log.js
@@ -1,14 +1,9 @@
 const { THEME } = require('../../log/theme')
 
-const { parseError } = require('./parse')
-
 // Serialize an error object into a title|body string to print in logs
-const serializeLogError = function(error, { debug }) {
-  const { title, message, pluginInfo, locationInfo, errorProps, isSuccess } = parseError({
-    error,
-    colors: true,
-    debug,
-  })
+const serializeLogError = function({
+  fullErrorInfo: { title, message, pluginInfo, locationInfo, errorProps, isSuccess },
+}) {
   const body = getBody({ message, pluginInfo, locationInfo, errorProps, isSuccess })
   return { title, body, isSuccess }
 }

--- a/packages/build/src/error/parse/serialize_status.js
+++ b/packages/build/src/error/parse/serialize_status.js
@@ -1,8 +1,5 @@
-const { parseError } = require('./parse')
-
 // Serialize an error object to `statuses` properties
-const serializeErrorStatus = function(error, { debug }) {
-  const { state, title, message, locationInfo, errorProps } = parseError({ error, colors: false, debug })
+const serializeErrorStatus = function({ fullErrorInfo: { state, title, message, locationInfo, errorProps } }) {
   const text = getText({ locationInfo, errorProps })
   return { state, title, summary: message, text }
 }

--- a/packages/build/src/log/main.js
+++ b/packages/build/src/log/main.js
@@ -4,6 +4,7 @@ const prettyMs = require('pretty-ms')
 
 const { name, version } = require('../../package.json')
 const { isSuccessException } = require('../error/cancel')
+const { getFullErrorInfo } = require('../error/parse/parse')
 const { serializeLogError } = require('../error/parse/serialize_log')
 const { roundTimerToMillisecs } = require('../time/measure')
 const { omit } = require('../utils/omit')
@@ -249,7 +250,8 @@ const logStatus = function(logs, { package, title = `Plugin ${package} ran succe
 }
 
 const logBuildError = function({ error, netlifyConfig, mode, logs, debug, testOpts }) {
-  const { title, body, isSuccess } = serializeLogError(error, { debug })
+  const fullErrorInfo = getFullErrorInfo({ error, colors: true, debug })
+  const { title, body, isSuccess } = serializeLogError({ fullErrorInfo })
   const logFunction = isSuccess ? logHeader : logErrorHeader
   logFunction(logs, title)
   logMessage(logs, `\n${body}\n`)

--- a/packages/build/src/status/add.js
+++ b/packages/build/src/status/add.js
@@ -1,5 +1,6 @@
 const { isErrorEvent } = require('../commands/get')
 const { addErrorInfo } = require('../error/info')
+const { getFullErrorInfo } = require('../error/parse/parse')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 
 // The last event handler of a plugin (except for `onError` and `onEnd`)
@@ -55,7 +56,8 @@ const canOverrideStatus = function(formerStatus, newStatus) {
 
 // Errors that happen during plugin loads should be reported as error statuses
 const addPluginLoadErrorStatus = function({ error, package, version, debug }) {
-  const errorStatus = serializeErrorStatus(error, { debug })
+  const fullErrorInfo = getFullErrorInfo({ error, colors: false, debug })
+  const errorStatus = serializeErrorStatus({ fullErrorInfo })
   const statuses = [{ ...errorStatus, event: 'load', package, version }]
   addErrorInfo(error, { statuses })
   return error


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/939#issuecomment-686542767 feature

This refactors the code by splitting the functions responsible for serializing error into statuses and logs, and the function responsible for retrieving full error information. This does not change the logic.