### PR TITLE
Fix wrong programmatic `success` return value

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -18,9 +18,9 @@ const runCli = async function() {
   const flags = parseFlags()
   const flagsA = filterObj(flags, isUserFlag)
 
-  const { severity = DEFAULT_SEVERITY, logs } = await build(flagsA)
+  const { severityCode, logs } = await build(flagsA)
   printLogs(logs)
-  process.exitCode = EXIT_CODES[severity]
+  process.exitCode = severityCode
 }
 
 const parseFlags = function() {
@@ -191,14 +191,5 @@ const printLogs = function(logs) {
   const allLogs = [logs.stdout.join('\n'), logs.stderr.join('\n')].filter(Boolean).join('\n\n')
   console.log(allLogs)
 }
-
-// The exit codes 1|2|3 indicates whether this was a user|plugin|system error
-const EXIT_CODES = {
-  none: 0,
-  info: 1,
-  warning: 2,
-  error: 3,
-}
-const DEFAULT_SEVERITY = 'error'
 
 runCli()

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -19,6 +19,7 @@ const { loadConfig } = require('./config')
 const { getConstants } = require('./constants')
 const { doDryRun } = require('./dry')
 const { normalizeFlags } = require('./flags')
+const { getSeverity } = require('./severity')
 
 /**
  * Main entry point of Netlify Build.
@@ -73,10 +74,12 @@ const build = async function(flags = {}) {
       testOpts,
       statsdOpts,
     })
-    return { success: true, severity: 'none', logs }
+    const { success, severityCode } = getSeverity('none')
+    return { success, severityCode, logs }
   } catch (error) {
     const { severity } = await handleBuildError(error, errorParams)
-    return { success: severity !== 'none', severity, logs }
+    const { success, severityCode } = getSeverity(severity)
+    return { success, severityCode, logs }
   }
 }
 

--- a/packages/build/src/core/severity.js
+++ b/packages/build/src/core/severity.js
@@ -1,0 +1,19 @@
+// Used for example as exit codes.
+// 1|2|3 indicate whether this was a user|plugin|system error.
+const getSeverity = function(severity = FALLBACK_SEVERITY) {
+  const severityCode = severity in SEVERITY_CODES ? SEVERITY_CODES[severity] : SEVERITY_CODES[FALLBACK_SEVERITY]
+  const success = severity === SUCCESS_SEVERITY
+  return { success, severityCode }
+}
+
+const SEVERITY_CODES = {
+  none: 0,
+  info: 1,
+  warning: 2,
+  error: 3,
+}
+const SUCCESS_SEVERITY = 'none'
+// Indicates a bug in our codebase
+const FALLBACK_SEVERITY = 'error'
+
+module.exports = { getSeverity }

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -38,6 +38,55 @@ test('Exit code is 2 on plugin error', async t => {
   t.is(exitCode, 2)
 })
 
+test('Success is true on success', async t => {
+  const {
+    returnValue: { success },
+  } = await runFixture(t, 'empty', { programmatic: true, snapshot: false })
+  t.true(success)
+})
+
+test('Success is true on build cancellation', async t => {
+  const {
+    returnValue: { success },
+  } = await runFixture(t, 'cancel', { programmatic: true, snapshot: false })
+  t.true(success)
+})
+
+test('Success is false on failure', async t => {
+  const {
+    returnValue: { success },
+  } = await runFixture(t, 'plugin_error', { programmatic: true, snapshot: false })
+  t.false(success)
+})
+
+test('severityCode is 0 on success', async t => {
+  const {
+    returnValue: { severityCode },
+  } = await runFixture(t, 'empty', { programmatic: true, snapshot: false })
+  t.is(severityCode, 0)
+})
+
+test('severityCode is 0 on build cancellation', async t => {
+  const {
+    returnValue: { severityCode },
+  } = await runFixture(t, 'cancel', { programmatic: true, snapshot: false })
+  t.is(severityCode, 0)
+})
+
+test('severityCode is 1 on user error', async t => {
+  const {
+    returnValue: { severityCode },
+  } = await runFixture(t, '', { flags: { config: '/invalid' }, programmatic: true, snapshot: false })
+  t.is(severityCode, 1)
+})
+
+test('severityCode is 2 on plugin error', async t => {
+  const {
+    returnValue: { severityCode },
+  } = await runFixture(t, 'plugin_error', { programmatic: true, snapshot: false })
+  t.is(severityCode, 2)
+})
+
 test('--cwd', async t => {
   await runFixture(t, '', { flags: { cwd: `${FIXTURES_DIR}/empty` } })
 })

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -11,7 +11,11 @@ const { runFixtureCommon, FIXTURES_DIR } = require('./common')
 const ROOT_DIR = `${__dirname}/../..`
 const BUILD_BIN_DIR = normalize(`${ROOT_DIR}/node_modules/.bin`)
 
-const runFixture = async function(t, fixtureName, { flags = {}, env: envOption = {}, ...opts } = {}) {
+const runFixture = async function(
+  t,
+  fixtureName,
+  { flags = {}, env: envOption = {}, programmatic = false, ...opts } = {},
+) {
   const binaryPath = await BINARY_PATH
   const flagsA = { debug: true, telemetry: false, buffer: true, ...flags }
   const envOptionA = {
@@ -25,10 +29,11 @@ const runFixture = async function(t, fixtureName, { flags = {}, env: envOption =
     [pathKey()]: `${env[pathKey()]}${delimiter}${BUILD_BIN_DIR}`,
     ...envOption,
   }
+  const mainFunc = programmatic ? netlifyBuild : getNetlifyBuildLogs
   return runFixtureCommon(t, fixtureName, { ...opts, flags: flagsA, env: envOptionA, mainFunc, binaryPath })
 }
 
-const mainFunc = async function(flags) {
+const getNetlifyBuildLogs = async function(flags) {
   const { logs } = await netlifyBuild(flags)
   return [logs.stdout.join('\n'), logs.stderr.join('\n')].filter(Boolean).join('\n\n')
 }


### PR DESCRIPTION
When the build fails, the `success` value returned programmatically is `true` instead of `false`.

This was not caught by our tests because:
  - The `severity` is used instead of `success` by `@netlify/build` CLI
  - The tests are only covering the logs output, not the programmatic return value

This PR fixes this bug and also:
  - Adds tests for the programmatic return value
  - Moves the logic that translates a `severity` to an exit code so that Netlify CLI can re-use it