### PR TITLE
Use `--feature-flags=triggerDeploy`

### DIFF
--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -24,6 +24,11 @@ const DEFAULT_FEATURE_FLAGS = {
   // When `true`, errors in `onSuccess`, `onEnd` and `onError` happening after
   // deploy do not make the build fail. They only make the plugin fail.
   postDeployErrors: false,
+  // When `true`, triggers a deploy by connecting to the buildbot deploy server
+  // and passing it a "deploySite" command. Netlify Build then waits for the
+  // buildbot to finish its deploy before running the "onSuccess" and
+  // "onEnd" hooks.
+  triggerDeploy: false,
 }
 
 module.exports = { normalizeFeatureFlags, DEFAULT_FEATURE_FLAGS }

--- a/packages/build/src/core/flags.js
+++ b/packages/build/src/core/flags.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 // All CLI flags
 const FLAGS = {
   config: {
@@ -96,15 +94,6 @@ Default: none`,
     describe: `Path to the buildbot server socket. This is used to connect to the buildbot to trigger deploys.`,
     hidden: true,
   },
-  triggerDeployWithBuildbotServer: {
-    boolean: true,
-    describe: `Feature flag.
-When enabled, triggers a deploy by connecting to the buildbot deploy server and
-passing it a "deploySite" command. Netlify Build then waits for the buildbot to
-finish its deploy before running the "onSuccess" and "onEnd" hooks.
-Default: false`,
-    hidden: true,
-  },
   telemetry: {
     boolean: true,
     describe: `Enable telemetry.
@@ -157,4 +146,3 @@ Default: true`,
 }
 
 module.exports = { FLAGS }
-/* eslint-enable max-lines */

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -126,7 +126,6 @@ const tExecBuild = async function({
   logs,
   timers,
   buildbotServerSocket,
-  triggerDeployWithBuildbotServer,
   sendStatus,
 }) {
   const {
@@ -183,7 +182,6 @@ const tExecBuild = async function({
     testOpts,
     featureFlags,
     buildbotServerSocket,
-    triggerDeployWithBuildbotServer,
   })
   return { netlifyConfig, siteInfo, commandsCount, timers: timersB }
 }
@@ -200,7 +198,6 @@ const runAndReportBuild = async function({
   functionsDistDir,
   buildImagePluginsDir,
   buildbotServerSocket,
-  triggerDeployWithBuildbotServer,
   dry,
   siteInfo,
   mode,
@@ -237,7 +234,6 @@ const runAndReportBuild = async function({
       testOpts,
       featureFlags,
       buildbotServerSocket,
-      triggerDeployWithBuildbotServer,
     })
     await reportStatuses({
       statuses,
@@ -295,7 +291,6 @@ const initAndRunBuild = async function({
   testOpts,
   featureFlags,
   buildbotServerSocket,
-  triggerDeployWithBuildbotServer,
 }) {
   const constants = await getConstants({
     configPath,
@@ -314,7 +309,6 @@ const initAndRunBuild = async function({
     constants,
     mode,
     buildImagePluginsDir,
-    triggerDeployWithBuildbotServer,
     featureFlags,
     logs,
     debug,

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -17,12 +17,11 @@ const tGetPluginsOptions = async function({
   constants,
   mode,
   buildImagePluginsDir,
-  triggerDeployWithBuildbotServer,
   featureFlags,
   logs,
   debug,
 }) {
-  const corePlugins = await getCorePlugins({ constants, buildDir, triggerDeployWithBuildbotServer })
+  const corePlugins = await getCorePlugins({ constants, buildDir, featureFlags })
   const allCorePlugins = corePlugins
     .map(corePlugin => addCoreProperties(corePlugin, plugins))
     .filter(corePlugin => !isOptionalCore(corePlugin, plugins))

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -25,12 +25,12 @@ const EDGE_HANDLERS_PLUGIN_PATH = require.resolve(EDGE_HANDLERS_PLUGIN_NAME)
 const getCorePlugins = async function({
   constants: { FUNCTIONS_SRC, EDGE_HANDLERS_SRC, BUILDBOT_SERVER_SOCKET },
   buildDir,
-  triggerDeployWithBuildbotServer,
+  featureFlags,
 }) {
   const functionsPlugin = getFunctionsPlugin(FUNCTIONS_SRC)
   const functionsInstallPlugin = getFunctionsInstallPlugin(FUNCTIONS_SRC)
   const edgeHandlersPlugin = await getEdgeHandlersPlugin({ buildDir, EDGE_HANDLERS_SRC })
-  const deployPlugin = getDeployPlugin(triggerDeployWithBuildbotServer, BUILDBOT_SERVER_SOCKET)
+  const deployPlugin = getDeployPlugin(featureFlags, BUILDBOT_SERVER_SOCKET)
   return [functionsPlugin, functionsInstallPlugin, edgeHandlersPlugin, deployPlugin].filter(Boolean)
 }
 
@@ -71,8 +71,8 @@ const usesEdgeHandlers = function({ buildDir, EDGE_HANDLERS_SRC }) {
   return isDirectory(`${buildDir}/${EDGE_HANDLERS_SRC}`)
 }
 
-const getDeployPlugin = function(triggerDeployWithBuildbotServer, BUILDBOT_SERVER_SOCKET) {
-  if (!triggerDeployWithBuildbotServer || BUILDBOT_SERVER_SOCKET === undefined) {
+const getDeployPlugin = function(featureFlags, BUILDBOT_SERVER_SOCKET) {
+  if (!featureFlags.triggerDeploy || BUILDBOT_SERVER_SOCKET === undefined) {
     return
   }
 


### PR DESCRIPTION
We have just added the `--feature-flags` CLI flag in #1823. This flag generalizes the concept of feature flags in order to avoid having to create new CLI flags for each new feature. This generalization helps with instrumenting this concept, e.g. connecting it with LaunchDarkly (https://github.com/netlify/buildbot/issues/949).

This PR replaces `--triggerDeployWithBuildbotServer` with `--feature-flags=triggerDeploy`.