### PR TITLE
Improve error handling of the buildbot socket

### DIFF
--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -3,6 +3,8 @@ const { promisify } = require('util')
 
 const pEvent = require('p-event')
 
+const { addAsyncErrorMessage } = require('../../utils/errors')
+
 const BUILDBOT_CLIENT_TIMEOUT_PERIOD = 60 * 1000
 
 const createBuildbotClient = function(buildbotServerSocket) {
@@ -18,22 +20,31 @@ const onBuildbotClientTimeout = function(client) {
   client.emit('error', `The TCP connection with the buildbot timed out after ${BUILDBOT_CLIENT_TIMEOUT_PERIOD}ms`)
 }
 
-const connectBuildbotClient = async function(client) {
+const eConnectBuildbotClient = async function(client) {
   await pEvent(client, 'connect')
 }
+
+const connectBuildbotClient = addAsyncErrorMessage(eConnectBuildbotClient, 'Could not connect to buildbot')
 
 const closeBuildbotClient = async function(client) {
   await promisify(client.end.bind(client))()
 }
 
-const writePayload = async function(buildbotClient, payload) {
+const cWritePayload = async function(buildbotClient, payload) {
   await promisify(buildbotClient.write.bind(buildbotClient))(JSON.stringify(payload))
 }
 
-const getNextParsedResponsePromise = async function(buildbotClient) {
+const writePayload = addAsyncErrorMessage(cWritePayload, 'Could not send payload to buildbot')
+
+const cGetNextParsedResponsePromise = async function(buildbotClient) {
   const data = await pEvent(buildbotClient, 'data')
   return JSON.parse(data)
 }
+
+const getNextParsedResponsePromise = addAsyncErrorMessage(
+  cGetNextParsedResponsePromise,
+  'Invalid response from buildbot',
+)
 
 const deploySiteWithBuildbotClient = async function(client) {
   const payload = { action: 'deploySite' }

--- a/packages/build/src/utils/errors.js
+++ b/packages/build/src/utils/errors.js
@@ -1,0 +1,14 @@
+// Wrap an async function so it prepends an error message on exceptions.
+// This helps locate errors.
+const addAsyncErrorMessage = function(asyncFunc, message) {
+  return async (...args) => {
+    try {
+      return await asyncFunc(...args)
+    } catch (error) {
+      error.stack = `${message}: ${error.stack}`
+      throw error
+    }
+  }
+}
+
+module.exports = { addAsyncErrorMessage }


### PR DESCRIPTION
This prepends error messages when the connection with the buildbot TCP socket (used by the deploy core plugin) fails, which would indicate a bug. Those error messages can help us locate which line of code went wrong, since the stack trace seems to be sometimes missing.

The `error` instance is kept since it usually is a Node.js core error which contains useful static properties.

The cases where the socket might fail:
  - Could not connect to the buildbot socket
  - Could not send a message to the buildbot socket
  - Could not receive a message from the buildbot socket
  - The buildbot socket sent a response with `succeeded: false` (this one was already implemented)

Instead of repeating similar looking `try`/`catch` blocks, this PR adds a utility helper.