### PR TITLE
Use `Array.isArray()`

### DIFF
--- a/packages/build/src/error/parse/normalize.js
+++ b/packages/build/src/error/parse/normalize.js
@@ -1,6 +1,6 @@
 // Ensure error is an `Error` instance
 const normalizeError = function(error) {
-  if (error instanceof Array) {
+  if (Array.isArray(error)) {
     return normalizeArray(error)
   }
 


### PR DESCRIPTION
Related to #1936.

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`no-array-instanceof`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-array-instanceof.md).