### PR TITLE
Add `--testOpts.buildbotServerSocketTimeout` CLI flag

### DIFF
--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -18,6 +18,7 @@ const getConstants = async function({
   token,
   mode,
   buildbotServerSocket,
+  testOpts: { buildbotServerSocketTimeout = BUILDBOT_SERVER_SOCKET_TIMEOUT },
 }) {
   const isLocal = mode !== 'buildbot'
   const [cacheDir, edgeHandlersSrc] = await Promise.all([
@@ -70,10 +71,17 @@ const getConstants = async function({
      * The path to the buildbot server socket
      */
     BUILDBOT_SERVER_SOCKET: buildbotServerSocket,
+    /**
+     * The buildbot server socket timeout. For testing only.
+     */
+    BUILDBOT_SERVER_SOCKET_TIMEOUT: buildbotServerSocketTimeout,
   }
   const constantsA = mapObj(constants, (key, path) => [key, normalizePath(path, buildDir, key)])
   return constantsA
 }
+
+// One minute
+const BUILDBOT_SERVER_SOCKET_TIMEOUT = 6e4
 
 // The default `edge-handlers` is only set to `constants.EDGE_HANDLERS_SRC` if
 // that directory exists

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -301,6 +301,7 @@ const initAndRunBuild = async function({
     token,
     mode,
     buildbotServerSocket,
+    testOpts,
   })
 
   const { pluginsOptions, timers: timersA } = await getPluginsOptions({

--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -5,19 +5,17 @@ const pEvent = require('p-event')
 
 const { addAsyncErrorMessage } = require('../../utils/errors')
 
-const BUILDBOT_CLIENT_TIMEOUT_PERIOD = 60 * 1000
-
-const createBuildbotClient = function(buildbotServerSocket) {
-  const client = net.createConnection(buildbotServerSocket)
-  client.setTimeout(BUILDBOT_CLIENT_TIMEOUT_PERIOD, () => {
-    onBuildbotClientTimeout(client)
+const createBuildbotClient = function({ BUILDBOT_SERVER_SOCKET, BUILDBOT_SERVER_SOCKET_TIMEOUT }) {
+  const client = net.createConnection(BUILDBOT_SERVER_SOCKET)
+  client.setTimeout(BUILDBOT_SERVER_SOCKET_TIMEOUT, () => {
+    onBuildbotClientTimeout({ client, BUILDBOT_SERVER_SOCKET_TIMEOUT })
   })
   return client
 }
 
-const onBuildbotClientTimeout = function(client) {
+const onBuildbotClientTimeout = function({ client, BUILDBOT_SERVER_SOCKET_TIMEOUT }) {
   client.end()
-  client.emit('error', `The TCP connection with the buildbot timed out after ${BUILDBOT_CLIENT_TIMEOUT_PERIOD}ms`)
+  client.emit('error', `The TCP connection with the buildbot timed out after ${BUILDBOT_SERVER_SOCKET_TIMEOUT}ms`)
 }
 
 const eConnectBuildbotClient = async function(client) {

--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -7,8 +7,8 @@ const {
   deploySiteWithBuildbotClient,
 } = require('./buildbot_client')
 
-const onPostBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET } }) {
-  const client = createBuildbotClient(BUILDBOT_SERVER_SOCKET)
+const onPostBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET, BUILDBOT_SERVER_SOCKET_TIMEOUT } }) {
+  const client = createBuildbotClient({ BUILDBOT_SERVER_SOCKET, BUILDBOT_SERVER_SOCKET_TIMEOUT })
   try {
     await connectBuildbotClient(client)
     await deploySiteWithBuildbotClient(client)


### PR DESCRIPTION
This adds a `--testOpts.buildbotServerSocketTimeout` CLI flag. It defaults to 60 seconds. This modifies how long the deploy core plugin waits for a buildbot TCP response before timing out. This is meant for testing purpose.