### PR TITLE
Add `postDeployErrors` feature flag

### DIFF
--- a/packages/build/src/commands/error.js
+++ b/packages/build/src/commands/error.js
@@ -24,6 +24,7 @@ const handleCommandError = async function({
   logs,
   debug,
   testOpts,
+  featureFlags,
 }) {
   // `build.command` do not report error statuses
   if (buildCommand !== undefined) {
@@ -37,7 +38,7 @@ const handleCommandError = async function({
   } = fullErrorInfo
   const newStatus = serializeErrorStatus({ fullErrorInfo })
 
-  if (type === 'failPlugin' || isSoftFailEvent(event)) {
+  if (type === 'failPlugin' || isSoftFailEvent(event, featureFlags)) {
     return handleFailPlugin({
       newStatus,
       package,

--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -1,7 +1,3 @@
-const {
-  env: { NETLIFY_POST_DEPLOY_ERRORS },
-} = require('process')
-
 const { EVENTS } = require('../plugins/events')
 
 // Get commands for all events
@@ -34,11 +30,9 @@ const isAmongEvents = function(events, event) {
 }
 
 // Check if failure of the event should not make the build fail
-const isSoftFailEvent =
-  NETLIFY_POST_DEPLOY_ERRORS === 'true'
-    ? isAmongEvents.bind(null, ['onSuccess', 'onError', 'onEnd'])
-    : // We currently feature flag this using an environment variable
-      () => false
+const isSoftFailEvent = function(event, featureFlags) {
+  return featureFlags.postDeployErrors && isAmongEvents(['onSuccess', 'onError', 'onEnd'], event)
+}
 
 // Check if the event is triggered even when an error happens
 const isErrorEvent = isAmongEvents.bind(null, ['onError', 'onEnd'])

--- a/packages/build/src/commands/run.js
+++ b/packages/build/src/commands/run.js
@@ -31,6 +31,7 @@ const runCommands = async function({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   const { index: commandsCount, error: errorA, statuses: statusesB, timers: timersC } = await pReduce(
     commands,
@@ -72,6 +73,7 @@ const runCommands = async function({
         debug,
         timers: timersA,
         testOpts,
+        featureFlags,
       })
       const statusesA = addStatus({ newStatus, statuses, event, package, pluginPackageJson })
       return {
@@ -124,6 +126,7 @@ const runCommand = async function({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   if (!shouldRunCommand({ event, package, error, failedPlugins })) {
     return {}
@@ -170,6 +173,7 @@ const runCommand = async function({
     timers: timersA,
     durationNs,
     testOpts,
+    featureFlags,
   })
   return { ...newValues, newIndex: index + 1 }
 }
@@ -269,6 +273,7 @@ const getNewValues = function({
   timers,
   durationNs,
   testOpts,
+  featureFlags,
 }) {
   if (newError !== undefined) {
     return handleCommandError({
@@ -284,6 +289,7 @@ const getNewValues = function({
       logs,
       debug,
       testOpts,
+      featureFlags,
     })
   }
 

--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -18,4 +18,10 @@ const getFeatureFlag = function(name) {
   return { [name]: true }
 }
 
-module.exports = { normalizeFeatureFlags }
+const DEFAULT_FEATURE_FLAGS = {
+  // When `true`, errors in `onSuccess`, `onEnd` and `onError` happening after
+  // deploy do not make the build fail. They only make the plugin fail.
+  postDeployErrors: false,
+}
+
+module.exports = { normalizeFeatureFlags, DEFAULT_FEATURE_FLAGS }

--- a/packages/build/src/core/flags.js
+++ b/packages/build/src/core/flags.js
@@ -3,7 +3,7 @@ const { env, execPath } = require('process')
 const { logFlags } = require('../log/main')
 const { removeFalsy } = require('../utils/remove_falsy')
 
-const { normalizeFeatureFlags } = require('./feature_flags')
+const { normalizeFeatureFlags, DEFAULT_FEATURE_FLAGS } = require('./feature_flags')
 
 // Normalize CLI flags
 const normalizeFlags = function(flags, logs) {
@@ -38,7 +38,7 @@ const getDefaultFlags = function({ env: envOpt = {} }) {
     telemetry: !combinedEnv.BUILD_TELEMETRY_DISABLED,
     sendStatus: false,
     testOpts: {},
-    featureFlags: {},
+    featureFlags: DEFAULT_FEATURE_FLAGS,
     statsd: { port: DEFAULT_STATSD_PORT },
   }
 }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -118,6 +118,7 @@ const tExecBuild = async function({
   mode,
   deployId,
   testOpts,
+  featureFlags,
   errorMonitor,
   errorParams,
   logs,
@@ -176,6 +177,7 @@ const tExecBuild = async function({
     timers: timersA,
     sendStatus,
     testOpts,
+    featureFlags,
   })
   return { netlifyConfig, siteInfo, commandsCount, timers: timersB }
 }
@@ -203,6 +205,7 @@ const runAndReportBuild = async function({
   timers,
   sendStatus,
   testOpts,
+  featureFlags,
 }) {
   try {
     const { commandsCount, statuses, timers: timersA } = await initAndRunBuild({
@@ -224,6 +227,7 @@ const runAndReportBuild = async function({
       debug,
       timers,
       testOpts,
+      featureFlags,
     })
     await reportStatuses({
       statuses,
@@ -279,6 +283,7 @@ const initAndRunBuild = async function({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   const constants = await getConstants({ configPath, buildDir, functionsDistDir, netlifyConfig, siteInfo, token, mode })
 
@@ -322,6 +327,7 @@ const initAndRunBuild = async function({
       debug,
       timers: timersB,
       testOpts,
+      featureFlags,
     })
   } finally {
     await stopPlugins(childProcesses)
@@ -348,6 +354,7 @@ const runBuild = async function({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   const { pluginsCommands, timers: timersA } = await loadPlugins({
     pluginsOptions,
@@ -356,6 +363,7 @@ const runBuild = async function({
     constants,
     timers,
     debug,
+    featureFlags,
   })
 
   const { commands, commandsCount } = getCommands(pluginsCommands, netlifyConfig)
@@ -380,6 +388,7 @@ const runBuild = async function({
     debug,
     timers: timersA,
     testOpts,
+    featureFlags,
   })
   return { commandsCount: commandsCountA, statuses, timers: timersB }
 }

--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -6,7 +6,7 @@ const { validatePlugin } = require('./validate')
 // This also validates the plugin.
 // Do it when parent requests it using the `load` event.
 // Also figure out the list of plugin commands. This is also passed to the parent.
-const load = function({ pluginPath, inputs, constants, netlifyConfig }) {
+const load = function({ pluginPath, inputs, constants, netlifyConfig, featureFlags }) {
   const logic = getLogic({ pluginPath, inputs })
 
   validatePlugin(logic)
@@ -14,7 +14,7 @@ const load = function({ pluginPath, inputs, constants, netlifyConfig }) {
   const pluginCommands = getPluginCommands(logic)
 
   // Context passed to every event handler
-  const context = { pluginCommands, constants, inputs, netlifyConfig }
+  const context = { pluginCommands, constants, inputs, netlifyConfig, featureFlags }
 
   return { pluginCommands, context }
 }

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -3,10 +3,13 @@ const { getNewEnvChanges, setEnvChanges } = require('../../env/changes.js')
 const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
-const run = async function({ event, error, envChanges }, { pluginCommands, constants, inputs, netlifyConfig }) {
+const run = async function(
+  { event, error, envChanges },
+  { pluginCommands, constants, inputs, netlifyConfig, featureFlags },
+) {
   const { method } = pluginCommands.find(pluginCommand => pluginCommand.event === event)
   const runState = {}
-  const utils = getUtils({ event, constants, runState })
+  const utils = getUtils({ event, constants, runState, featureFlags })
   const runOptions = { utils, constants, inputs, netlifyConfig, error }
 
   const envBefore = setEnvChanges(envChanges)

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -5,8 +5,8 @@ const { addLazyProp } = require('./lazy')
 const { show } = require('./status')
 
 // Retrieve the `utils` argument.
-const getUtils = function({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runState }) {
-  const build = getBuildUtils(event)
+const getUtils = function({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runState, featureFlags }) {
+  const build = getBuildUtils(event, featureFlags)
   const utils = { build }
   addLazyProp(utils, 'git', getGitUtils)
   addLazyProp(utils, 'cache', getCacheUtils.bind(null, CACHE_DIR))
@@ -16,8 +16,8 @@ const getUtils = function({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runS
   return utils
 }
 
-const getBuildUtils = function(event) {
-  if (isSoftFailEvent(event)) {
+const getBuildUtils = function(event, featureFlags) {
+  if (isSoftFailEvent(event, featureFlags)) {
     return {
       failPlugin,
       failBuild: failPluginWithWarning.bind(null, 'failBuild', event),

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -5,10 +5,10 @@ const { callChild } = require('./ipc')
 
 // Retrieve all plugins commands
 // Can use either a module name or a file path to the plugin.
-const tLoadPlugins = async function({ pluginsOptions, childProcesses, netlifyConfig, constants, debug }) {
+const tLoadPlugins = async function({ pluginsOptions, childProcesses, netlifyConfig, constants, debug, featureFlags }) {
   const pluginsCommands = await Promise.all(
     pluginsOptions.map((pluginOptions, index) =>
-      loadPlugin(pluginOptions, { childProcesses, index, netlifyConfig, constants, debug }),
+      loadPlugin(pluginOptions, { childProcesses, index, netlifyConfig, constants, debug, featureFlags }),
     ),
   )
   const pluginsCommandsA = pluginsCommands.flat()
@@ -21,7 +21,7 @@ const loadPlugins = measureDuration(tLoadPlugins, 'load_plugins')
 // Do it by executing the plugin `load` event handler.
 const loadPlugin = async function(
   { package, pluginPackageJson, pluginPackageJson: { version } = {}, pluginPath, inputs, loadedFrom, origin },
-  { childProcesses, index, netlifyConfig, constants, debug },
+  { childProcesses, index, netlifyConfig, constants, debug, featureFlags },
 ) {
   const { childProcess } = childProcesses[index]
   const event = 'load'
@@ -31,7 +31,7 @@ const loadPlugin = async function(
     const { pluginCommands } = await callChild(
       childProcess,
       'load',
-      { pluginPath, inputs, netlifyConfig, constants: constantsA },
+      { pluginPath, inputs, netlifyConfig, constants: constantsA, featureFlags },
       { plugin: { package, pluginPackageJson }, location: { event, package, loadedFrom, origin } },
     )
     const pluginCommandsA = pluginCommands.map(({ event }) => ({


### PR DESCRIPTION
This uses the new `--featureFlags` CLI flag for the `onSuccess` post-deploy breaking change.

When `--featureFlags=postDeployErrors` is passed to `@netlify/build` from the buildbot, this will enable the following new behavior: errors inside plugin `onSuccess` and `onEnd` will not make the build fail. Instead, only the plugin itself will fail. This is a breaking change, and is therefore being a feature flag.

Before this PR, the feature was already available behing an environment variable. This PR uses the `--featureFlags` CLI flag instead as described in https://github.com/netlify/build/issues/1817 and https://github.com/netlify/buildbot/issues/949. This will allow using LaunchDarkly on it.