### PR TITLE
Fix `no-unused-vars` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
   "reportUnusedDisableDirectives": true,
   "rules": {
     "no-console": 0,
-    "no-unused-vars": 2,
+    "no-unused-vars": [2, {}],
     "no-empty": [2, { "allowEmptyCatch": true }],
     "import/order": [
       2,


### PR DESCRIPTION
This fixes the `no-unused-vars` ESLint rule so it warns against unused arguments. I am not quite sure why this requires this empty object, but it does :)