### PR TITLE
Add `error.severity: none`

### DIFF
--- a/packages/build/src/error/cancel.js
+++ b/packages/build/src/error/cancel.js
@@ -1,6 +1,3 @@
-const { getErrorInfo } = require('./info')
-const { getTypeInfo } = require('./type')
-
 // Cancel builds, for example when a plugin uses `utils.build.cancelBuild()`
 const cancelBuild = async function({ api, deployId }) {
   if (api === undefined || !deployId) {
@@ -10,11 +7,4 @@ const cancelBuild = async function({ api, deployId }) {
   await api.cancelSiteDeploy({ deploy_id: deployId })
 }
 
-// Is an exception but not a build error, e.g. canceled builds
-const isSuccessException = function(error) {
-  const errorInfo = getErrorInfo(error)
-  const { isSuccess } = getTypeInfo(errorInfo)
-  return Boolean(isSuccess)
-}
-
-module.exports = { cancelBuild, isSuccessException }
+module.exports = { cancelBuild }

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -37,7 +37,7 @@ const reportBuildError = async function({ error, errorMonitor, childEnv, logs, t
 // Plugin authors test their plugins as local plugins. Errors there are more
 // like development errors, and should be reported as `info` only.
 const getSeverity = function(severity, { location: { loadedFrom } = {} }) {
-  if (loadedFrom === 'local') {
+  if (loadedFrom === 'local' || severity === 'none') {
     return 'info'
   }
 

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -16,8 +16,8 @@ const getFullErrorInfo = function({ error, colors, debug }) {
     errorProps,
     errorInfo,
     errorInfo: { location = {}, plugin = {} },
+    severity,
     title,
-    isSuccess,
     stackType,
     locationType,
     showErrorProps,
@@ -26,7 +26,7 @@ const getFullErrorInfo = function({ error, colors, debug }) {
 
   const titleA = getTitle(title, errorInfo)
 
-  const { message: messageA, stack: stackA } = getStackInfo({ message, stack, stackType, rawStack, isSuccess, debug })
+  const { message: messageA, stack: stackA } = getStackInfo({ message, stack, stackType, rawStack, severity, debug })
 
   const pluginInfo = getPluginInfo(plugin, location)
   const locationInfo = getLocationInfo({ stack: stackA, location, locationType })
@@ -39,18 +39,9 @@ const getFullErrorInfo = function({ error, colors, debug }) {
 const parseErrorInfo = function(error) {
   const { message, stack, ...errorProps } = normalizeError(error)
   const errorInfo = getErrorInfo(errorProps)
-  const {
-    type,
-    state,
-    severity,
-    title,
-    group,
-    isSuccess,
-    stackType,
-    locationType,
-    showErrorProps,
-    rawStack,
-  } = getTypeInfo(errorInfo)
+  const { type, state, severity, title, group, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(
+    errorInfo,
+  )
   const basicErrorInfo = {
     message,
     stack,
@@ -61,7 +52,6 @@ const parseErrorInfo = function(error) {
     severity,
     title,
     group,
-    isSuccess,
     stackType,
     locationType,
     showErrorProps,

--- a/packages/build/src/error/parse/serialize_log.js
+++ b/packages/build/src/error/parse/serialize_log.js
@@ -2,14 +2,14 @@ const { THEME } = require('../../log/theme')
 
 // Serialize an error object into a title|body string to print in logs
 const serializeLogError = function({
-  fullErrorInfo: { title, message, pluginInfo, locationInfo, errorProps, isSuccess },
+  fullErrorInfo: { title, severity, message, pluginInfo, locationInfo, errorProps },
 }) {
-  const body = getBody({ message, pluginInfo, locationInfo, errorProps, isSuccess })
-  return { title, body, isSuccess }
+  const body = getBody({ message, pluginInfo, locationInfo, errorProps, severity })
+  return { title, body }
 }
 
-const getBody = function({ message, pluginInfo, locationInfo, errorProps, isSuccess }) {
-  if (isSuccess) {
+const getBody = function({ message, pluginInfo, locationInfo, errorProps, severity }) {
+  if (severity === 'none') {
     return message
   }
 

--- a/packages/build/src/error/parse/stack.js
+++ b/packages/build/src/error/parse/stack.js
@@ -1,9 +1,9 @@
 const { cleanStacks } = require('./clean_stack')
 
 // Retrieve the stack trace
-const getStackInfo = function({ message, stack, stackType, rawStack, isSuccess, debug }) {
+const getStackInfo = function({ message, stack, stackType, rawStack, severity, debug }) {
   const { message: messageA, stack: stackA } = splitStackInfo({ message, stack, stackType })
-  const messageB = isSuccess ? messageA.replace(SUCCESS_ERROR_NAME, '') : messageA
+  const messageB = severity === 'none' ? messageA.replace(SUCCESS_ERROR_NAME, '') : messageA
   const stackB = cleanStacks({ stack: stackA, rawStack, debug })
   return { message: messageB, stack: stackB }
 }

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -9,7 +9,6 @@ const getTypeInfo = function({ type }) {
 //  - `title`: main title shown in build error logs and in the UI (statuses)
 //  - `locationType`: retrieve a human-friendly location of the error, printed
 //    in build error logs
-//  - `isSuccess`: `true` when this should not be reported as an error
 //  - `showErrorProps`: `true` when the `Error` instance static properties
 //    should be printed in build error logs. Only useful when the `Error`
 //    instance was not created by us.
@@ -20,17 +19,27 @@ const getTypeInfo = function({ type }) {
 //      - `message`: printed as is, but taken from `error.message`.
 //        Used when `error.stack` is not being correct due to the error being
 //        passed between different processes.
+//  - `severity`: error severity (also used by Bugsnag):
+//      - `none`: not an error, e.g. build cancellation
+//      - `info`: user error
+//      - `warning`: plugin author error, or possible system error
+//      - `error`: likely system error
 // Related to error statuses:
 //  - `state`: error status state. Defaults to `failed_build`
 // Related to Bugsnag:
 //  - `group`: main title shown in Bugsnag. Also used to group errors together
 //    in Bugsnag, combined with `error.message`.
 //    Defaults to `title`.
-//  - `severity`: Bugsnag error severity:
-//      - `info`: user error
-//      - `warning`: plugin author error, or possible system error
-//      - `error`: likely system error
 const TYPES = {
+  // Plugin called `utils.build.cancelBuild()`
+  cancelBuild: {
+    title: ({ location: { package } }) => `Build canceled by ${package}`,
+    stackType: 'stack',
+    locationType: 'buildFail',
+    severity: 'none',
+    state: 'canceled_build',
+  },
+
   // User configuration error (`@netlify/config`, wrong Node.js version)
   resolveConfig: {
     title: 'Configuration error',
@@ -70,16 +79,6 @@ const TYPES = {
     locationType: 'buildFail',
     severity: 'info',
     state: 'failed_plugin',
-  },
-
-  // Plugin called `utils.build.cancelBuild()`
-  cancelBuild: {
-    title: ({ location: { package } }) => `Build canceled by ${package}`,
-    stackType: 'stack',
-    locationType: 'buildFail',
-    isSuccess: true,
-    severity: 'info',
-    state: 'canceled_build',
   },
 
   // Plugin has an invalid shape


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/939#issuecomment-686542767 feature

Note: this PR diff includes another PR (https://github.com/netlify/build/pull/1802). Once #1802 is merged, this PR can be rebased to make the diff smaller.

We currently have the three following error severity levels:
  - `info`: user error:
  - `warning`: plugin error
  - `error`: system error

There is a fourth severity level: exceptions that are actually not errors. The only instance we currently have of those are build cancellations, which are handled as exceptions, but are still supposed to result in a successful build.

At the moment, those are using a boolean `isSuccess` flag. This PR switches to using a new severity level `none` instead. This will make it easier to map severity levels to exit codes.