### PR TITLE
Remove unnecessary `return` statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
   "rules": {
     "no-console": 0,
     "no-unused-vars": 2,
+    "no-empty": [2, { "allowEmptyCatch": true }],
     "import/order": [
       2,
       {

--- a/packages/build/src/env/git.js
+++ b/packages/build/src/env/git.js
@@ -19,9 +19,7 @@ const git = async function(args, cwd) {
   try {
     const { stdout } = await execa('git', args, { cwd })
     return stdout
-  } catch (error) {
-    return
-  }
+  } catch (error) {}
 }
 
 module.exports = { getGitEnv }

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -104,7 +104,6 @@ const reportError = async function({ errorMonitor, error, logs, testOpts, eventP
     // Failsafe
   } catch (error) {
     log(logs, `Error monitor could not notify\n${error.stack}`)
-    return
   }
 }
 

--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -34,7 +34,6 @@ const startErrorMonitor = function({ flags: { mode }, logs, bugsnagKey }) {
     // Failsafe
   } catch (error) {
     log(logs, `Error monitor could not start\n${error.stack}`)
-    return
   }
 }
 

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -99,9 +99,7 @@ const tryBuildImagePath = async function({ package, buildDir, buildImagePluginsD
 const tryResolvePath = async function(package, baseDir) {
   try {
     return await resolvePath(package, baseDir)
-  } catch (error) {
-    return
-  }
+  } catch (error) {}
 }
 
 // Handle plugins that were neither local, in the build image cache nor in

--- a/packages/build/src/telemetry/track.js
+++ b/packages/build/src/telemetry/track.js
@@ -20,9 +20,7 @@ const track = async function({ payload, testOpts: { telemetryOrigin = '' } = {} 
     }
 
     await childProcess
-  } catch (error) {
-    return
-  }
+  } catch (error) {}
 }
 
 module.exports = { track }

--- a/packages/build/tests/helpers/dir.js
+++ b/packages/build/tests/helpers/dir.js
@@ -30,7 +30,6 @@ const createGit = async function(cwd, git) {
 const removeDir = async function(dir) {
   try {
     await del(dir, { force: true })
-    // eslint-disable-next-line no-empty
   } catch (error) {}
 }
 

--- a/packages/cache-utils/src/fs.js
+++ b/packages/cache-utils/src/fs.js
@@ -57,9 +57,7 @@ const getSrcGlob = async function(src) {
 const getStat = async function(src) {
   try {
     return await pStat(src)
-  } catch (error) {
-    return
-  }
+  } catch (error) {}
 }
 
 module.exports = { moveCacheFile, hasFiles }

--- a/packages/config/src/options/branch.js
+++ b/packages/config/src/options/branch.js
@@ -22,9 +22,7 @@ const getGitBranch = async function(repositoryRoot) {
   try {
     const { stdout } = await execa.command('git rev-parse --abbrev-ref HEAD', { cwd: repositoryRoot })
     return stdout
-  } catch (error) {
-    return
-  }
+  } catch (error) {}
 }
 
 const FALLBACK_BRANCH = 'master'


### PR DESCRIPTION
This removes some unnecessary `return` statements. 
In order to do it, this also fixes the `no-empty` ESLint rule.