### PR TITLE
Fix telemetry crash when required programmatically

### DIFF
--- a/packages/build/src/core/normalize_flags.js
+++ b/packages/build/src/core/normalize_flags.js
@@ -24,18 +24,18 @@ const normalizeFlags = function(flags, logs) {
 }
 
 // Default values of CLI flags
-const getDefaultFlags = function({ env: envOpt = {} }) {
+const getDefaultFlags = function({ env: envOpt = {}, mode = REQUIRE_MODE }) {
   const combinedEnv = { ...env, ...envOpt }
   return {
     env: envOpt,
     nodePath: execPath,
     token: combinedEnv.NETLIFY_AUTH_TOKEN,
-    mode: 'require',
+    mode: REQUIRE_MODE,
     functionsDistDir: DEFAULT_FUNCTIONS_DIST,
     deployId: combinedEnv.DEPLOY_ID,
     debug: Boolean(combinedEnv.NETLIFY_BUILD_DEBUG),
     bugsnagKey: combinedEnv.BUGSNAG_KEY,
-    telemetry: !combinedEnv.BUILD_TELEMETRY_DISABLED,
+    telemetry: !combinedEnv.BUILD_TELEMETRY_DISABLED && mode !== REQUIRE_MODE,
     sendStatus: false,
     testOpts: {},
     featureFlags: DEFAULT_FEATURE_FLAGS,
@@ -43,6 +43,7 @@ const getDefaultFlags = function({ env: envOpt = {} }) {
   }
 }
 
+const REQUIRE_MODE = 'require'
 const DEFAULT_FUNCTIONS_DIST = '.netlify/functions/'
 const DEFAULT_STATSD_PORT = 8125
 

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -263,6 +263,16 @@ test('Telemetry disabled with flag', async t => {
   t.is(requests.length, 0)
 })
 
+test('Telemetry disabled with mode', async t => {
+  const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
+  await runFixture(t, 'success', {
+    flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: undefined },
+    snapshot: false,
+  })
+  await stopServer()
+  t.is(requests.length, 0)
+})
+
 test('Telemetry error', async t => {
   const { stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {


### PR DESCRIPTION
The two main ways `@netlify/build` is used (called `mode`) are the buildbot and the CLI. There is a third way: programmatically with `require()`. That third way is only useful in some specific cases, such as when testing a Build plugin.

Our telemetry logic does not make much sense in that mode, since the code could potentially be run a lot of times if the user is doing stress testing. Also, we found that this code is sometimes crashing. Therefore, it is safer to disable telemetry by default when `mode` is `require`, which this PR does.