### PR TITLE
Move core plugin-specific information

### DIFF
--- a/packages/build/src/commands/plugin.js
+++ b/packages/build/src/commands/plugin.js
@@ -23,7 +23,7 @@ const firePluginCommand = async function({
     const { newEnvChanges, status } = await callChild(
       childProcess,
       'run',
-      { event, error, envChanges },
+      { event, error, envChanges, loadedFrom },
       { plugin: { pluginPackageJson, package }, location: { event, package, loadedFrom, origin } },
     )
     const newStatus = getSuccessStatus(status, { commands, event, package })

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -4,7 +4,7 @@ const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
 const run = async function(
-  { event, error, envChanges },
+  { event, error, envChanges, loadedFrom },
   { pluginCommands, constants, inputs, netlifyConfig, featureFlags },
 ) {
   const { method } = pluginCommands.find(pluginCommand => pluginCommand.event === event)
@@ -12,10 +12,27 @@ const run = async function(
   const utils = getUtils({ event, constants, runState, featureFlags })
   const runOptions = { utils, constants, inputs, netlifyConfig, error }
 
+  const runOptionsA = cleanRunOptions({ loadedFrom, runOptions })
+
   const envBefore = setEnvChanges(envChanges)
-  await method(runOptions)
+  await method(runOptionsA)
   const newEnvChanges = getNewEnvChanges(envBefore)
   return { ...runState, newEnvChanges }
+}
+
+// Remove any runOptions that is only intended for core plugins
+const cleanRunOptions = function({
+  loadedFrom,
+  runOptions: {
+    constants: { BUILDBOT_SERVER_SOCKET, ...constants },
+    ...runOptions
+  },
+}) {
+  if (loadedFrom !== 'core') {
+    return { ...runOptions, constants }
+  }
+
+  return { ...runOptions, constants: { ...constants, BUILDBOT_SERVER_SOCKET } }
 }
 
 module.exports = { run }

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -25,13 +25,12 @@ const loadPlugin = async function(
 ) {
   const { childProcess } = childProcesses[index]
   const event = 'load'
-  const constantsA = cleanConstants(constants, loadedFrom)
 
   try {
     const { pluginCommands } = await callChild(
       childProcess,
       'load',
-      { pluginPath, inputs, netlifyConfig, constants: constantsA, featureFlags },
+      { pluginPath, inputs, netlifyConfig, constants, featureFlags },
       { plugin: { package, pluginPackageJson }, location: { event, package, loadedFrom, origin } },
     )
     const pluginCommandsA = pluginCommands.map(({ event }) => ({
@@ -47,15 +46,6 @@ const loadPlugin = async function(
     const errorA = addPluginLoadErrorStatus({ error, package, version, debug })
     throw errorA
   }
-}
-
-// Only core plugins can use `constants.BUILDBOT_SERVER_SOCKET` at the moment
-const cleanConstants = function({ BUILDBOT_SERVER_SOCKET, ...constants }, loadedFrom) {
-  if (loadedFrom !== 'core') {
-    return constants
-  }
-
-  return { ...constants, BUILDBOT_SERVER_SOCKET }
 }
 
 module.exports = { loadPlugins }


### PR DESCRIPTION
There are some arguments that we'd like to pass to some core plugins, but not to user plugins:
  - `constants.API_TOKEN` used to be meant only for the Edge handler core plugin
  - `constants.BUILDBOT_SERVER_SOCKET` is meant only for the core deploy plugin
  - an upcoming PR will pass the list of plugin events, which is meant only for the core deploy plugin

The core plugin-only information was previously computed at the wrong point in the codebase. It allowed up to cleanup core plugin-only `constants` but this was done too early to cleanup core plugin-only information like the list of plugin events.

This PR moves this logic in order to support that new use case.