### PR TITLE
Run deploy as an onPostBuild event using a new core plugin

### DIFF
--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -17,6 +17,7 @@ const getConstants = async function({
   siteInfo: { id: siteId },
   token,
   mode,
+  buildbotServerSocket,
 }) {
   const isLocal = mode !== 'buildbot'
   const [cacheDir, edgeHandlersSrc] = await Promise.all([
@@ -65,6 +66,10 @@ const getConstants = async function({
      * The Netlify API access token
      */
     NETLIFY_API_TOKEN: token,
+    /**
+     * The path to the buildbot server socket
+     */
+    BUILDBOT_SERVER_SOCKET: buildbotServerSocket,
   }
   const constantsA = mapObj(constants, (key, path) => [key, normalizePath(path, buildDir, key)])
   return constantsA

--- a/packages/build/src/core/flags.js
+++ b/packages/build/src/core/flags.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 // All CLI flags
 const FLAGS = {
   config: {
@@ -89,6 +91,20 @@ Default: automatically guessed`,
 Default: none`,
     hidden: true,
   },
+  buildbotServerSocket: {
+    string: true,
+    describe: `Path to the buildbot server socket. This is used to connect to the buildbot to trigger deploys.`,
+    hidden: true,
+  },
+  triggerDeployWithBuildbotServer: {
+    boolean: true,
+    describe: `Feature flag.
+When enabled, triggers a deploy by connecting to the buildbot deploy server and
+passing it a "deploySite" command. Netlify Build then waits for the buildbot to
+finish its deploy before running the "onSuccess" and "onEnd" hooks.
+Default: false`,
+    hidden: true,
+  },
   telemetry: {
     boolean: true,
     describe: `Enable telemetry.
@@ -141,3 +157,4 @@ Default: true`,
 }
 
 module.exports = { FLAGS }
+/* eslint-enable max-lines */

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -125,6 +125,8 @@ const tExecBuild = async function({
   errorParams,
   logs,
   timers,
+  buildbotServerSocket,
+  triggerDeployWithBuildbotServer,
   sendStatus,
 }) {
   const {
@@ -180,6 +182,8 @@ const tExecBuild = async function({
     sendStatus,
     testOpts,
     featureFlags,
+    buildbotServerSocket,
+    triggerDeployWithBuildbotServer,
   })
   return { netlifyConfig, siteInfo, commandsCount, timers: timersB }
 }
@@ -195,6 +199,8 @@ const runAndReportBuild = async function({
   childEnv,
   functionsDistDir,
   buildImagePluginsDir,
+  buildbotServerSocket,
+  triggerDeployWithBuildbotServer,
   dry,
   siteInfo,
   mode,
@@ -230,6 +236,8 @@ const runAndReportBuild = async function({
       timers,
       testOpts,
       featureFlags,
+      buildbotServerSocket,
+      triggerDeployWithBuildbotServer,
     })
     await reportStatuses({
       statuses,
@@ -286,8 +294,19 @@ const initAndRunBuild = async function({
   timers,
   testOpts,
   featureFlags,
+  buildbotServerSocket,
+  triggerDeployWithBuildbotServer,
 }) {
-  const constants = await getConstants({ configPath, buildDir, functionsDistDir, netlifyConfig, siteInfo, token, mode })
+  const constants = await getConstants({
+    configPath,
+    buildDir,
+    functionsDistDir,
+    netlifyConfig,
+    siteInfo,
+    token,
+    mode,
+    buildbotServerSocket,
+  })
 
   const { pluginsOptions, timers: timersA } = await getPluginsOptions({
     netlifyConfig,
@@ -295,6 +314,7 @@ const initAndRunBuild = async function({
     constants,
     mode,
     buildImagePluginsDir,
+    triggerDeployWithBuildbotServer,
     logs,
     debug,
     timers,

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -50,12 +50,12 @@ const loadPlugin = async function(
 }
 
 // Only core plugins can use `constants.NETLIFY_API_TOKEN` at the moment
-const cleanConstants = function({ NETLIFY_API_TOKEN, ...constants }, loadedFrom) {
+const cleanConstants = function({ NETLIFY_API_TOKEN, BUILDBOT_SERVER_SOCKET, ...constants }, loadedFrom) {
   if (loadedFrom !== 'core') {
     return constants
   }
 
-  return { ...constants, NETLIFY_API_TOKEN }
+  return { ...constants, NETLIFY_API_TOKEN, BUILDBOT_SERVER_SOCKET }
 }
 
 module.exports = { loadPlugins }

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -20,10 +20,11 @@ const tGetPluginsOptions = async function({
   constants,
   mode,
   buildImagePluginsDir,
+  triggerDeployWithBuildbotServer,
   logs,
   debug,
 }) {
-  const corePlugins = await getCorePlugins({ constants, buildDir })
+  const corePlugins = await getCorePlugins({ constants, buildDir, triggerDeployWithBuildbotServer })
   const allCorePlugins = corePlugins
     .map(corePlugin => addCoreProperties(corePlugin, plugins))
     .filter(corePlugin => !isOptionalCore(corePlugin, plugins))

--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -1,0 +1,69 @@
+const net = require('net')
+const { promisify } = require('util')
+
+const pEvent = require('p-event')
+
+const { addErrorInfo } = require('../../error/info')
+
+const BUILDBOT_CLIENT_TIMEOUT_PERIOD = 60 * 1000
+
+const createBuildbotClient = function(buildbotServerSocket) {
+  return net.createConnection(buildbotServerSocket)
+}
+
+const connectBuildbotClient = async function(client) {
+  try {
+    client.setTimeout(BUILDBOT_CLIENT_TIMEOUT_PERIOD, () => {
+      client.end()
+    })
+    await pEvent(client, 'connect')
+    return client
+  } catch (error) {
+    addErrorInfo(error, { type: 'buildbotClient' })
+    throw error
+  }
+}
+
+const closeBuildbotClient = async function(client) {
+  try {
+    await promisify(client.end.bind(client))()
+  } catch (error) {
+    addErrorInfo(error, { type: 'buildbotClient' })
+    throw error
+  }
+}
+
+const writePayload = async function(buildbotClient, payload) {
+  await promisify(buildbotClient.write.bind(buildbotClient))(JSON.stringify(payload))
+}
+
+const getNextParsedResponsePromise = async function(buildbotClient) {
+  const data = await pEvent(buildbotClient, 'data')
+  return JSON.parse(data)
+}
+
+const deploySiteWithBuildbotClient = async function(client) {
+  const payload = { action: 'deploySite' }
+  try {
+    const [response] = await Promise.all([getNextParsedResponsePromise(client), writePayload(client, payload)])
+
+    if (!response.succeeded) {
+      throw new Error(`Deploy did not succeed: ${response.values.error}`)
+    }
+  } catch (error) {
+    addErrorInfo(error, {
+      type: 'buildbotClient',
+      location: { payload },
+    })
+    throw error
+  }
+
+  return
+}
+
+module.exports = {
+  createBuildbotClient,
+  connectBuildbotClient,
+  closeBuildbotClient,
+  deploySiteWithBuildbotClient,
+}

--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -1,0 +1,22 @@
+const {
+  env: { NETLIFY_BUILD_EVENTS_ORDER },
+} = require('process')
+
+const {
+  createBuildbotClient,
+  connectBuildbotClient,
+  closeBuildbotClient,
+  deploySiteWithBuildbotClient,
+} = require('./buildbot_client')
+
+const onBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET } }) {
+  const client = createBuildbotClient(BUILDBOT_SERVER_SOCKET)
+  try {
+    await connectBuildbotClient(client)
+    await deploySiteWithBuildbotClient(client)
+  } finally {
+    await closeBuildbotClient(client)
+  }
+}
+
+module.exports = NETLIFY_BUILD_EVENTS_ORDER === '1' ? { onBuild } : { onPostBuild: onBuild }

--- a/packages/build/src/plugins_core/deploy/manifest.yml
+++ b/packages/build/src/plugins_core/deploy/manifest.yml
@@ -1,0 +1,1 @@
+name: '@netlify/plugin-deploy-core'


### PR DESCRIPTION
**Which problem is this pull request solving?**

Currently deploys run after `netlify-build` has completed. This means that plugins can't run after the deploy has completed.

This PR allows the use of two flags: `--buildbotServerSocket` and `--triggerDeployWithBuildbotServer`. The second is designed to be removed once it is no longer in use. If both flags are passed, it enables a core plugin that sends a deploy message to the buildbot server as the final `onPostBuild` action (via a new core plugin).

Once this has been coordinated with other work in the buildbot, this will allow `onSuccess` and `onEnd` hooks to run after the deploy has completed and the site is live.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
