### PR TITLE
Lint `process` variable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,8 @@ module.exports = {
     'max-nested-callbacks': [2, 2],
     'require-await': 2,
 
+    'node/prefer-global/process': [2, 'never'],
+
     'eslint-comments/no-unused-disable': 0,
     'eslint-comments/no-use': [
       2,

--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -1,3 +1,4 @@
+const process = require('process')
 const { promisify } = require('util')
 
 const pEvent = require('p-event')

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -1,4 +1,4 @@
-const { platform, execPath } = require('process')
+const { platform, execPath, kill } = require('process')
 
 const test = require('ava')
 const getNode = require('get-node')
@@ -238,7 +238,7 @@ if (platform !== 'win32') {
 
     // Cleanup the lingering process
     const [, pid] = PID_LINE_REGEXP.exec(returnValue)
-    process.kill(pid)
+    kill(pid)
 
     t.true(returnValue.includes('There are some lingering processes'))
     t.true(returnValue.includes('forever.js'))

--- a/packages/build/tests/env/fixtures/bugsnag_key/index.js
+++ b/packages/build/tests/env/fixtures/bugsnag_key/index.js
@@ -1,1 +1,3 @@
-console.log(process.env.BUGSNAG_KEY)
+const { env } = require('process')
+
+console.log(env.BUGSNAG_KEY)

--- a/packages/build/tests/env/fixtures/empty_string/index.js
+++ b/packages/build/tests/env/fixtures/empty_string/index.js
@@ -1,1 +1,3 @@
-console.log('Contains TEST environment variable', 'TEST' in process.env)
+const { env } = require('process')
+
+console.log('Contains TEST environment variable', 'TEST' in env)

--- a/packages/build/tests/error/fixtures/command_full_stack/command.js
+++ b/packages/build/tests/error/fixtures/command_full_stack/command.js
@@ -1,6 +1,8 @@
+const { exit } = require('process')
+
 const test = function() {
   console.log(new Error('test'))
-  process.exit(2)
+  exit(2)
 }
 
 test()

--- a/packages/build/tests/error/fixtures/early_exit/plugin.js
+++ b/packages/build/tests/error/fixtures/early_exit/plugin.js
@@ -1,6 +1,8 @@
+const { env, pid } = require('process')
+
 module.exports = {
   onPreBuild() {
-    process.env.TEST_PID = process.pid
+    env.TEST_PID = pid
   },
   onPostBuild() {},
 }

--- a/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
+++ b/packages/build/tests/error/fixtures/early_exit/plugin_slow.js
@@ -1,3 +1,4 @@
+const { env, kill } = require('process')
 const { promisify } = require('util')
 
 const processExists = require('process-exists')
@@ -6,12 +7,12 @@ const pSetTimeout = promisify(setTimeout)
 
 module.exports = {
   async onBuild() {
-    process.kill(process.env.TEST_PID)
+    kill(env.TEST_PID)
 
     // Signals are async, so we need to wait for the child process to exit
     // The while loop is required due to `await`
     // eslint-disable-next-line fp/no-loops
-    while (await processExists(process.env.TEST_PID)) {
+    while (await processExists(env.TEST_PID)) {
       await pSetTimeout(1e2)
     }
   },

--- a/packages/build/tests/error/fixtures/ipc/plugin.js
+++ b/packages/build/tests/error/fixtures/ipc/plugin.js
@@ -1,6 +1,8 @@
+const { exit } = require('process')
+
 module.exports = {
   onPreBuild() {
-    process.exit()
+    exit()
   },
   onBuild() {},
 }

--- a/packages/build/tests/error/fixtures/plugin_exit/plugin.js
+++ b/packages/build/tests/error/fixtures/plugin_exit/plugin.js
@@ -1,6 +1,8 @@
+const { exit } = require('process')
+
 module.exports = {
   onPreBuild() {
-    process.exit(1)
+    exit(1)
   },
   onBuild() {
     console.log('test')

--- a/packages/cache-utils/tests/dir.js
+++ b/packages/cache-utils/tests/dir.js
@@ -1,3 +1,5 @@
+const { cwd: getCwd, chdir } = require('process')
+
 const test = require('ava')
 const pathExists = require('path-exists')
 
@@ -7,8 +9,8 @@ const { pWriteFile, createTmpDir, removeFiles } = require('./helpers/main')
 
 test('Should allow not changing the cache directory', async t => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
-  const currentDir = process.cwd()
-  process.chdir(srcDir)
+  const currentDir = getCwd()
+  chdir(srcDir)
   try {
     const srcFile = `${srcDir}/test`
     await pWriteFile(srcFile, '')
@@ -17,7 +19,7 @@ test('Should allow not changing the cache directory', async t => {
     t.true(await cacheUtils.restore(srcFile))
     t.true(await pathExists(srcFile))
   } finally {
-    process.chdir(currentDir)
+    chdir(currentDir)
     await removeFiles([cacheDir, srcDir])
   }
 })

--- a/packages/cache-utils/tests/path.js
+++ b/packages/cache-utils/tests/path.js
@@ -1,4 +1,5 @@
 const { homedir } = require('os')
+const { platform } = require('process')
 
 const test = require('ava')
 const pathExists = require('path-exists')
@@ -28,7 +29,7 @@ test('Should not allow caching a direct parent directory', async t => {
 })
 
 // Windows does not allow deleting directory uses as current directory
-if (process.platform !== 'win32') {
+if (platform !== 'win32') {
   test('Should not allow invalid cwd with relative paths', async t => {
     const tmpDir = await createTmpDir()
     await removeFiles(tmpDir)

--- a/packages/git-utils/tests/main.js
+++ b/packages/git-utils/tests/main.js
@@ -1,3 +1,5 @@
+const { env, chdir, cwd: getCwd } = require('process')
+
 const test = require('ava')
 
 const getGitUtils = require('..')
@@ -49,22 +51,22 @@ test('Should error when the option "head" points to an unknown commit', t => {
 
 test.serial('Should allow using the environment variable CACHED_COMMIT_REF', t => {
   try {
-    process.env.CACHED_COMMIT_REF = BASE
+    env.CACHED_COMMIT_REF = BASE
     const { linesOfCode } = getGitUtils({ head: HEAD })
     t.is(linesOfCode, 163)
   } finally {
-    delete process.env.CACHED_COMMIT_REF
+    delete env.CACHED_COMMIT_REF
   }
 })
 
 test.serial('Should allow overriding the current directory', t => {
-  const currentCwd = process.cwd()
+  const currentCwd = getCwd()
   try {
-    process.chdir('/')
+    chdir('/')
     const { linesOfCode } = getGitUtils({ ...DEFAULT_OPTS, cwd: currentCwd })
     t.is(linesOfCode, 163)
   } finally {
-    process.chdir(currentCwd)
+    chdir(currentCwd)
   }
 })
 

--- a/packages/run-utils/src/main.js
+++ b/packages/run-utils/src/main.js
@@ -1,3 +1,5 @@
+const process = require('process')
+
 const execa = require('execa')
 
 // Run a command, with arguments being an array


### PR DESCRIPTION
This adds the `node/prefer-global/process` ESLint rule (see [rule documentation](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/process.md)).

This is useful to ensure we are consistent with how we access the `process` global variable.
This is also useful to require this in the top of the file since it is technically a dependency (albeit it is also available as a global variable).