### PR TITLE
Use `Set.has()` instead of `Array.includes()`

### DIFF
--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -41,10 +41,10 @@ be used instead of the CLI flag --dry.`
 
 // Remove `yargs`-specific options, shortcuts, dash-cased and aliases
 const isUserFlag = function(key, value) {
-  return value !== undefined && !INTERNAL_KEYS.includes(key) && key.length !== 1 && !key.includes('-')
+  return value !== undefined && !INTERNAL_KEYS.has(key) && key.length !== 1 && !key.includes('-')
 }
 
-const INTERNAL_KEYS = ['help', 'version', '_', '$0', 'dryRun']
+const INTERNAL_KEYS = new Set(['help', 'version', '_', '$0', 'dryRun'])
 
 // Used mostly for testing
 const printLogs = function(logs) {

--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -93,7 +93,7 @@ const DEFAULT_EDGE_HANDLERS_SRC = 'edge-handlers'
 // Instead of passing absolute paths, we pass paths relative to `buildDir`, so
 // that logs are less verbose.
 const normalizePath = function(path, buildDir, key) {
-  if (path === undefined || !CONSTANT_PATHS.includes(key)) {
+  if (path === undefined || !CONSTANT_PATHS.has(key)) {
     return path
   }
 
@@ -106,13 +106,13 @@ const normalizePath = function(path, buildDir, key) {
   return pathA
 }
 
-const CONSTANT_PATHS = [
+const CONSTANT_PATHS = new Set([
   'CONFIG_PATH',
   'PUBLISH_DIR',
   'FUNCTIONS_SRC',
   'FUNCTIONS_DIST',
   'EDGE_HANDLERS_SRC',
   'CACHE_DIR',
-]
+])
 
 module.exports = { getConstants }

--- a/packages/build/src/env/main.js
+++ b/packages/build/src/env/main.js
@@ -36,10 +36,10 @@ const getParentEnv = function(envOpt) {
 }
 
 const shouldKeepEnv = function(key) {
-  return !REMOVED_PARENT_ENV.includes(key.toLowerCase())
+  return !REMOVED_PARENT_ENV.has(key.toLowerCase())
 }
 
-const REMOVED_PARENT_ENV = ['bugsnag_key']
+const REMOVED_PARENT_ENV = new Set(['bugsnag_key'])
 
 // Environment variables that can be unset by local ones or configuration ones
 const getDefaultEnv = function() {

--- a/packages/build/src/env/metadata.js
+++ b/packages/build/src/env/metadata.js
@@ -8,11 +8,11 @@ const getEnvMetadata = function(childEnv = env) {
 }
 
 const isEnvMetadata = function(name) {
-  return ENVIRONMENT_VARIABLES.includes(name)
+  return ENVIRONMENT_VARIABLES.has(name)
 }
 
 // This is sorted by most useful in debugging to least
-const ENVIRONMENT_VARIABLES = [
+const ENVIRONMENT_VARIABLES = new Set([
   // URL and IDs
   'BUILD_ID',
   'DEPLOY_ID',
@@ -78,6 +78,6 @@ const ENVIRONMENT_VARIABLES = [
   // Git LFS
   'GIT_LFS_ENABLED',
   'GIT_LFS_FETCH_INCLUDE',
-]
+])
 
 module.exports = { getEnvMetadata }

--- a/packages/build/src/plugins/manifest/validate.js
+++ b/packages/build/src/plugins/manifest/validate.js
@@ -25,13 +25,13 @@ const validateBasic = function(manifest) {
 }
 
 const validateUnknownProps = function(manifest) {
-  const unknownProp = Object.keys(manifest).find(key => !VALID_PROPS.includes(key))
+  const unknownProp = Object.keys(manifest).find(key => !VALID_PROPS.has(key))
   if (unknownProp !== undefined) {
     throw new Error(`unknown property "${unknownProp}"`)
   }
 }
 
-const VALID_PROPS = ['name', 'inputs']
+const VALID_PROPS = new Set(['name', 'inputs'])
 
 const validateName = function({ name }) {
   if (name === undefined) {
@@ -73,13 +73,13 @@ Input at position ${index} ${error.message}.`
 }
 
 const validateUnknownInputProps = function(input) {
-  const unknownProp = Object.keys(input).find(key => !VALID_INPUT_PROPS.includes(key))
+  const unknownProp = Object.keys(input).find(key => !VALID_INPUT_PROPS.has(key))
   if (unknownProp !== undefined) {
     throw new Error(`has an unknown property "${unknownProp}"`)
   }
 }
 
-const VALID_INPUT_PROPS = ['name', 'description', 'required', 'default']
+const VALID_INPUT_PROPS = new Set(['name', 'description', 'required', 'default'])
 
 const validateInputName = function({ name }) {
   if (name === undefined) {

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -11,13 +11,13 @@ const FUNCTIONS_PLUGIN_NAME = '@netlify/plugin-functions-core'
 const FUNCTIONS_INSTALL_PLUGIN_NAME = '@netlify/plugin-functions-install-core'
 const EDGE_HANDLERS_PLUGIN_NAME = '@netlify/plugin-edge-handlers'
 const DEPLOY_PLUGIN_NAME = '@netlify/plugin-deploy-core'
-const CORE_PLUGINS = [
+const CORE_PLUGINS = new Set([
   FUNCTIONS_PLUGIN_NAME,
   FUNCTIONS_INSTALL_PLUGIN_NAME,
   LOCAL_INSTALL_PLUGIN_NAME,
   EDGE_HANDLERS_PLUGIN_NAME,
   DEPLOY_PLUGIN_NAME,
-]
+])
 
 const EDGE_HANDLERS_PLUGIN_PATH = require.resolve(EDGE_HANDLERS_PLUGIN_NAME)
 
@@ -80,7 +80,7 @@ const getDeployPlugin = function(featureFlags, BUILDBOT_SERVER_SOCKET) {
 }
 
 const isCorePlugin = function(packageName) {
-  return CORE_PLUGINS.includes(packageName)
+  return CORE_PLUGINS.has(packageName)
 }
 
 module.exports = { getCorePlugins, isCorePlugin }

--- a/packages/config/src/bin/flags.js
+++ b/packages/config/src/bin/flags.js
@@ -112,9 +112,9 @@ The result is printed as a JSON object on stdout with the following properties:
 
 // Remove `yargs`-specific options, shortcuts, dash-cased and aliases
 const isUserFlag = function(key, value) {
-  return value !== undefined && !INTERNAL_KEYS.includes(key) && key.length !== 1 && !key.includes('-')
+  return value !== undefined && !INTERNAL_KEYS.has(key) && key.length !== 1 && !key.includes('-')
 }
 
-const INTERNAL_KEYS = ['help', 'version', '_', '$0']
+const INTERNAL_KEYS = new Set(['help', 'version', '_', '$0'])
 
 module.exports = { parseFlags }

--- a/packages/config/src/log/cleanup.js
+++ b/packages/config/src/log/cleanup.js
@@ -40,12 +40,12 @@ const cleanupConfig = function({
 }
 
 const cleanupEnvironment = function(environment) {
-  return Object.keys(environment).filter(key => !BUILDBOT_ENVIRONMENT.includes(key))
+  return Object.keys(environment).filter(key => !BUILDBOT_ENVIRONMENT.has(key))
 }
 
 // Added by the buildbot. We only want to print environment variables specified
 // by the user.
-const BUILDBOT_ENVIRONMENT = [
+const BUILDBOT_ENVIRONMENT = new Set([
   'BRANCH',
   'CONTEXT',
   'DEPLOY_PRIME_URL',
@@ -55,7 +55,7 @@ const BUILDBOT_ENVIRONMENT = [
   'SITE_ID',
   'SITE_NAME',
   'URL',
-]
+])
 
 const cleanupPlugin = function({ package: packageName, origin, inputs = {} }) {
   const inputsA = filterObj(inputs, isPublicInput)


### PR DESCRIPTION
Related to #1936.

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`prefer-set-has`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-set-has.md).