### PR TITLE
Do not wait for post-processing for most builds

### DIFF
--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -5,7 +5,8 @@ const getCommands = function(pluginsCommands, netlifyConfig) {
   const commands = addBuildCommand(pluginsCommands, netlifyConfig)
   const commandsA = sortCommands(commands)
   const commandsCount = commandsA.filter(({ event }) => !runsOnlyOnBuildFailure(event)).length
-  return { commands: commandsA, commandsCount }
+  const events = getEvents(commandsA)
+  return { commands: commandsA, commandsCount, events }
 }
 
 // Merge `build.command` with plugin event handlers
@@ -25,6 +26,16 @@ const sortCommands = function(commands) {
   return EVENTS.flatMap(event => commands.filter(command => command.event === event))
 }
 
+// Retrieve list of unique events
+const getEvents = function(commands) {
+  const events = commands.map(getEvent)
+  return [...new Set(events)]
+}
+
+const getEvent = function({ event }) {
+  return event
+}
+
 const isAmongEvents = function(events, event) {
   return events.includes(event)
 }
@@ -40,4 +51,7 @@ const runsAlsoOnBuildFailure = isAmongEvents.bind(null, ['onError', 'onEnd'])
 // Check if the event is only triggered when the build fails
 const runsOnlyOnBuildFailure = isAmongEvents.bind(null, ['onError'])
 
-module.exports = { getCommands, isSoftFailEvent, runsAlsoOnBuildFailure, runsOnlyOnBuildFailure }
+// Check if the event is happening after deploy
+const runsAfterDeploy = isAmongEvents.bind(null, ['onSuccess', 'onEnd'])
+
+module.exports = { getCommands, isSoftFailEvent, runsAlsoOnBuildFailure, runsOnlyOnBuildFailure, runsAfterDeploy }

--- a/packages/build/src/commands/plugin.js
+++ b/packages/build/src/commands/plugin.js
@@ -14,6 +14,7 @@ const firePluginCommand = async function({
   origin,
   envChanges,
   commands,
+  events,
   error,
   logs,
 }) {
@@ -23,7 +24,7 @@ const firePluginCommand = async function({
     const { newEnvChanges, status } = await callChild(
       childProcess,
       'run',
-      { event, error, envChanges, loadedFrom },
+      { event, events, error, envChanges, loadedFrom },
       { plugin: { pluginPackageJson, package }, location: { event, package, loadedFrom, origin } },
     )
     const newStatus = getSuccessStatus(status, { commands, event, package })

--- a/packages/build/src/commands/run_command.js
+++ b/packages/build/src/commands/run_command.js
@@ -23,6 +23,7 @@ const runCommand = async function({
   childEnv,
   envChanges,
   commands,
+  events,
   mode,
   api,
   errorMonitor,
@@ -58,6 +59,7 @@ const runCommand = async function({
     childEnv,
     envChanges,
     commands,
+    events,
     error,
     logs,
     timers,
@@ -146,6 +148,7 @@ const tFireCommand = function({
   childEnv,
   envChanges,
   commands,
+  events,
   error,
   logs,
 }) {
@@ -171,6 +174,7 @@ const tFireCommand = function({
     origin,
     envChanges,
     commands,
+    events,
     error,
     logs,
   })

--- a/packages/build/src/commands/run_commands.js
+++ b/packages/build/src/commands/run_commands.js
@@ -12,6 +12,7 @@ const { runCommand } = require('./run_command')
 // Runs `onEnd` events at the end, whether an error was thrown or not.
 const runCommands = async function({
   commands,
+  events,
   configPath,
   buildDir,
   nodePath,
@@ -56,6 +57,7 @@ const runCommands = async function({
         childEnv,
         envChanges,
         commands,
+        events,
         mode,
         api,
         errorMonitor,

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -389,7 +389,7 @@ const runBuild = async function({
     featureFlags,
   })
 
-  const { commands, commandsCount } = getCommands(pluginsCommands, netlifyConfig)
+  const { commands, commandsCount, events } = getCommands(pluginsCommands, netlifyConfig)
 
   if (dry) {
     doDryRun({ commands, commandsCount, logs })
@@ -398,6 +398,7 @@ const runBuild = async function({
 
   const { commandsCount: commandsCountA, statuses, timers: timersB } = await runCommands({
     commands,
+    events,
     configPath,
     buildDir,
     nodePath,

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -4,14 +4,14 @@ const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
 const run = async function(
-  { event, error, envChanges, loadedFrom },
+  { event, events, error, envChanges, loadedFrom },
   { pluginCommands, constants, inputs, netlifyConfig, featureFlags },
 ) {
   const { method } = pluginCommands.find(pluginCommand => pluginCommand.event === event)
   const runState = {}
   const utils = getUtils({ event, constants, runState, featureFlags })
-  const runOptions = { utils, constants, inputs, netlifyConfig, error }
 
+  const runOptions = { utils, constants, inputs, netlifyConfig, error, events }
   const runOptionsA = cleanRunOptions({ loadedFrom, runOptions })
 
   const envBefore = setEnvChanges(envChanges)
@@ -25,6 +25,7 @@ const cleanRunOptions = function({
   loadedFrom,
   runOptions: {
     constants: { BUILDBOT_SERVER_SOCKET, ...constants },
+    events,
     ...runOptions
   },
 }) {
@@ -32,7 +33,7 @@ const cleanRunOptions = function({
     return { ...runOptions, constants }
   }
 
-  return { ...runOptions, constants: { ...constants, BUILDBOT_SERVER_SOCKET } }
+  return { ...runOptions, constants: { ...constants, BUILDBOT_SERVER_SOCKET }, events }
 }
 
 module.exports = { run }

--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -7,11 +7,11 @@ const {
   deploySiteWithBuildbotClient,
 } = require('./buildbot_client')
 
-const onPostBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET, BUILDBOT_SERVER_SOCKET_TIMEOUT } }) {
+const onPostBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET, BUILDBOT_SERVER_SOCKET_TIMEOUT }, events }) {
   const client = createBuildbotClient({ BUILDBOT_SERVER_SOCKET, BUILDBOT_SERVER_SOCKET_TIMEOUT })
   try {
     await connectBuildbotClient(client)
-    await deploySiteWithBuildbotClient(client)
+    await deploySiteWithBuildbotClient({ client, events })
     logDeploySuccess()
   } finally {
     await closeBuildbotClient(client)

--- a/packages/build/tests/plugins/fixtures/end/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/end/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/end/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/end/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin.js"

--- a/packages/build/tests/plugins/fixtures/end/plugin.js
+++ b/packages/build/tests/plugins/fixtures/end/plugin.js
@@ -1,0 +1,5 @@
+module.exports = {
+  onEnd() {
+    console.log('onEnd')
+  },
+}

--- a/packages/build/tests/plugins/fixtures/success/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/success/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/success/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/success/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin.js"

--- a/packages/build/tests/plugins/fixtures/success/plugin.js
+++ b/packages/build/tests/plugins/fixtures/success/plugin.js
@@ -1,0 +1,5 @@
+module.exports = {
+  onSuccess() {
+    console.log('onSuccess')
+  },
+}


### PR DESCRIPTION
Builds that use `onSuccess` and `onEnd` needs to wait for post-processing to end, which can take time.
Until we figure out whether this is something we want or not, this PR disables waiting for post-processing if the build does not use any of those events. It does it by sending a different action to the buildbot, which then uses it to decide whether to wait on post-processing or not.

This PR includes 3 integration tests.