### PR TITLE
Lint dynamic `require()` statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,8 @@ module.exports = {
     'max-nested-callbacks': [2, 2],
     'require-await': 2,
 
+    'node/global-require': 2,
+    'node/no-mixed-requires': 2,
     'node/prefer-global/process': [2, 'never'],
 
     'eslint-comments/no-unused-disable': 0,

--- a/packages/build/src/plugins/child/logic.js
+++ b/packages/build/src/plugins/child/logic.js
@@ -8,6 +8,7 @@ const getLogic = function({ pluginPath, inputs }) {
 
 const requireLogic = function(pluginPath) {
   try {
+    // eslint-disable-next-line node/global-require
     return require(pluginPath)
   } catch (error) {
     error.message = `Could not import plugin:\n${error.message}`

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -29,19 +29,23 @@ const getBuildUtils = function(event) {
 }
 
 const getGitUtils = function() {
+  // eslint-disable-next-line node/global-require
   return require('@netlify/git-utils')()
 }
 
 const getCacheUtils = function(CACHE_DIR) {
+  // eslint-disable-next-line node/global-require
   const cacheUtils = require('@netlify/cache-utils')
   return cacheUtils.bindOpts({ cacheDir: CACHE_DIR })
 }
 
 const getRunUtils = function() {
+  // eslint-disable-next-line node/global-require
   return require('@netlify/run-utils')
 }
 
 const getFunctionsUtils = function(FUNCTIONS_SRC) {
+  // eslint-disable-next-line node/global-require
   const functionsUtils = require('@netlify/functions-utils')
   const add = src => functionsUtils.add(src, FUNCTIONS_SRC, { fail: failBuild })
   const list = functionsUtils.list.bind(null, FUNCTIONS_SRC, { fail: failBuild })

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -135,6 +135,7 @@ const loadEdgeHandlerBundle = async function({ outputDir, manifestPath }) {
 }
 
 const getEdgeHandlerBundlePath = function({ outputDir, manifestPath }) {
+  // eslint-disable-next-line node/global-require
   const { sha } = require(manifestPath)
   return `${outputDir}/${sha}`
 }
@@ -142,6 +143,7 @@ const getEdgeHandlerBundlePath = function({ outputDir, manifestPath }) {
 const requireEdgeHandleBundle = function(bundlePath) {
   const set = spy()
   global.netlifyRegistry = { set }
+  // eslint-disable-next-line node/global-require
   require(bundlePath)
   delete global.netlifyRegistry
   return set.args.map(normalizeEdgeHandler)


### PR DESCRIPTION
This adds the [`node/global-require`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/global-require.md) and [`node/no-mixed-requires`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-mixed-requires.md) ESLint rules.

Dynamic `require()` statements should be avoided when possible.
There are some cases when those are useful though. In those cases, `// eslint-disable-next-line` can be used.