### PR TITLE
Use consistent case in \u escapes

### DIFF
--- a/packages/build/src/log/logger.js
+++ b/packages/build/src/log/logger.js
@@ -38,7 +38,7 @@ const INDENT_SIZE = 2
 // We need to add a zero width space character in empty lines. Otherwise the
 // buildbot removes those due to a bug: https://github.com/netlify/buildbot/issues/595
 const EMPTY_LINES_REGEXP = /^\s*$/gm
-const EMPTY_LINE = '\u{200b}'
+const EMPTY_LINE = '\u{200B}'
 
 const logError = function(logs, string, opts) {
   log(logs, string, { color: THEME.errorLine, ...opts })

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -14,7 +14,7 @@ const replaceOutput = function(output, [regExp, replacement]) {
 const NORMALIZE_REGEXPS = [
   // Zero width space characters due to a bug in buildbot:
   // https://github.com/netlify/buildbot/issues/595
-  [/\u{200b}/gu, ''],
+  [/\u{200B}/gu, ''],
   // Windows specifics
   [/\r\n/gu, '\n'],
   [/\\/gu, '/'],

--- a/packages/config/src/log/logger.js
+++ b/packages/config/src/log/logger.js
@@ -31,7 +31,7 @@ const log = function(logs, string) {
 // We need to add a zero width space character in empty lines. Otherwise the
 // buildbot removes those due to a bug: https://github.com/netlify/buildbot/issues/595
 const EMPTY_LINES_REGEXP = /^\s*$/gm
-const EMPTY_LINE = '\u{200b}'
+const EMPTY_LINE = '\u{200B}'
 
 const logObject = function(logs, object) {
   const string = serializeObject(object)


### PR DESCRIPTION
Related to #1936.

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`escape-case`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/escape-case.md).