### PR TITLE
Add `del` to Node 8 dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,7 @@
         'chalk',
         'clean-stack',
         'cp-file',
+        'del',
         'eslint',
         'execa',
         'find-up',


### PR DESCRIPTION
This adds `del` to the list of dependencies that cannot be upgraded due to their lack of support for Node 8.