### PR TITLE
Try to fix statsd test

### DIFF
--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -49,6 +49,7 @@ const serializeTimerRequests = function(timerRequests) {
     .map(normalizeRequest)
     .sort()
     .join('\n')
+    .trim()
 }
 
 const normalizeRequest = function(request) {


### PR DESCRIPTION
The tests for statsd are randomly failing in CI. I cannot reproduce this locally. 
This PR attempts to improve how failure of the test is currently being reported. Due to trailing spaces, it is hard to see the snapshot difference. The trailing spaces might also be the reason of the snapshot difference. Therefore this PR removes any trailing spaces.