### PR TITLE
Only run linting on Node 14 in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,7 @@ jobs:
         run: npm install
       - name: Linting
         run: npm run format
+        if: ${{ matrix.node == 14 }}
       - name: Tests
         run: npm run test:ci
       - name: Codecov test coverage


### PR DESCRIPTION
Fixes #1962.
Also implemented in Netlify CLI at https://github.com/netlify/cli/pull/1387

This runs linting on Node 14 only in CI.