### PR TITLE
Fix publish directory bug with the deploy core plugin

### DIFF
--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -2,6 +2,7 @@ const net = require('net')
 const { promisify } = require('util')
 
 const pEvent = require('p-event')
+const { isDirectory } = require('path-type')
 
 const { runsAfterDeploy } = require('../../commands/get')
 const { addAsyncErrorMessage } = require('../../utils/errors')
@@ -52,7 +53,11 @@ const getNextParsedResponsePromise = addAsyncErrorMessage(
   'Invalid response from buildbot',
 )
 
-const deploySiteWithBuildbotClient = async function({ client, events }) {
+const deploySiteWithBuildbotClient = async function({ client, events, PUBLISH_DIR, failBuild }) {
+  if (!(await isDirectory(PUBLISH_DIR))) {
+    return failBuild(`Publish directory does not exist: ${PUBLISH_DIR}`)
+  }
+
   const action = shouldWaitForPostProcessing(events) ? 'deploySiteAndAwaitLive' : 'deploySite'
   const payload = { action }
   const [response] = await Promise.all([getNextParsedResponsePromise(client), writePayload(client, payload)])

--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -7,11 +7,17 @@ const {
   deploySiteWithBuildbotClient,
 } = require('./buildbot_client')
 
-const onPostBuild = async function({ constants: { BUILDBOT_SERVER_SOCKET }, events }) {
+const onPostBuild = async function({
+  constants: { BUILDBOT_SERVER_SOCKET, PUBLISH_DIR },
+  events,
+  utils: {
+    build: { failBuild },
+  },
+}) {
   const client = createBuildbotClient(BUILDBOT_SERVER_SOCKET)
   try {
     await connectBuildbotClient(client)
-    await deploySiteWithBuildbotClient({ client, events })
+    await deploySiteWithBuildbotClient({ client, events, PUBLISH_DIR, failBuild })
     logDeploySuccess()
   } finally {
     await closeBuildbotClient(client)

--- a/packages/build/tests/plugins/fixtures/invalid_publish/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/invalid_publish/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+publish = "does-not-exist"

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -294,6 +294,20 @@ test('Deploy plugin waits for post-processing if using onEnd', async t => {
   t.true(requests.every(waitsForPostProcessing))
 })
 
+test('Deploy plugin when publish directory does not exist', async t => {
+  const { address, stopServer } = await startDeployServer()
+  try {
+    const { exitCode, returnValue } = await runFixture(t, 'invalid_publish', {
+      flags: { buildbotServerSocket: address, featureFlags: 'triggerDeploy' },
+      snapshot: false,
+    })
+    t.not(exitCode, 0)
+    t.true(returnValue.includes('Publish directory does not exist'))
+  } finally {
+    await stopServer()
+  }
+})
+
 const startDeployServer = function(opts = {}) {
   const useUnixSocket = platform !== 'win32'
   return startTcpServer({ useUnixSocket, response: { succeeded: true, ...opts.response }, ...opts })


### PR DESCRIPTION
Fixes #1912.

When publishing a site and the publish directory does not exist, this prints a user error message, as opposed to a system error.

@Benaiah @vbrown608, could you please confirm that, when a publish directory does not exist while publishing a site, this is always an error?