### PR TITLE
Add documentation about file paths

### DIFF
--- a/packages/config/docs/file_paths.md
+++ b/packages/config/docs/file_paths.md
@@ -45,7 +45,7 @@ The following directories are searched (from highest to lowest priority):
 - The current directory
 - Any parent directory to the current directory
 
-If the `netlify.toml` specifies a `base` directory, the configuration file is searched a second time but using that
+If the `netlify.toml` specifies a `base` directory, the configuration file is searched for a second time using the
 `base` directory instead (\*).
 
 ## Absolute paths

--- a/packages/config/docs/file_paths.md
+++ b/packages/config/docs/file_paths.md
@@ -1,4 +1,4 @@
-This document explains some of the main file paths used in a Netlify Site. This is mostly intended for code
+This document explains some of the main file paths used in a Netlify site. This is mostly intended for code
 contributors.
 
 ## Current directory
@@ -20,14 +20,14 @@ This is used as the current directory when running the build command and Build p
 This is also used to resolve any file paths inside `netlify.toml` or the UI build settings, except for the `base`
 configuration property (which is relative to the repository root instead).
 
-We sometimes refer to this as the "base directory" or the "Site root" instead.
+We sometimes refer to this as the "base directory" or the "site root" instead.
 
 Its value is (from highest to lowest priority):
 
 - The `base` property specified in `netlify.toml` or UI build settings. This is useful when targetting specific
   directories inside a monorepo.
-- In the Netlify CLI: if a project has multiple Netlify Sites, the user can step into it inside a terminal (using `cd`
-  for example). The closest parent with a `netlify.toml` or `.netlify` will be used.
+- In the Netlify CLI: if a project has multiple Netlify sites, the user can change directories to this build directory
+  inside the terminal (using `cd` for example). The closest parent with a `netlify.toml` or `.netlify` will be used.
 - The repository root.
 
 ## Configuration path
@@ -57,7 +57,7 @@ Prepending `./` is not required and does not do anything.
 
 ## baseRelDir
 
-Boolean flag intended for backward compatibility. This is set for any Sites created since the end of 2019.
+Boolean flag intended for backward compatibility. This is set for any sites created since the end of 2019.
 
 When unset:
 
@@ -66,7 +66,7 @@ When unset:
 
 ## Publish directory
 
-Directory where the Site built assets are output
+Directory where the site's built assets are output
 
 Set using the `build.publish` property in `netlify.toml` or the UI build setting.
 

--- a/packages/config/docs/file_paths.md
+++ b/packages/config/docs/file_paths.md
@@ -1,0 +1,107 @@
+This document explains some of the main file paths used in a Netlify Site. This is mostly intended for code
+contributors.
+
+## Current directory
+
+Process's current directory, as specified by `process.cwd()`.
+
+This is mostly relevant for the Netlify CLI, where users can change it in their terminal.
+
+## Repository root
+
+Project root repository. In monorepos, this is the monorepo root.
+
+This is the closest parent with a `.git` directory. If none is found, this defaults to the current directory.
+
+## Build directory
+
+This is used as the current directory when running the build command and Build plugins.
+
+This is also used to resolve any file paths inside `netlify.toml` or the UI build settings, except for the `base`
+configuration property (which is relative to the repository root instead).
+
+We sometimes refer to this as the "base directory" or the "Site root" instead.
+
+Its value is (from highest to lowest priority):
+
+- The `base` property specified in `netlify.toml` or UI build settings. This is useful when targetting specific
+  directories inside a monorepo.
+- In the Netlify CLI: if a project has multiple Netlify Sites, the user can step into it inside a terminal (using `cd`
+  for example). The closest parent with a `netlify.toml` or `.netlify` will be used.
+- The repository root.
+
+## Configuration path
+
+Path to the `netlify.toml`.
+
+This is `undefined` if no `netlify.toml` exists.
+
+This is relative to the current directory.
+
+The following directories are searched (from highest to lowest priority):
+
+- In the Netlify CLI: `--config` flag
+- The build directory
+- The current directory
+- Any parent directory to the current directory
+
+If the `netlify.toml` specifies a `base` directory, the configuration file is searched a second time but using that
+`base` directory instead (\*).
+
+## Absolute paths
+
+The Netlify configuration never allows absolute paths. Any leading `/` in a path is omitted, resulting in a relative
+path.
+
+Prepending `./` is not required and does not do anything.
+
+## baseRelDir
+
+Boolean flag intended for backward compatibility. This is set for any Sites created since the end of 2019.
+
+When unset:
+
+- The points marked with (\*) above do not apply
+- Paths in `netlify.toml` are relative to the repository root instead of the build directory
+
+## Publish directory
+
+Directory where the Site built assets are output
+
+Set using the `build.publish` property in `netlify.toml` or the UI build setting.
+
+This defaults to the build directory.
+
+## Functions source directory
+
+Location of the Netlify Functions source files.
+
+Set using the `build.functions` property in `netlify.toml` or the UI build setting.
+
+Can be `undefined`.
+
+## Functions destination directory
+
+Where Netlify Functions are bundled.
+
+In:
+
+- The production builds: this is a temporary directory inside `/tmp`
+- The CLI: this is `.netlify/functions/`, relative to the build directory
+
+## Edge handlers source directory
+
+Location of the Edge handlers source files.
+
+Its value is (from highest to lowest priority):
+
+- `build.edge_handlers` property in `netlify.toml`
+- `./edge-handlers`, providing this directory exists
+
+Can be `undefined`.
+
+## Edge handlers destination directory
+
+Where Edge handlers are bundled.
+
+It is always `.netlify/edge-handlers`, relative to the build directory.


### PR DESCRIPTION
This adds some documentation about the different file paths we use in the Netlify configuration.

We have many (current directory, repository root, build directory, configuration path, publish directory, function source/destination directories, edge handlers source/destination directories) so it can get pretty confusing quickly.

However, there are compelling reasons explaining why we do:
  - We need to support both local/CLI users, UI users and programmatic users (e.g. our tests)
  - Monorepo support
  - We use many heuristics so users don't have to configure anything
  - Some projects does not use Git
  - Some projects do not distinguish between source directories and publish directories

Any new features involving file path resolution needs to pick the right directory to resolve from, and should try to re-use on of the above. This requires understanding the different directories, which this documentation aims at doing.

Also, `@netlify/config` is resolving all those different locations under different circumstances. If possible, we should try to use the output of `@netlify/config` instead of re-implementing its logic.