### PR TITLE
Lint Ava test files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "prettier/standard",
     "plugin:eslint-comments/recommended",
     "plugin:fp/recommended",
+    "plugin:ava/recommended",
     "plugin:you-dont-need-lodash-underscore/all"
   ],
   "reportUnusedDisableDirectives": true,
@@ -82,7 +83,10 @@
           { "object": "process", "property": "exitCode" }
         ]
       }
-    ]
+    ],
+    "ava/no-ignored-test-files": [2, { "files": ["tests/**/*.js", "!tests/{helpers,fixtures}/**/*.{js,json}"] }],
+    "ava/no-import-test-files": [2, { "files": ["tests/**/*.js", "!tests/{helpers,fixtures}/**/*.{js,json}"] }],
+    "ava/no-skip-test": 0
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3240,6 +3240,12 @@
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
+    "buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -4472,6 +4478,16 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+      "dev": true,
+      "requires": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      }
+    },
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
@@ -4670,6 +4686,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deep-strict-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
+      "dev": true,
+      "requires": {
+        "core-assert": "^0.2.0"
+      }
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -4987,6 +5012,15 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enhance-visitors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+      "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.13.1"
       }
     },
     "entities": {
@@ -5321,6 +5355,51 @@
           "requires": {
             "find-up": "^2.1.0"
           }
+        }
+      }
+    },
+    "eslint-plugin-ava": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-11.0.0.tgz",
+      "integrity": "sha512-UMGedfl/gIKx1tzjGtAsTSJgowyAEZU2VWmpoWXYcuuV4B2H4Cu90yuMgMPEVt1mQlIZ21L7YM2CSpHUFJo/LQ==",
+      "dev": true,
+      "requires": {
+        "deep-strict-equal": "^0.2.0",
+        "enhance-visitors": "^1.0.0",
+        "eslint-utils": "^2.1.0",
+        "espree": "^7.2.0",
+        "espurify": "^2.0.1",
+        "import-modules": "^2.0.0",
+        "micro-spelling-correcter": "^1.1.1",
+        "pkg-dir": "^4.2.0",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "espree": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+          "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.3.0"
+          }
+        },
+        "espurify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/espurify/-/espurify-2.0.1.tgz",
+          "integrity": "sha512-7w/dUrReI/QbJFHRwfomTlkQOXaB1NuCrBRn5Y26HXn5gvh18/19AgLbayVrNxXQfkckvgrJloWyvZDuJ7dhEA==",
+          "dev": true
         }
       }
     },
@@ -7118,6 +7197,12 @@
         "resolve-cwd": "^3.0.0"
       }
     },
+    "import-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.0.0.tgz",
+      "integrity": "sha512-iczM/v9drffdNnABOKwj0f9G3cFDon99VcG1mxeBsdqnbd+vnQ5c2uAiCHNQITqFTOPaEvwg3VjoWCur0uHLEw==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -8330,6 +8415,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micro-spelling-correcter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+      "integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
       "dev": true
     },
     "micromatch": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-ava": "^11.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-html": "^6.1.0",

--- a/packages/build/tests/README.md
+++ b/packages/build/tests/README.md
@@ -57,6 +57,8 @@ On the other hand, it has the following upsides:
 
 Every test follows this template:
 
+<!-- eslint-disable-next-line ava/no-ignored-test-files -->
+
 ```js
 const test = require('ava')
 

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -3,9 +3,7 @@ require('log-process-errors/build/register/ava')
 const { normalize } = require('path')
 const { env } = require('process')
 
-const {
-  meta: { file: testFile },
-} = require('ava')
+const test = require('ava')
 const { magentaBright } = require('chalk')
 const cpy = require('cpy')
 const execa = require('execa')
@@ -15,6 +13,7 @@ const { createRepoDir, removeDir } = require('./dir')
 const { normalizeOutput } = require('./normalize')
 const { startServer } = require('./server')
 
+const testFile = test.meta.file
 const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
 
 // Run a CLI using a fixture directory, then snapshot the output.

--- a/packages/build/tests/plugins/fixtures/handlers_simple/edge-handlers/test.js
+++ b/packages/build/tests/plugins/fixtures/handlers_simple/edge-handlers/test.js
@@ -1,5 +1,6 @@
 import isPlainObj from 'is-plain-obj'
 
+// eslint-disable-next-line ava/no-import-test-files
 import data from './data.json'
 
 export function onRequest(event) {

--- a/packages/config/tests/cli/tests.js
+++ b/packages/config/tests/cli/tests.js
@@ -39,7 +39,7 @@ test('Does not stabilitize output without the --stable flag', async t => {
 
 // This test is too slow in local development
 if (isCI) {
-  test.only('Handles big outputs', async t => {
+  test('Handles big outputs', async t => {
     const bigNetlify = `${FIXTURES_DIR}/big/netlify.toml`
     await del(bigNetlify, { force: true })
     try {


### PR DESCRIPTION
This adds [`eslint-plugin-ava`](https://github.com/avajs/eslint-plugin-ava) to lint our Ava test files.

What do you think @erezrokah?