### PR TITLE
Do not show the `buildbotServerSocket` CLI flag in production

### DIFF
--- a/packages/build/src/log/messages/config.js
+++ b/packages/build/src/log/messages/config.js
@@ -24,6 +24,7 @@ const INTERNAL_FLAGS = [
   'statsd',
   'framework',
   'featureFlags',
+  'buildbotServerSocket',
 ]
 const HIDDEN_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, ...INTERNAL_FLAGS]
 const HIDDEN_DEBUG_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS]


### PR DESCRIPTION
The `buildbotServerSocket` CLI flag should not be printed in build logs, it is internal only.