### PR TITLE
Add deploy message

### DIFF
--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -44,8 +44,13 @@ const logFunctionsToBundle = function(functions, FUNCTIONS_SRC) {
   logArray(undefined, functions, { indent: false })
 }
 
+const logDeploySuccess = function() {
+  log(undefined, 'Site was successfully deployed')
+}
+
 module.exports = {
   logLoadingPlugins,
   logFailPluginWarning,
   logFunctionsToBundle,
+  logDeploySuccess,
 }

--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -1,3 +1,5 @@
+const { logDeploySuccess } = require('../../log/messages/plugins')
+
 const {
   createBuildbotClient,
   connectBuildbotClient,
@@ -10,6 +12,7 @@ const onBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET } }) {
   try {
     await connectBuildbotClient(client)
     await deploySiteWithBuildbotClient(client)
+    logDeploySuccess()
   } finally {
     await closeBuildbotClient(client)
   }


### PR DESCRIPTION
This adds a log message when the core deploy plugin successfully deploys a Site. 
This makes it clear for plugins running `onSuccess` and `onEnd` events that the Site has now been deployed.