### PR TITLE
Fix `token` returned by `@netlify/config`

### DIFF
--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -26,9 +26,9 @@ const {
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
 const resolveConfig = async function(opts) {
-  const { cachedConfig, ...optsA } = addDefaultOpts(opts)
+  const { cachedConfig, token, ...optsA } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
-  const api = getApiClient(optsA)
+  const api = getApiClient({ ...optsA, token })
 
   // Performance optimization when @netlify/config caller has already previously
   // called it and cached the result.
@@ -36,7 +36,10 @@ const resolveConfig = async function(opts) {
   //  - first calls @netlify/config since it needs configuration property
   //  - later calls @netlify/build, which runs @netlify/config under the hood
   if (cachedConfig !== undefined) {
-    return { ...getConfig(cachedConfig, 'cached'), api }
+    // The CLI does not print the API `token` for security reasons, which means
+    // it might be missing from `cachedConfig`. We provide the one passed in
+    // `opts` as a fallback.
+    return { token, ...getConfig(cachedConfig, 'cached'), api }
   }
 
   const {
@@ -50,7 +53,6 @@ const resolveConfig = async function(opts) {
     branch,
     siteId,
     baseRelDir,
-    token,
     mode,
     debug,
     logs,

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -80,7 +80,7 @@ test('--cachedConfig with an invalid path', async t => {
 })
 
 test('--cachedConfig with a token', async t => {
-  const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: { token: 'test' } })
+  const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false })
   await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue, token: 'test' } })
 })
 


### PR DESCRIPTION
Fixes https://github.com/netlify/build/issues/1816

When called as a binary, `@netlify/config` does not print the API `token` for security reasons. 

The return value of `@netlify/config` is printed on `stdout` which is used by the buildbot and passed back to `@netlify/config` using the `cachedConfig` option. When this happens, the `token` is therefore missing from `cachedConfig`. This results in `@netlify/config` return value missing the `token` under those conditions.

This means, in production, `constants.NETLIFY_API_TOKEN` passed to core plugins like the Edge handlers core plugins, is `undefined`. This PR fixes this problem. It also fixes the related integration test.