### PR TITLE
Fix `yarn` when there is a space in the home directory

### DIFF
--- a/packages/build/src/install/main.js
+++ b/packages/build/src/install/main.js
@@ -15,11 +15,10 @@ const addLatestDependencies = function({ packageRoot, isLocal, packages }) {
   return runCommand({ packageRoot, packages, isLocal, type: 'add' })
 }
 
-const runCommand = async function({ packageRoot, packages, isLocal, type }) {
+const runCommand = async function({ packageRoot, packages = [], isLocal, type }) {
   try {
-    const command = await getCommand({ packageRoot, type, isLocal })
-    const packagesList = packages === undefined ? '' : ` ${packages.join(' ')}`
-    await execa.command(`${command}${packagesList}`, { cwd: packageRoot, all: true })
+    const [command, ...args] = await getCommand({ packageRoot, type, isLocal })
+    await execa(command, [...args, ...packages], { cwd: packageRoot, all: true })
   } catch (error) {
     const message = getErrorMessage(error.all)
     const errorA = new Error(`Error while installing dependencies in ${packageRoot}\n${message}`)
@@ -51,11 +50,11 @@ const getManager = async function(type, packageRoot) {
 
 const COMMANDS = {
   npm: {
-    add: 'npm install --no-progress --no-audit --no-fund --no-save',
-    install: 'npm install --no-progress --no-audit --no-fund',
+    add: ['npm', 'install', '--no-progress', '--no-audit', '--no-fund', '--no-save'],
+    install: ['npm', 'install', '--no-progress', '--no-audit', '--no-fund'],
   },
   yarn: {
-    install: 'yarn install --no-progress --non-interactive',
+    install: ['yarn', 'install', '--no-progress', '--non-interactive'],
   },
 }
 
@@ -65,7 +64,7 @@ const addYarnCustomCache = function(command, manager, isLocal) {
     return command
   }
 
-  return `${command} --cache-folder=${YARN_CI_CACHE_DIR}`
+  return [...command, '--cache-folder', YARN_CI_CACHE_DIR]
 }
 
 const YARN_CI_CACHE_DIR = `${homedir()}/.yarn_cache`


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1853

We run `yarn` in a couple of cases. We use the `--cache-folder=$HOME/.yarn_cache` directory to re-use the cache directory from the buildbot. The command is currently executed with `execa.command()`, which assumes arguments are spaces-delimited. However, this assumption can be wrong when `$HOME` contains a space in it.

This PR switches to `execa()` instead, which does not require spaces escaping.

Ideally, a regression test should be added. This is quite an edge case on a piece of logic that is seldomly used, and creating an integration test is not straightforward, so I'd like to request the permission to skip it for this time :)
The logic around `yarn` is otherwise fully covered, and all tests are passing.