### PR TITLE
Fix `statsd` test

### DIFF
--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -48,6 +48,7 @@ const closeClient = async function(client) {
   // statsd-clent does not provide with a way of knowing when the socket is done
   // closing, so we need to use the following hack.
   await pSetTimeout(CLOSE_TIMEOUT)
+  await pSetTimeout(CLOSE_TIMEOUT)
 }
 
 // See https://github.com/msiebuhr/node-statsd-client/blob/45a93ee4c94ca72f244a40b06cb542d4bd7c3766/lib/EphemeralSocket.js#L81


### PR DESCRIPTION
The statsd test is randomly failing.
This seems to be due to the statsd library we are using. That library buffers packets to be sent. When closing the connection, it does not provide with a callback/promise/event to know when the buffer is flushed. Therefore, we need to use an unconditional timeout. Adding a second `pTimeout()` seems to fix it, by making sure the microtask created by the library's underlying `setTimeout()` is set first.