### PR TITLE
Fix Windows support on some tests

### DIFF
--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -20,6 +20,7 @@ const NORMALIZE_REGEXPS = [
   [/\\/gu, '/'],
   [/[A-Z]:\//g, '/'],
   [/Program Files/gu, 'ProgramFiles'],
+  [/Users\/([^/])\//gu, 'Users/User'],
   [new RegExp(tick, 'g'), '√'],
   [new RegExp(pointer, 'g'), '>'],
   [new RegExp(arrowDown, 'g'), '↓'],

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -20,7 +20,7 @@ const NORMALIZE_REGEXPS = [
   [/\\/gu, '/'],
   [/[A-Z]:\//g, '/'],
   [/Program Files/gu, 'ProgramFiles'],
-  [/Users\/([^/])\//gu, 'Users/User'],
+  [/Users\/([^/])+\//gu, 'Users/User'],
   [new RegExp(tick, 'g'), '√'],
   [new RegExp(pointer, 'g'), '>'],
   [new RegExp(arrowDown, 'g'), '↓'],

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -20,7 +20,7 @@ const NORMALIZE_REGEXPS = [
   [/\\/gu, '/'],
   [/[A-Z]:\//g, '/'],
   [/Program Files/gu, 'ProgramFiles'],
-  [/Users\/([^/])+\//gu, 'Users/User'],
+  [/Users\/([^/])+\//gu, 'Users/User/'],
   [new RegExp(tick, 'g'), '√'],
   [new RegExp(pointer, 'g'), '>'],
   [new RegExp(arrowDown, 'g'), '↓'],


### PR DESCRIPTION
Fixes #1853.

This improves how file paths inside test snapshots logs are being normalized when they contain spaces in them, especially on Windows when the user has a space in their username.