### PR TITLE
Fix core deploy event

### DIFF
--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -5,7 +5,7 @@ const {
   deploySiteWithBuildbotClient,
 } = require('./buildbot_client')
 
-const onBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET } }) {
+const onPostBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET } }) {
   const client = createBuildbotClient(BUILDBOT_SERVER_SOCKET)
   try {
     await connectBuildbotClient(client)
@@ -15,4 +15,4 @@ const onBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET } }) {
   }
 }
 
-module.exports = { onBuild }
+module.exports = { onPostBuild }


### PR DESCRIPTION
Deploy should happen at the end of `onPostBuild`, right before `onSuccess`. At the moment, it is done at the end of `onBuild`, right before `onPostBuild`.