### PR TITLE
Improve error handling when buildbot socket closes

### DIFF
--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -23,6 +23,10 @@ const connectBuildbotClient = async function(client) {
 }
 
 const closeBuildbotClient = async function(client) {
+  if (client.destroyed) {
+    return
+  }
+
   await promisify(client.end.bind(client))()
 }
 


### PR DESCRIPTION
When something went wrong inside the deploy core plugin, we close the TCP connection with the buildbot.
However, it is possible this connection has already ended. In that case, `client.end()` will throw, and the original error will be gone, making debugging harder.

This PR solves this problem by not attempting to end the connection when it has already ended.