### PR TITLE
Lint Lodash and Underscore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
     "plugin:node/recommended",
     "prettier",
     "plugin:eslint-comments/recommended",
-    "plugin:fp/recommended"
+    "plugin:fp/recommended",
+    "plugin:you-dont-need-lodash-underscore/all"
   ],
   "reportUnusedDisableDirectives": true,
   "rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5503,6 +5503,15 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-you-dont-need-lodash-underscore": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.10.0.tgz",
+      "integrity": "sha512-Zu1KbHiWKf+alVvT+kFX2M5HW1gmtnkfF1l2cjmFozMnG0gbGgXo8oqK7lwk+ygeOXDmVfOyijqBd7SUub9AEQ==",
+      "dev": true,
+      "requires": {
+        "kebab-case": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -7712,6 +7721,12 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "kebab-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
+      "integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes=",
+      "dev": true
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",
     "husky": "^4.2.3",
     "lerna": "^3.20.2",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Using Node `8.3.0`, many common utilities provided by Lodash or Underscore can now be done with vanilla JavaScript with the same expressiveness. In those cases, using vanilla JavaScript is better than introducing an additional utility, as it is faster, easier to debug and clearer.

This PR adds an ESLint plugin that lints against those patterns. It does not prevent using those libraries, it just prevents using them in cases they are not needed.