### PR TITLE
Fix `Array.length` linting error

### DIFF
--- a/packages/git-utils/README.md
+++ b/packages/git-utils/README.md
@@ -14,7 +14,7 @@ module.exports = {
     const { git } = utils
 
     /* Do stuff if files modified */
-    if (git.modifiedFiles.length) {
+    if (git.modifiedFiles.length !== 0) {
       console.log('Modified files:', git.modifiedFiles)
     }
 


### PR DESCRIPTION
Related to #1936.

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`explicit-length-check`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/explicit-length-check.md).