### PR TITLE
Fix lingering processes warning

### DIFF
--- a/packages/build/src/core/lingering.js
+++ b/packages/build/src/core/lingering.js
@@ -12,7 +12,7 @@ const warnOnLingeringProcesses = async function({ mode, logs, testOpts: { silent
   const {
     stdout: processList,
   } = await execa(
-    'ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/opt/build-bin/buildbot" | grep -v [d]efunct | grep -vw \'[build]\' | grep -v "@netlify/build"',
+    'ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/opt/build-bin/buildbot" | grep -v [d]efunct | grep -vw \'[build]\' | grep -v "@netlify/build" | grep -v "gatsby-telemetry" | grep -v "jest-worker"',
     { shell: 'bash' },
   )
 


### PR DESCRIPTION
Fixes #1896.

This does not report the lingering processes from Gatsby telemetry and Jest workers.