### PR TITLE
Add `yargs` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,7 @@
         'p-locate',
         'prettier',
         'pretty-ms',
+        'yargs',
       ],
       major: {
         enabled: false,


### PR DESCRIPTION
This adds `yargs` to `renovate.json5` list of dependencies that do not support Node 8