### PR TITLE
Small file path linting error

### DIFF
--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -4,7 +4,7 @@ const { env } = require('process')
 const { getBinPath } = require('get-bin-path')
 const pathKey = require('path-key')
 
-const netlifyBuild = require('../../')
+const netlifyBuild = require('../..')
 
 const { runFixtureCommon, FIXTURES_DIR } = require('./common')
 


### PR DESCRIPTION
Related to #1936.

This fixes a linting error from `eslint-plugin-unicorn`.