### PR TITLE
Upgrade Prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9882,9 +9882,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lerna": "^3.20.2",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.1.2"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/packages/build/src/commands/build_command.js
+++ b/packages/build/src/commands/build_command.js
@@ -8,7 +8,7 @@ const { logBuildCommandStart } = require('../log/messages/commands')
 const { getBuildCommandStdio, handleBuildCommandOutput } = require('../log/stream')
 
 // Fire `build.command`
-const fireBuildCommand = async function({
+const fireBuildCommand = async function ({
   buildCommand,
   buildCommandOrigin,
   configPath,

--- a/packages/build/src/commands/error.js
+++ b/packages/build/src/commands/error.js
@@ -13,7 +13,7 @@ const { isSoftFailEvent } = require('./get')
 //    stop, but are still reported, and prevent future events from the same
 //    plugin.
 // This also computes error statuses that are sent to the API.
-const handleCommandError = function({
+const handleCommandError = function ({
   event,
   newError,
   childEnv,
@@ -57,7 +57,7 @@ const handleCommandError = function({
 }
 
 // On `utils.build.failPlugin()` or during `onSuccess` or `onEnd`
-const handleFailPlugin = async function({
+const handleFailPlugin = async function ({
   fullErrorInfo,
   fullErrorInfo: {
     errorInfo: { location: { packageName } = {} },
@@ -77,20 +77,20 @@ const handleFailPlugin = async function({
 }
 
 // On `utils.build.cancelBuild()`
-const handleCancelBuild = async function({ fullErrorInfo, newError, api, deployId }) {
+const handleCancelBuild = async function ({ fullErrorInfo, newError, api, deployId }) {
   const newStatus = serializeErrorStatus({ fullErrorInfo, state: 'canceled_build' })
   await cancelBuild({ api, deployId })
   return { newError, newStatus }
 }
 
 // On `utils.build.failBuild()` or uncaught exception
-const handleFailBuild = function({ fullErrorInfo, newError }) {
+const handleFailBuild = function ({ fullErrorInfo, newError }) {
   const newStatus = serializeErrorStatus({ fullErrorInfo, state: 'failed_build' })
   return { newError, newStatus }
 }
 
 // Unlike community plugins, core plugin bugs should be handled as system errors
-const handlePluginError = function(error, loadedFrom) {
+const handlePluginError = function (error, loadedFrom) {
   if (!isCorePluginBug(error, loadedFrom)) {
     return
   }
@@ -98,7 +98,7 @@ const handlePluginError = function(error, loadedFrom) {
   addErrorInfo(error, { type: 'corePlugin' })
 }
 
-const isCorePluginBug = function(error, loadedFrom) {
+const isCorePluginBug = function (error, loadedFrom) {
   const { severity } = parseErrorInfo(error)
   return severity === 'warning' && loadedFrom === 'core'
 }

--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -1,7 +1,7 @@
 const { EVENTS } = require('../plugins/events')
 
 // Get commands for all events
-const getCommands = function(pluginsCommands, netlifyConfig) {
+const getCommands = function (pluginsCommands, netlifyConfig) {
   const commands = addBuildCommand(pluginsCommands, netlifyConfig)
   const commandsA = sortCommands(commands)
   const commandsCount = commandsA.filter(({ event }) => !runsOnlyOnBuildFailure(event)).length
@@ -10,7 +10,7 @@ const getCommands = function(pluginsCommands, netlifyConfig) {
 }
 
 // Merge `build.command` with plugin event handlers
-const addBuildCommand = function(
+const addBuildCommand = function (
   pluginsCommands,
   { build: { command: buildCommand, commandOrigin: buildCommandOrigin } },
 ) {
@@ -22,21 +22,21 @@ const addBuildCommand = function(
 }
 
 // Sort plugin commands by event order.
-const sortCommands = function(commands) {
-  return EVENTS.flatMap(event => commands.filter(command => command.event === event))
+const sortCommands = function (commands) {
+  return EVENTS.flatMap((event) => commands.filter((command) => command.event === event))
 }
 
 // Retrieve list of unique events
-const getEvents = function(commands) {
+const getEvents = function (commands) {
   const events = commands.map(getEvent)
   return [...new Set(events)]
 }
 
-const getEvent = function({ event }) {
+const getEvent = function ({ event }) {
   return event
 }
 
-const isAmongEvents = function(events, event) {
+const isAmongEvents = function (events, event) {
   return events.includes(event)
 }
 

--- a/packages/build/src/commands/plugin.js
+++ b/packages/build/src/commands/plugin.js
@@ -5,7 +5,7 @@ const { getSuccessStatus } = require('../status/success')
 const { handlePluginError } = require('./error')
 
 // Fire a plugin command
-const firePluginCommand = async function({
+const firePluginCommand = async function ({
   event,
   childProcess,
   packageName,

--- a/packages/build/src/commands/return.js
+++ b/packages/build/src/commands/return.js
@@ -4,7 +4,7 @@ const { logTimer } = require('../log/messages/core')
 const { handleCommandError } = require('./error')
 
 // Retrieve the return value of a build command or plugin event handler
-const getCommandReturn = function({
+const getCommandReturn = function ({
   event,
   packageName,
   newError,

--- a/packages/build/src/commands/run_command.js
+++ b/packages/build/src/commands/run_command.js
@@ -7,7 +7,7 @@ const { firePluginCommand } = require('./plugin')
 const { getCommandReturn } = require('./return')
 
 // Run a command (shell or plugin)
-const runCommand = async function({
+const runCommand = async function ({
   event,
   childProcess,
   packageName,
@@ -109,7 +109,7 @@ const runCommand = async function({
 // `onSuccess` is the opposite. It is triggered after the build succeeded.
 // `onEnd` is triggered after the build either failed or succeeded.
 // It is useful for resources cleanup.
-const shouldRunCommand = function({ event, packageName, error, failedPlugins }) {
+const shouldRunCommand = function ({ event, packageName, error, failedPlugins }) {
   if (failedPlugins.includes(packageName)) {
     return false
   }
@@ -122,7 +122,7 @@ const shouldRunCommand = function({ event, packageName, error, failedPlugins }) 
 }
 
 // Wrap command function to measure its time
-const getFireCommand = function({ packageName, event }) {
+const getFireCommand = function ({ packageName, event }) {
   if (packageName === undefined) {
     return measureDuration(tFireCommand, 'build_command')
   }
@@ -131,7 +131,7 @@ const getFireCommand = function({ packageName, event }) {
   return measureDuration(tFireCommand, event, { parentTag, category: 'pluginEvent' })
 }
 
-const tFireCommand = function({
+const tFireCommand = function ({
   event,
   childProcess,
   packageName,

--- a/packages/build/src/commands/run_commands.js
+++ b/packages/build/src/commands/run_commands.js
@@ -10,7 +10,7 @@ const { runCommand } = require('./run_command')
 // list of `failedPlugins` (that ran `utils.build.failPlugin()`).
 // If an error arises, runs `onError` events.
 // Runs `onEnd` events at the end, whether an error was thrown or not.
-const runCommands = async function({
+const runCommands = async function ({
   commands,
   events,
   configPath,

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -15,7 +15,7 @@ const build = require('./main')
 // programmatic command instead, so that the new logic is available when run
 // programmatically as well. This file should only contain logic that makes
 // sense only in CLI, such as CLI flags parsing and exit code.
-const runCli = async function() {
+const runCli = async function () {
   const flags = parseFlags()
   const flagsA = filterObj(flags, isUserFlag)
 
@@ -24,11 +24,8 @@ const runCli = async function() {
   process.exitCode = severityCode
 }
 
-const parseFlags = function() {
-  return yargs
-    .options(FLAGS)
-    .usage(USAGE)
-    .parse()
+const parseFlags = function () {
+  return yargs.options(FLAGS).usage(USAGE).parse()
 }
 
 const USAGE = `netlify-build [OPTIONS...]
@@ -40,14 +37,14 @@ NETLIFY_BUILD_. For example the environment variable NETLIFY_BUILD_DRY=true can
 be used instead of the CLI flag --dry.`
 
 // Remove `yargs`-specific options, shortcuts, dash-cased and aliases
-const isUserFlag = function(key, value) {
+const isUserFlag = function (key, value) {
   return value !== undefined && !INTERNAL_KEYS.has(key) && key.length !== 1 && !key.includes('-')
 }
 
 const INTERNAL_KEYS = new Set(['help', 'version', '_', '$0', 'dryRun'])
 
 // Used mostly for testing
-const printLogs = function(logs) {
+const printLogs = function (logs) {
   if (logs === undefined) {
     return
   }

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -7,7 +7,7 @@ const { logBuildDir, logConfigPath, logConfig, logContext } = require('../log/me
 const { measureDuration } = require('../time/main')
 
 // Retrieve configuration object
-const tLoadConfig = async function({
+const tLoadConfig = async function ({
   config,
   defaultConfig,
   cachedConfig,
@@ -69,7 +69,7 @@ const loadConfig = measureDuration(tLoadConfig, 'resolve_config')
 
 // Retrieve configuration file and related information
 // (path, build directory, etc.)
-const resolveFullConfig = async function({
+const resolveFullConfig = async function ({
   config,
   defaultConfig,
   cachedConfig,
@@ -111,7 +111,7 @@ const resolveFullConfig = async function({
   }
 }
 
-const logConfigInfo = function({ logs, configPath, buildDir, netlifyConfig, context, debug }) {
+const logConfigInfo = function ({ logs, configPath, buildDir, netlifyConfig, context, debug }) {
   logBuildDir(logs, buildDir)
   logConfigPath(logs, configPath)
   logConfig({ logs, netlifyConfig, debug })

--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -7,7 +7,7 @@ const { isDirectory } = require('path-type')
 const { version } = require('../../package.json')
 
 // Retrieve constants passed to plugins
-const getConstants = async function({
+const getConstants = async function ({
   configPath,
   buildDir,
   functionsDistDir,
@@ -77,7 +77,7 @@ const getConstants = async function({
 
 // The default `edge-handlers` is only set to `constants.EDGE_HANDLERS_SRC` if
 // that directory exists
-const getEdgeHandlersSrc = async function(edgeHandlers, buildDir) {
+const getEdgeHandlersSrc = async function (edgeHandlers, buildDir) {
   if (edgeHandlers !== undefined) {
     return edgeHandlers
   }
@@ -92,7 +92,7 @@ const DEFAULT_EDGE_HANDLERS_SRC = 'edge-handlers'
 // The current directory is `buildDir`. Most constants are inside this `buildDir`.
 // Instead of passing absolute paths, we pass paths relative to `buildDir`, so
 // that logs are less verbose.
-const normalizePath = function(path, buildDir, key) {
+const normalizePath = function (path, buildDir, key) {
   if (path === undefined || !CONSTANT_PATHS.has(key)) {
     return path
   }

--- a/packages/build/src/core/dry.js
+++ b/packages/build/src/core/dry.js
@@ -2,7 +2,7 @@ const { runsOnlyOnBuildFailure } = require('../commands/get')
 const { logDryRunStart, logDryRunCommand, logDryRunEnd } = require('../log/messages/dry')
 
 // If the `dry` flag is specified, do a dry run
-const doDryRun = function({ commands, commandsCount, logs }) {
+const doDryRun = function ({ commands, commandsCount, logs }) {
   const successCommands = commands.filter(({ event }) => !runsOnlyOnBuildFailure(event))
   const eventWidth = Math.max(...successCommands.map(getEventLength))
 
@@ -15,7 +15,7 @@ const doDryRun = function({ commands, commandsCount, logs }) {
   logDryRunEnd(logs)
 }
 
-const getEventLength = function({ event }) {
+const getEventLength = function ({ event }) {
   return event.length
 }
 

--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -1,20 +1,14 @@
 // From `--featureFlags=a,b,c` to `{ a: true, b: true, c: true }`
-const normalizeFeatureFlags = function({ featureFlags = '', ...rawFlags }) {
-  const normalizedFeatureFlags = Object.assign(
-    {},
-    ...featureFlags
-      .split(',')
-      .filter(isNotEmpty)
-      .map(getFeatureFlag),
-  )
+const normalizeFeatureFlags = function ({ featureFlags = '', ...rawFlags }) {
+  const normalizedFeatureFlags = Object.assign({}, ...featureFlags.split(',').filter(isNotEmpty).map(getFeatureFlag))
   return { ...rawFlags, featureFlags: normalizedFeatureFlags }
 }
 
-const isNotEmpty = function(name) {
+const isNotEmpty = function (name) {
   return name.trim() !== ''
 }
 
-const getFeatureFlag = function(name) {
+const getFeatureFlag = function (name) {
   return { [name]: true }
 }
 

--- a/packages/build/src/core/lingering.js
+++ b/packages/build/src/core/lingering.js
@@ -4,7 +4,7 @@ const { logLingeringProcesses } = require('../log/messages/core')
 
 // Print a warning when some build processes are still running.
 // This is only run in the buildbot at the moment (Linux only).
-const warnOnLingeringProcesses = async function({ mode, logs, testOpts: { silentLingeringProcesses = false } }) {
+const warnOnLingeringProcesses = async function ({ mode, logs, testOpts: { silentLingeringProcesses = false } }) {
   if (mode !== 'buildbot' || silentLingeringProcesses) {
     return
   }
@@ -24,11 +24,11 @@ const warnOnLingeringProcesses = async function({ mode, logs, testOpts: { silent
 }
 
 // Note that `ps aux` has a header line which is always printed.
-const hasLingeringProcesses = function(processList) {
+const hasLingeringProcesses = function (processList) {
   return processList.split('\n').filter(isNotEmptyLine).length > 1
 }
 
-const isNotEmptyLine = function(line) {
+const isNotEmptyLine = function (line) {
   return line.trim() !== ''
 }
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -46,7 +46,7 @@ const { getSeverity } = require('./severity')
  * 0 (success), 1 (build cancelled), 2 (user error), 3 (plugin error), 4 (system error). Can be used as exit code.
  * @returns {string[]} buildResult.logs - When using the `buffer` option, all log messages
  */
-const build = async function(flags = {}) {
+const build = async function (flags = {}) {
   const { errorMonitor, framework, mode, logs, debug, testOpts, statsdOpts, dry, telemetry, ...flagsA } = startBuild(
     flags,
   )
@@ -89,7 +89,7 @@ const build = async function(flags = {}) {
 // Performed on build start. Must be kept small and unlikely to fail since it
 // does not have proper error handling. Error handling relies on `errorMonitor`
 // being built, which relies itself on flags being normalized.
-const startBuild = function(flags) {
+const startBuild = function (flags) {
   const timers = initTimers()
 
   const logs = getBufferLogs(flags)
@@ -101,7 +101,7 @@ const startBuild = function(flags) {
   return { ...flagsA, errorMonitor, logs, timers }
 }
 
-const tExecBuild = async function({
+const tExecBuild = async function ({
   config,
   defaultConfig,
   cachedConfig,
@@ -190,7 +190,7 @@ const tExecBuild = async function({
 const execBuild = measureDuration(tExecBuild, 'total', { parentTag: 'build_site' })
 
 // Runs a build then report any plugin statuses
-const runAndReportBuild = async function({
+const runAndReportBuild = async function ({
   netlifyConfig,
   configPath,
   buildDir,
@@ -271,7 +271,7 @@ const runAndReportBuild = async function({
 }
 
 // Initialize plugin processes then runs a build
-const initAndRunBuild = async function({
+const initAndRunBuild = async function ({
   netlifyConfig,
   configPath,
   buildDir,
@@ -358,7 +358,7 @@ const initAndRunBuild = async function({
 
 // Load plugin main files, retrieve their event handlers then runs them,
 // together with the build command
-const runBuild = async function({
+const runBuild = async function ({
   childProcesses,
   pluginsOptions,
   netlifyConfig,
@@ -414,7 +414,7 @@ const runBuild = async function({
 }
 
 // Logs and reports that a build successfully ended
-const handleBuildSuccess = async function({
+const handleBuildSuccess = async function ({
   commandsCount,
   netlifyConfig,
   framework,

--- a/packages/build/src/core/normalize_flags.js
+++ b/packages/build/src/core/normalize_flags.js
@@ -6,7 +6,7 @@ const { removeFalsy } = require('../utils/remove_falsy')
 const { normalizeFeatureFlags, DEFAULT_FEATURE_FLAGS } = require('./feature_flags')
 
 // Normalize CLI flags
-const normalizeFlags = function(flags, logs) {
+const normalizeFlags = function (flags, logs) {
   const rawFlags = removeFalsy(flags)
   const rawFlagsA = normalizeFeatureFlags(rawFlags)
   const defaultFlags = getDefaultFlags(rawFlagsA)
@@ -24,7 +24,7 @@ const normalizeFlags = function(flags, logs) {
 }
 
 // Default values of CLI flags
-const getDefaultFlags = function({ env: envOpt = {}, mode = REQUIRE_MODE }) {
+const getDefaultFlags = function ({ env: envOpt = {}, mode = REQUIRE_MODE }) {
   const combinedEnv = { ...env, ...envOpt }
   return {
     env: envOpt,

--- a/packages/build/src/core/severity.js
+++ b/packages/build/src/core/severity.js
@@ -1,6 +1,6 @@
 // Used for example as exit codes.
 // 1|2|3 indicate whether this was a user|plugin|system error.
-const getSeverity = function(severity = FALLBACK_SEVERITY) {
+const getSeverity = function (severity = FALLBACK_SEVERITY) {
   const severityCode = severity in SEVERITY_CODES ? SEVERITY_CODES[severity] : SEVERITY_CODES[FALLBACK_SEVERITY]
   const success = severity === SUCCESS_SEVERITY
   return { success, severityCode }

--- a/packages/build/src/env/changes.js
+++ b/packages/build/src/env/changes.js
@@ -6,9 +6,9 @@ const mapObj = require('map-obj')
 // If plugins modify `process.env`, this is propagated in other plugins and in
 // `build.command`. Since those are different processes, we figure out when they
 // do this and communicate the new `process.env` to other processes.
-const getNewEnvChanges = function(envBefore) {
+const getNewEnvChanges = function (envBefore) {
   const envChanges = filterObj(env, (name, value) => value !== envBefore[name])
-  const deletedEnv = filterObj(envBefore, name => env[name] === undefined)
+  const deletedEnv = filterObj(envBefore, (name) => env[name] === undefined)
   const deletedEnvA = mapObj(deletedEnv, setToNull)
   return { ...envChanges, ...deletedEnvA }
 }
@@ -17,18 +17,18 @@ const getNewEnvChanges = function(envBefore) {
 // convert it to `null`
 // Note: `process.env[name] = undefined` actually does
 // `process.env[name] = 'undefined'` in Node.js.
-const setToNull = function(name) {
+const setToNull = function (name) {
   return [name, null]
 }
 
 // Set `process.env` changes from a previous different plugin.
 // Can also merge with a `currentEnv` plain object instead of `process.env`.
-const setEnvChanges = function(envChanges, currentEnv = env) {
+const setEnvChanges = function (envChanges, currentEnv = env) {
   Object.entries(envChanges).forEach(([name, value]) => setEnvChange(name, value, currentEnv))
   return { ...currentEnv }
 }
 
-const setEnvChange = function(name, value, currentEnv) {
+const setEnvChange = function (name, value, currentEnv) {
   if (currentEnv[name] === value) {
     return
   }

--- a/packages/build/src/env/git.js
+++ b/packages/build/src/env/git.js
@@ -5,7 +5,7 @@ const { removeFalsy } = require('../utils/remove_falsy')
 // Retrieve git-related information for use in environment variables.
 // git is optional and there might be not git repository.
 // We purposely keep this decoupled from the git utility.
-const getGitEnv = async function(buildDir, branch) {
+const getGitEnv = async function (buildDir, branch) {
   const [COMMIT_REF, CACHED_COMMIT_REF] = await Promise.all([
     git(['rev-parse', 'HEAD'], buildDir),
     git(['rev-parse', 'HEAD^'], buildDir),
@@ -15,7 +15,7 @@ const getGitEnv = async function(buildDir, branch) {
   return gitEnvA
 }
 
-const git = async function(args, cwd) {
+const git = async function (args, cwd) {
   try {
     const { stdout } = await execa('git', args, { cwd })
     return stdout

--- a/packages/build/src/env/main.js
+++ b/packages/build/src/env/main.js
@@ -9,7 +9,7 @@ const { getGitEnv } = require('./git')
 
 // Retrieve the environment variables passed to plugins and `build.command`
 // When run locally, this tries to emulate the production environment.
-const getChildEnv = async function({ netlifyConfig, buildDir, branch, context, siteInfo, deployId, envOpt, mode }) {
+const getChildEnv = async function ({ netlifyConfig, buildDir, branch, context, siteInfo, deployId, envOpt, mode }) {
   const parentEnv = getParentEnv(envOpt)
 
   if (mode === 'buildbot') {
@@ -30,24 +30,24 @@ const getChildEnv = async function({ netlifyConfig, buildDir, branch, context, s
 }
 
 // Current process's environment variables, with some of them removed
-const getParentEnv = function(envOpt) {
+const getParentEnv = function (envOpt) {
   const parentEnv = { ...env, ...envOpt }
   return filterObj(parentEnv, shouldKeepEnv)
 }
 
-const shouldKeepEnv = function(key) {
+const shouldKeepEnv = function (key) {
   return !REMOVED_PARENT_ENV.has(key.toLowerCase())
 }
 
 const REMOVED_PARENT_ENV = new Set(['bugsnag_key'])
 
 // Environment variables that can be unset by local ones or configuration ones
-const getDefaultEnv = function() {
+const getDefaultEnv = function () {
   return {}
 }
 
 // Environment variables that can be unset by configuration ones but not local
-const getConfigurableEnv = function() {
+const getConfigurableEnv = function () {
   const parentColorEnv = getParentColorEnv()
   return {
     // Localization
@@ -64,7 +64,7 @@ const getConfigurableEnv = function() {
 
 // Environment variables specified in UI settings, in `build.environment` or
 // in CLI flags
-const getConfigEnv = function({ build: { environment } }, deployId) {
+const getConfigEnv = function ({ build: { environment } }, deployId) {
   const deployIdEnv = deployId === undefined ? {} : { DEPLOY_ID: deployId }
   const configEnv = omit(environment, READONLY_ENV)
   return { ...deployIdEnv, ...configEnv }
@@ -100,7 +100,7 @@ const READONLY_ENV = [
 ]
 
 // Environment variables that can be unset by neither local nor configuration
-const getForcedEnv = async function({
+const getForcedEnv = async function ({
   buildDir,
   branch,
   context,

--- a/packages/build/src/env/metadata.js
+++ b/packages/build/src/env/metadata.js
@@ -3,11 +3,11 @@ const { env } = require('process')
 const filterObj = require('filter-obj')
 
 // Retrieve enviroment variables used in error monitoring
-const getEnvMetadata = function(childEnv = env) {
+const getEnvMetadata = function (childEnv = env) {
   return filterObj(childEnv, isEnvMetadata)
 }
 
-const isEnvMetadata = function(name) {
+const isEnvMetadata = function (name) {
   return ENVIRONMENT_VARIABLES.has(name)
 }
 

--- a/packages/build/src/error/api.js
+++ b/packages/build/src/error/api.js
@@ -4,7 +4,7 @@ const mapObj = require('map-obj')
 const { addErrorInfo } = require('./info')
 
 // Wrap `api.*` methods so that they add more error information
-const addApiErrorHandlers = function(api) {
+const addApiErrorHandlers = function (api) {
   if (api === undefined) {
     return
   }
@@ -12,7 +12,7 @@ const addApiErrorHandlers = function(api) {
   return mapObj(api, addErrorHandler)
 }
 
-const addErrorHandler = function(key, value) {
+const addErrorHandler = function (key, value) {
   if (typeof value !== 'function') {
     return [key, value]
   }
@@ -21,7 +21,7 @@ const addErrorHandler = function(key, value) {
   return [key, valueA]
 }
 
-const apiMethodHandler = async function(endpoint, method, parameters, ...args) {
+const apiMethodHandler = async function (endpoint, method, parameters, ...args) {
   try {
     return await method(parameters, ...args)
   } catch (error) {
@@ -32,7 +32,7 @@ const apiMethodHandler = async function(endpoint, method, parameters, ...args) {
 }
 
 // Redact API token from the build logs
-const redactError = function(error) {
+const redactError = function (error) {
   if (
     error instanceof Error &&
     isPlainObj(error.data) &&

--- a/packages/build/src/error/build.js
+++ b/packages/build/src/error/build.js
@@ -4,7 +4,7 @@ const { addErrorInfo, getErrorInfo } = require('./info')
 
 // Retrieve error information from child process and re-build it in current
 // process. We need this since errors are not JSON-serializable.
-const jsonToError = function({ name, message, stack, info = {}, errorProps = {} }, defaultInfo = {}) {
+const jsonToError = function ({ name, message, stack, info = {}, errorProps = {} }, defaultInfo = {}) {
   const error = new Error('')
 
   assignErrorProps(error, { name, message, stack })
@@ -20,15 +20,15 @@ const jsonToError = function({ name, message, stack, info = {}, errorProps = {} 
 }
 
 // Make sure `name`, `message` and `stack` are not enumerable
-const assignErrorProps = function(error, values) {
-  ERROR_PROPS.forEach(name => {
+const assignErrorProps = function (error, values) {
+  ERROR_PROPS.forEach((name) => {
     assignErrorProp(error, name, values[name])
   })
 }
 
 const ERROR_PROPS = ['name', 'message', 'stack']
 
-const assignErrorProp = function(error, name, value) {
+const assignErrorProp = function (error, name, value) {
   // `Object.defineProperty()` requires direct mutation
   // eslint-disable-next-line fp/no-mutating-methods
   Object.defineProperty(error, name, { value, enumerable: false, writable: true, configurable: true })
@@ -36,7 +36,7 @@ const assignErrorProp = function(error, name, value) {
 
 // Inverse of `jsonToError()`. We do not keep `plugin` and `location` since not
 // needed at the moment.
-const errorToJson = function({ name, message, stack, ...errorProps }, defaultInfo = {}) {
+const errorToJson = function ({ name, message, stack, ...errorProps }, defaultInfo = {}) {
   const info = getErrorInfo(errorProps)
   const infoA = { ...defaultInfo, ...info }
   const errorPayload = { name, message, stack, info: infoA, errorProps }

--- a/packages/build/src/error/cancel.js
+++ b/packages/build/src/error/cancel.js
@@ -1,5 +1,5 @@
 // Cancel builds, for example when a plugin uses `utils.build.cancelBuild()`
-const cancelBuild = async function({ api, deployId }) {
+const cancelBuild = async function ({ api, deployId }) {
   if (api === undefined || !deployId) {
     return
   }

--- a/packages/build/src/error/colors.js
+++ b/packages/build/src/error/colors.js
@@ -1,7 +1,7 @@
 const stripAnsi = require('strip-ansi')
 
 // Remove ANSI sequences from `error.message`
-const removeErrorColors = function(error) {
+const removeErrorColors = function (error) {
   if (!(error instanceof Error)) {
     return
   }

--- a/packages/build/src/error/handle.js
+++ b/packages/build/src/error/handle.js
@@ -11,7 +11,10 @@ const { removeErrorColors } = require('./colors')
 const { reportBuildError } = require('./monitor/report')
 
 // Logs and reports a build failure
-const handleBuildError = async function(error, { errorMonitor, netlifyConfig, childEnv, mode, logs, debug, testOpts }) {
+const handleBuildError = async function (
+  error,
+  { errorMonitor, netlifyConfig, childEnv, mode, logs, debug, testOpts },
+) {
   const basicErrorInfo = parseErrorInfo(error)
 
   if (await isCancelCrash(error)) {
@@ -32,7 +35,7 @@ const handleBuildError = async function(error, { errorMonitor, netlifyConfig, ch
 // logged nor reported.
 // However builds canceled with `utils.build.cancelBuild()` should still show
 // "Build canceled by ..."
-const isCancelCrash = async function(error) {
+const isCancelCrash = async function (error) {
   const { type } = getErrorInfo(error)
   if (type === 'cancelBuild') {
     return false

--- a/packages/build/src/error/info.js
+++ b/packages/build/src/error/info.js
@@ -1,5 +1,5 @@
 // Add information related to an error without colliding with existing properties
-const addErrorInfo = function(error, info) {
+const addErrorInfo = function (error, info) {
   if (!canHaveErrorInfo(error)) {
     return
   }
@@ -7,7 +7,7 @@ const addErrorInfo = function(error, info) {
   error[INFO_SYM] = { ...error[INFO_SYM], ...info }
 }
 
-const getErrorInfo = function(error) {
+const getErrorInfo = function (error) {
   if (!isBuildError(error)) {
     return {}
   }
@@ -15,13 +15,13 @@ const getErrorInfo = function(error) {
   return error[INFO_SYM]
 }
 
-const isBuildError = function(error) {
+const isBuildError = function (error) {
   return canHaveErrorInfo(error) && error[INFO_SYM] !== undefined
 }
 
 // Exceptions that are not objects (including `Error` instances) cannot have an
 // `INFO_SYM` property
-const canHaveErrorInfo = function(error) {
+const canHaveErrorInfo = function (error) {
   return error != null
 }
 

--- a/packages/build/src/error/monitor/location.js
+++ b/packages/build/src/error/monitor/location.js
@@ -1,5 +1,5 @@
 // Retrieve plugin's location and build logs
-const getLocationMetadata = function(location, envMetadata) {
+const getLocationMetadata = function (location, envMetadata) {
   const buildLogs = getBuildLogs(envMetadata)
 
   if (buildLogs === undefined && location === undefined) {
@@ -10,7 +10,7 @@ const getLocationMetadata = function(location, envMetadata) {
 }
 
 // Retrieve the URL to the build logs
-const getBuildLogs = function({ SITE_NAME, DEPLOY_ID }) {
+const getBuildLogs = function ({ SITE_NAME, DEPLOY_ID }) {
   if (SITE_NAME === undefined || DEPLOY_ID === undefined) {
     return
   }

--- a/packages/build/src/error/monitor/normalize.js
+++ b/packages/build/src/error/monitor/normalize.js
@@ -1,25 +1,22 @@
 // We group errors by `error.message`. However some `error.message` contain
 // unique IDs, etc. which defeats that grouping. So we normalize those to make
 // them consistent
-const normalizeGroupingMessage = function(message, type) {
+const normalizeGroupingMessage = function (message, type) {
   const messageA = removeDependenciesLogs(message, type)
   return NORMALIZE_REGEXPS.reduce(normalizeMessage, messageA)
 }
 
 // Discard debug/info installation information
-const removeDependenciesLogs = function(message, type) {
+const removeDependenciesLogs = function (message, type) {
   if (type !== 'dependencies') {
     return message
   }
 
-  return message
-    .split('\n')
-    .filter(isErrorLine)
-    .join('\n')
+  return message.split('\n').filter(isErrorLine).join('\n')
 }
 
-const isErrorLine = function(line) {
-  return ERROR_LINES.some(errorLine => line.startsWith(errorLine))
+const isErrorLine = function (line) {
+  return ERROR_LINES.some((errorLine) => line.startsWith(errorLine))
 }
 
 const ERROR_LINES = [
@@ -29,7 +26,7 @@ const ERROR_LINES = [
   'error',
 ]
 
-const normalizeMessage = function(message, [regExp, replacement]) {
+const normalizeMessage = function (message, [regExp, replacement]) {
   return message.replace(regExp, replacement)
 }
 

--- a/packages/build/src/error/monitor/print.js
+++ b/packages/build/src/error/monitor/print.js
@@ -1,7 +1,7 @@
 const { log } = require('../../log/logger.js')
 
 // Print event payload instead of sending actual request during tests
-const printEventForTest = function(
+const printEventForTest = function (
   { name: errorClass, message: errorMessage },
   {
     context,

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -13,7 +13,7 @@ const { normalizeGroupingMessage } = require('./normalize')
 const { printEventForTest } = require('./print')
 
 // Report a build failure for monitoring purpose
-const reportBuildError = async function({ error, errorMonitor, childEnv, logs, testOpts }) {
+const reportBuildError = async function ({ error, errorMonitor, childEnv, logs, testOpts }) {
   if (errorMonitor === undefined) {
     return
   }
@@ -36,7 +36,7 @@ const reportBuildError = async function({ error, errorMonitor, childEnv, logs, t
 
 // Plugin authors test their plugins as local plugins. Errors there are more
 // like development errors, and should be reported as `info` only.
-const getSeverity = function(severity, { location: { loadedFrom } = {} }) {
+const getSeverity = function (severity, { location: { loadedFrom } = {} }) {
   if (loadedFrom === 'local' || severity === 'none') {
     return 'info'
   }
@@ -44,7 +44,7 @@ const getSeverity = function(severity, { location: { loadedFrom } = {} }) {
   return severity
 }
 
-const getGroup = function(group, errorInfo) {
+const getGroup = function (group, errorInfo) {
   if (typeof group !== 'function') {
     return group
   }
@@ -52,20 +52,20 @@ const getGroup = function(group, errorInfo) {
   return group(errorInfo)
 }
 
-const getGroupingHash = function(group, error, type) {
+const getGroupingHash = function (group, error, type) {
   const message = error instanceof Error && typeof error.message === 'string' ? error.message : String(error)
   const messageA = normalizeGroupingMessage(message, type)
   return `${group}\n${messageA}`
 }
 
-const getMetadata = function({ location, plugin }, childEnv, groupingHash) {
+const getMetadata = function ({ location, plugin }, childEnv, groupingHash) {
   const pluginMetadata = getPluginMetadata({ location, plugin })
   const envMetadata = getEnvMetadata(childEnv)
   const locationMetadata = getLocationMetadata(location, envMetadata)
   return { location: locationMetadata, ...pluginMetadata, env: envMetadata, other: { groupingHash } }
 }
 
-const getPluginMetadata = function({ location, plugin }) {
+const getPluginMetadata = function ({ location, plugin }) {
   if (plugin === undefined) {
     return {}
   }
@@ -75,7 +75,7 @@ const getPluginMetadata = function({ location, plugin }) {
   return { plugin: { ...pluginA, homepage }, pluginPackageJson }
 }
 
-const getApp = function() {
+const getApp = function () {
   return {
     osName: type(),
     osVersion: osName(),
@@ -87,27 +87,27 @@ const getApp = function() {
 // `error.name` is shown proeminently in the Bugsnag UI. We need to update it to
 // match error `type` since it is more granular and useful.
 // But we change it back after Bugsnag is done reporting.
-const updateErrorName = function(error, type) {
+const updateErrorName = function (error, type) {
   const { name } = error
   error.name = type
   return name
 }
 
-const reportError = async function({ errorMonitor, error, logs, testOpts, eventProps }) {
+const reportError = async function ({ errorMonitor, error, logs, testOpts, eventProps }) {
   if (testOpts.errorMonitor) {
     printEventForTest(error, eventProps, logs)
     return
   }
 
   try {
-    await promisify(errorMonitor.notify)(error, event => onError(event, eventProps))
+    await promisify(errorMonitor.notify)(error, (event) => onError(event, eventProps))
     // Failsafe
   } catch (error) {
     log(logs, `Error monitor could not notify\n${error.stack}`)
   }
 }
 
-const getEventProps = function({ severity, group, groupingHash, metadata, app }) {
+const getEventProps = function ({ severity, group, groupingHash, metadata, app }) {
   // `unhandled` is used to calculate Releases "stabiity score", which is
   // basically the percentage of unhandled errors. Since we handle all errors,
   // we need to implement this according to error types.
@@ -116,7 +116,7 @@ const getEventProps = function({ severity, group, groupingHash, metadata, app })
 }
 
 // Add more information to Bugsnag events
-const onError = function(event, eventProps) {
+const onError = function (event, eventProps) {
   // Bugsnag client requires directly mutating the `event`
   // eslint-disable-next-line fp/no-mutating-assign
   Object.assign(event, {

--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -7,7 +7,7 @@ const { log } = require('../../log/logger.js')
 const projectRoot = `${__dirname}/../../..`
 
 // Start a client to monitor errors
-const startErrorMonitor = function({ flags: { mode }, logs, bugsnagKey }) {
+const startErrorMonitor = function ({ flags: { mode }, logs, bugsnagKey }) {
   if (!bugsnagKey) {
     return
   }
@@ -37,7 +37,7 @@ const startErrorMonitor = function({ flags: { mode }, logs, bugsnagKey }) {
   }
 }
 
-const isBugsnagTest = function(bugsnagKey) {
+const isBugsnagTest = function (bugsnagKey) {
   return bugsnagKey === BUGSNAG_TEST_KEY
 }
 
@@ -49,7 +49,7 @@ const BUGSNAG_TEST_KEY = '00000000000000000000000000000000'
 const startBugsnag = memoizeOne(Bugsnag.start.bind(Bugsnag), () => true)
 
 // Based the release stage on the `mode`
-const getReleaseStage = function(mode = DEFAULT_RELEASE_STAGE) {
+const getReleaseStage = function (mode = DEFAULT_RELEASE_STAGE) {
   return mode
 }
 
@@ -59,11 +59,11 @@ const DEFAULT_RELEASE_STAGE = 'unknown'
 // We also want to use our own `log` utility, unprefixed.
 // In tests, we don't print Bugsnag because it sometimes randomly fails to
 // send sessions, which prints warning messags in test snapshots.
-const getLogger = function(logs, isTest) {
+const getLogger = function (logs, isTest) {
   const logFunc = isTest ? noop : log.bind(null, logs)
   return { debug: noop, info: noop, warn: logFunc, error: logFunc }
 }
 
-const noop = function() {}
+const noop = function () {}
 
 module.exports = { startErrorMonitor }

--- a/packages/build/src/error/parse/clean_stack.js
+++ b/packages/build/src/error/parse/clean_stack.js
@@ -11,7 +11,7 @@ const stripAnsi = require('strip-ansi')
 // Keep non stack trace lines as is.
 // We do not use libraries that patch `Error.prepareStackTrace()` because they
 // tend to create issues.
-const cleanStacks = function({ stack, rawStack, debug }) {
+const cleanStacks = function ({ stack, rawStack, debug }) {
   if (stack === undefined) {
     return
   }
@@ -22,13 +22,10 @@ const cleanStacks = function({ stack, rawStack, debug }) {
     return stack
   }
 
-  return stack
-    .split('\n')
-    .reduce(cleanStackLine, '')
-    .replace(INITIAL_NEWLINES, '')
+  return stack.split('\n').reduce(cleanStackLine, '').replace(INITIAL_NEWLINES, '')
 }
 
-const cleanStackLine = function(lines, line) {
+const cleanStackLine = function (lines, line) {
   const lineA = line.replace(getCwd(), '')
   const lineB = stripAnsi(lineA)
 
@@ -55,7 +52,7 @@ const cleanStackLine = function(lines, line) {
 
 // `process.cwd()` can sometimes fail: directory name too long, current
 // directory has been removed, access denied.
-const getCwd = function() {
+const getCwd = function () {
   try {
     return cwd()
   } catch (error) {
@@ -66,7 +63,7 @@ const getCwd = function() {
 // Check if a line is part of a stack trace
 const STACK_LINE_REGEXP = /^\s+at /
 
-const isUselessStack = function(line) {
+const isUselessStack = function (line) {
   const lineA = normalizePathSlashes(line)
   return (
     // Anonymous function
@@ -79,7 +76,7 @@ const isUselessStack = function(line) {
 }
 
 // This is only needed for local builds and tests
-const isInternalStack = function(line) {
+const isInternalStack = function (line) {
   const lineA = normalizePathSlashes(line)
   return INTERNAL_STACK_REGEXP.test(lineA)
 }
@@ -88,7 +85,7 @@ const INTERNAL_STACK_REGEXP = /(packages|@netlify)\/build\/(src\/|tests\/helpers
 
 const INITIAL_NEWLINES = /^\n+/
 
-const normalizePathSlashes = function(line) {
+const normalizePathSlashes = function (line) {
   return line.replace(BACKLASH_REGEXP, '/')
 }
 

--- a/packages/build/src/error/parse/location.js
+++ b/packages/build/src/error/parse/location.js
@@ -2,7 +2,7 @@ const { getBuildCommandDescription, getPluginOrigin } = require('../../log/descr
 
 // Retrieve an error's location to print in logs.
 // Each error type has its own logic (or none if there's no location to print).
-const getLocationInfo = function({ stack, location, locationType }) {
+const getLocationInfo = function ({ stack, location, locationType }) {
   // No location to print
   if (locationType === undefined && stack === undefined) {
     return
@@ -17,19 +17,19 @@ const getLocationInfo = function({ stack, location, locationType }) {
   return [locationString, stack].filter(Boolean).join('\n')
 }
 
-const getBuildCommandLocation = function({ buildCommand, buildCommandOrigin }) {
+const getBuildCommandLocation = function ({ buildCommand, buildCommandOrigin }) {
   const description = getBuildCommandDescription(buildCommandOrigin)
   return `In ${description}:
 ${buildCommand}`
 }
 
-const getBuildFailLocation = function({ event, packageName, loadedFrom, origin }) {
+const getBuildFailLocation = function ({ event, packageName, loadedFrom, origin }) {
   const eventMessage = getEventMessage(event)
   const pluginOrigin = getPluginOrigin(loadedFrom, origin)
   return `${eventMessage} "${packageName}" ${pluginOrigin}`
 }
 
-const getEventMessage = function(event) {
+const getEventMessage = function (event) {
   if (event === 'load') {
     return `While loading`
   }
@@ -37,7 +37,7 @@ const getEventMessage = function(event) {
   return `In "${event}" event in`
 }
 
-const getApiLocation = function({ endpoint, parameters }) {
+const getApiLocation = function ({ endpoint, parameters }) {
   return `While calling the Netlify API endpoint '${endpoint}' with:\n${JSON.stringify(parameters, null, 2)}`
 }
 

--- a/packages/build/src/error/parse/normalize.js
+++ b/packages/build/src/error/parse/normalize.js
@@ -1,5 +1,5 @@
 // Ensure error is an `Error` instance
-const normalizeError = function(error) {
+const normalizeError = function (error) {
   if (Array.isArray(error)) {
     return normalizeArray(error)
   }
@@ -12,7 +12,7 @@ const normalizeError = function(error) {
 }
 
 // Some libraries throw arrays of Errors
-const normalizeArray = function(errorArray) {
+const normalizeArray = function (errorArray) {
   const [error, ...errors] = errorArray.map(normalizeError)
   error.errors = errors
   return error

--- a/packages/build/src/error/parse/parse.js
+++ b/packages/build/src/error/parse/parse.js
@@ -8,7 +8,7 @@ const { getErrorProps } = require('./properties')
 const { getStackInfo } = require('./stack')
 
 // Add additional type-specific error information
-const getFullErrorInfo = function({ error, colors, debug }) {
+const getFullErrorInfo = function ({ error, colors, debug }) {
   const basicErrorInfo = parseErrorInfo(error)
   const {
     message,
@@ -36,7 +36,7 @@ const getFullErrorInfo = function({ error, colors, debug }) {
 }
 
 // Parse error instance into all the basic properties containing information
-const parseErrorInfo = function(error) {
+const parseErrorInfo = function (error) {
   const { message, stack, ...errorProps } = normalizeError(error)
   const errorInfo = getErrorInfo(errorProps)
   const { type, severity, title, group, stackType, locationType, showErrorProps, rawStack } = getTypeInfo(errorInfo)
@@ -58,7 +58,7 @@ const parseErrorInfo = function(error) {
 }
 
 // Retrieve title to print in logs
-const getTitle = function(title, errorInfo) {
+const getTitle = function (title, errorInfo) {
   if (typeof title !== 'function') {
     return title
   }

--- a/packages/build/src/error/parse/plugin.js
+++ b/packages/build/src/error/parse/plugin.js
@@ -1,6 +1,6 @@
 // Retrieve plugin's package.json details to include in error messages.
 // Please note `pluginPackageJson` has been normalized by `normalize-package-data`.
-const getPluginInfo = function({ pluginPackageJson = {} }, { packageName, loadedFrom }) {
+const getPluginInfo = function ({ pluginPackageJson = {} }, { packageName, loadedFrom }) {
   if (Object.keys(pluginPackageJson).length === 0) {
     return
   }
@@ -12,7 +12,7 @@ const getPluginInfo = function({ pluginPackageJson = {} }, { packageName, loaded
 }
 
 // Serialize a single package.json field
-const serializeField = function({ name, getField, pluginPackageJson, packageName, loadedFrom }) {
+const serializeField = function ({ name, getField, pluginPackageJson, packageName, loadedFrom }) {
   const field = getField(pluginPackageJson, { packageName, loadedFrom })
   if (field === undefined) {
     return
@@ -24,11 +24,11 @@ const serializeField = function({ name, getField, pluginPackageJson, packageName
 
 const NAME_PADDING = 16
 
-const getPackage = function(pluginPackageJson, { packageName }) {
+const getPackage = function (pluginPackageJson, { packageName }) {
   return packageName
 }
 
-const getVersion = function({ version }) {
+const getVersion = function ({ version }) {
   if (version === '') {
     return
   }
@@ -36,7 +36,7 @@ const getVersion = function({ version }) {
   return version
 }
 
-const getHomepage = function(pluginPackageJson = {}, { loadedFrom } = {}) {
+const getHomepage = function (pluginPackageJson = {}, { loadedFrom } = {}) {
   return (
     getRepository(pluginPackageJson) ||
     getNpmLink(pluginPackageJson, { loadedFrom }) ||
@@ -44,11 +44,11 @@ const getHomepage = function(pluginPackageJson = {}, { loadedFrom } = {}) {
   )
 }
 
-const getRepository = function({ repository: { url } = {} }) {
+const getRepository = function ({ repository: { url } = {} }) {
   return url
 }
 
-const getNpmLink = function({ name }, { loadedFrom }) {
+const getNpmLink = function ({ name }, { loadedFrom }) {
   if (!name || loadedFrom === 'local') {
     return
   }
@@ -56,7 +56,7 @@ const getNpmLink = function({ name }, { loadedFrom }) {
   return `https://www.npmjs.com/package/${name}`
 }
 
-const getIssuesLink = function({ bugs: { url } = {} }) {
+const getIssuesLink = function ({ bugs: { url } = {} }) {
   return url
 }
 

--- a/packages/build/src/error/parse/properties.js
+++ b/packages/build/src/error/parse/properties.js
@@ -4,7 +4,7 @@ const { omit } = require('../../utils/omit')
 const { INFO_SYM } = require('../info')
 
 // In uncaught exceptions, print error static properties
-const getErrorProps = function({ errorProps, showErrorProps, colors }) {
+const getErrorProps = function ({ errorProps, showErrorProps, colors }) {
   const errorPropsA = omit(errorProps, CLEANED_ERROR_PROPS)
 
   if (!showErrorProps || Object.keys(errorPropsA).length === 0) {

--- a/packages/build/src/error/parse/serialize_log.js
+++ b/packages/build/src/error/parse/serialize_log.js
@@ -1,14 +1,14 @@
 const { THEME } = require('../../log/theme')
 
 // Serialize an error object into a title|body string to print in logs
-const serializeLogError = function({
+const serializeLogError = function ({
   fullErrorInfo: { title, severity, message, pluginInfo, locationInfo, errorProps },
 }) {
   const body = getBody({ message, pluginInfo, locationInfo, errorProps, severity })
   return { title, body }
 }
 
-const getBody = function({ message, pluginInfo, locationInfo, errorProps, severity }) {
+const getBody = function ({ message, pluginInfo, locationInfo, errorProps, severity }) {
   if (severity === 'none') {
     return message
   }
@@ -24,11 +24,11 @@ const getBody = function({ message, pluginInfo, locationInfo, errorProps, severi
     .join('\n\n')
 }
 
-const blockHasValue = function([, value]) {
+const blockHasValue = function ([, value]) {
   return value !== undefined
 }
 
-const serializeBlock = function([key, value]) {
+const serializeBlock = function ([key, value]) {
   return `${THEME.errorSubHeader(LOG_BLOCK_NAMES[key])}\n${value}`
 }
 

--- a/packages/build/src/error/parse/serialize_status.js
+++ b/packages/build/src/error/parse/serialize_status.js
@@ -1,10 +1,10 @@
 // Serialize an error object to `statuses` properties
-const serializeErrorStatus = function({ fullErrorInfo: { title, message, locationInfo, errorProps }, state }) {
+const serializeErrorStatus = function ({ fullErrorInfo: { title, message, locationInfo, errorProps }, state }) {
   const text = getText({ locationInfo, errorProps })
   return { state, title, summary: message, text }
 }
 
-const getText = function({ locationInfo, errorProps }) {
+const getText = function ({ locationInfo, errorProps }) {
   const parts = [locationInfo, getErrorProps(errorProps)].filter(Boolean)
 
   if (parts.length === 0) {
@@ -14,7 +14,7 @@ const getText = function({ locationInfo, errorProps }) {
   return parts.join('\n\n')
 }
 
-const getErrorProps = function(errorProps) {
+const getErrorProps = function (errorProps) {
   if (errorProps === undefined) {
     return
   }

--- a/packages/build/src/error/parse/stack.js
+++ b/packages/build/src/error/parse/stack.js
@@ -1,14 +1,14 @@
 const { cleanStacks } = require('./clean_stack')
 
 // Retrieve the stack trace
-const getStackInfo = function({ message, stack, stackType, rawStack, severity, debug }) {
+const getStackInfo = function ({ message, stack, stackType, rawStack, severity, debug }) {
   const { message: messageA, stack: stackA } = splitStackInfo({ message, stack, stackType })
   const messageB = severity === 'none' ? messageA.replace(SUCCESS_ERROR_NAME, '') : messageA
   const stackB = cleanStacks({ stack: stackA, rawStack, debug })
   return { message: messageB, stack: stackB }
 }
 
-const splitStackInfo = function({ message, stack, stackType }) {
+const splitStackInfo = function ({ message, stack, stackType }) {
   // Some errors should not show any stack trace
   if (stackType === 'none') {
     return { message }
@@ -23,7 +23,7 @@ const splitStackInfo = function({ message, stack, stackType }) {
   return splitStack(stack)
 }
 
-const splitStack = function(string) {
+const splitStack = function (string) {
   const lines = string.split('\n')
   const stackIndex = lines.findIndex(isStackTrace)
 
@@ -36,7 +36,7 @@ const splitStack = function(string) {
   return { message: messageA, stack: stackA }
 }
 
-const isStackTrace = function(line) {
+const isStackTrace = function (line) {
   return line.trim().startsWith('at ')
 }
 

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -1,5 +1,5 @@
 // Retrieve error-type specific information
-const getTypeInfo = function({ type }) {
+const getTypeInfo = function ({ type }) {
   const typeA = TYPES[type] === undefined ? DEFAULT_TYPE : type
   return { type: typeA, ...TYPES[typeA] }
 }

--- a/packages/build/src/install/functions.js
+++ b/packages/build/src/install/functions.js
@@ -7,7 +7,7 @@ const { logInstallFunctionDependencies } = require('../log/messages/install')
 const { installDependencies } = require('./main')
 
 // Install dependencies of Netlify Functions
-const installFunctionDependencies = async function(functionsSrc, isLocal) {
+const installFunctionDependencies = async function (functionsSrc, isLocal) {
   const packagePaths = await getPackagePaths(functionsSrc)
   if (packagePaths.length === 0) {
     return
@@ -16,14 +16,14 @@ const installFunctionDependencies = async function(functionsSrc, isLocal) {
   logInstallFunctionDependencies()
 
   const packageRoots = packagePaths.map(getPackageRoot)
-  await Promise.all(packageRoots.map(packageRoot => installDependencies({ packageRoot, isLocal })))
+  await Promise.all(packageRoots.map((packageRoot) => installDependencies({ packageRoot, isLocal })))
 }
 
-const getPackagePaths = function(functionsSrc) {
+const getPackagePaths = function (functionsSrc) {
   return readdirp.promise(functionsSrc, { depth: 1, fileFilter: 'package.json' })
 }
 
-const getPackageRoot = function({ fullPath }) {
+const getPackageRoot = function ({ fullPath }) {
   return dirname(fullPath)
 }
 

--- a/packages/build/src/install/local.js
+++ b/packages/build/src/install/local.js
@@ -8,7 +8,7 @@ const { installDependencies } = require('./main')
 // Users must add this plugin to their `netlify.toml` `plugins` to use this
 // feature. We don't want to provide it by default because this makes build
 // slow and buggy.
-const installLocalPluginsDependencies = async function({ plugins, pluginsOptions, buildDir, mode, logs }) {
+const installLocalPluginsDependencies = async function ({ plugins, pluginsOptions, buildDir, mode, logs }) {
   if (!plugins.some(isLocalInstallOptIn)) {
     return
   }
@@ -31,35 +31,32 @@ const installLocalPluginsDependencies = async function({ plugins, pluginsOptions
   )
 }
 
-const isLocalInstallOptIn = function(plugin) {
+const isLocalInstallOptIn = function (plugin) {
   return plugin.package === LOCAL_INSTALL_PLUGIN_NAME
 }
 
 const LOCAL_INSTALL_PLUGIN_NAME = '@netlify/plugin-local-install-core'
 
 // Core plugins and non-local plugins already have their dependencies installed
-const getLocalPluginsOptions = function(pluginsOptions) {
-  return pluginsOptions
-    .filter(isLocalPlugin)
-    .filter(isUnique)
-    .filter(hasPackageDir)
+const getLocalPluginsOptions = function (pluginsOptions) {
+  return pluginsOptions.filter(isLocalPlugin).filter(isUnique).filter(hasPackageDir)
 }
 
-const isLocalPlugin = function({ loadedFrom }) {
+const isLocalPlugin = function ({ loadedFrom }) {
   return loadedFrom === 'local'
 }
 
 // Remove duplicates
-const isUnique = function({ packageDir }, index, pluginsOptions) {
-  return pluginsOptions.slice(index + 1).every(pluginOption => pluginOption.packageDir !== packageDir)
+const isUnique = function ({ packageDir }, index, pluginsOptions) {
+  return pluginsOptions.slice(index + 1).every((pluginOption) => pluginOption.packageDir !== packageDir)
 }
 
-const hasPackageDir = function({ packageDir }) {
+const hasPackageDir = function ({ packageDir }) {
   return packageDir !== undefined
 }
 
 // We only install dependencies of local plugins that have their own `package.json`
-const removeMainRoot = async function(localPluginsOptions, buildDir) {
+const removeMainRoot = async function (localPluginsOptions, buildDir) {
   const mainPackageDir = await pkgDir(buildDir)
   return localPluginsOptions.filter(({ packageDir }) => packageDir !== mainPackageDir)
 }

--- a/packages/build/src/install/main.js
+++ b/packages/build/src/install/main.js
@@ -6,16 +6,16 @@ const pathExists = require('path-exists')
 const { addErrorInfo } = require('../error/info')
 
 // Install Node.js dependencies in a specific directory
-const installDependencies = function({ packageRoot, isLocal }) {
+const installDependencies = function ({ packageRoot, isLocal }) {
   return runCommand({ packageRoot, isLocal, type: 'install' })
 }
 
 // Add new Node.js dependencies
-const addLatestDependencies = function({ packageRoot, isLocal, packages }) {
+const addLatestDependencies = function ({ packageRoot, isLocal, packages }) {
   return runCommand({ packageRoot, packages, isLocal, type: 'add' })
 }
 
-const runCommand = async function({ packageRoot, packages = [], isLocal, type }) {
+const runCommand = async function ({ packageRoot, packages = [], isLocal, type }) {
   try {
     const [command, ...args] = await getCommand({ packageRoot, type, isLocal })
     await execa(command, [...args, ...packages], { cwd: packageRoot, all: true })
@@ -28,14 +28,14 @@ const runCommand = async function({ packageRoot, packages = [], isLocal, type })
 }
 
 // Retrieve the shell command to install or add dependencies
-const getCommand = async function({ packageRoot, type, isLocal }) {
+const getCommand = async function ({ packageRoot, type, isLocal }) {
   const manager = await getManager(type, packageRoot)
   const command = COMMANDS[manager][type]
   const commandA = addYarnCustomCache(command, manager, isLocal)
   return commandA
 }
 
-const getManager = async function(type, packageRoot) {
+const getManager = async function (type, packageRoot) {
   // `addLatestDependencies()` is only supported with npm at the moment
   if (type === 'add') {
     return 'npm'
@@ -59,7 +59,7 @@ const COMMANDS = {
 }
 
 // In CI, yarn uses a custom cache folder
-const addYarnCustomCache = function(command, manager, isLocal) {
+const addYarnCustomCache = function (command, manager, isLocal) {
   if (manager !== 'yarn' || isLocal) {
     return command
   }
@@ -70,16 +70,13 @@ const addYarnCustomCache = function(command, manager, isLocal) {
 const YARN_CI_CACHE_DIR = `${homedir()}/.yarn_cache`
 
 // Retrieve message to add to install errors
-const getErrorMessage = function(allOutput) {
-  return allOutput
-    .split('\n')
-    .filter(isNotNpmLogMessage)
-    .join('\n')
+const getErrorMessage = function (allOutput) {
+  return allOutput.split('\n').filter(isNotNpmLogMessage).join('\n')
 }
 
 // Debug logs shown at the end of npm errors is not useful in Netlify Build
-const isNotNpmLogMessage = function(line) {
-  return NPM_LOG_MESSAGES.every(message => !line.includes(message))
+const isNotNpmLogMessage = function (line) {
+  return NPM_LOG_MESSAGES.every((message) => !line.includes(message))
 }
 const NPM_LOG_MESSAGES = ['complete log of this run', '-debug.log']
 

--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -13,7 +13,7 @@ const pWriteFile = promisify(writeFile)
 // Find the path to the directory used to install plugins automatically.
 // It is a subdirectory of `buildDir`, so that the plugin can require the
 // project's dependencies (peer dependencies).
-const getAutoPluginsDirPath = function(buildDir) {
+const getAutoPluginsDirPath = function (buildDir) {
   return `${buildDir}/${AUTO_PLUGINS_DIR}`
 }
 
@@ -25,7 +25,7 @@ const AUTO_PLUGINS_DIR = '.netlify/plugins/'
 // We are always using `npm` to mimic the behavior of plugins cached in the
 // build image. Users requiring `yarn` or custom npm/yarn flags should install
 // the plugin in their `package.json`.
-const installMissingPlugins = async function({ pluginsOptions, autoPluginsDir, mode, logs }) {
+const installMissingPlugins = async function ({ pluginsOptions, autoPluginsDir, mode, logs }) {
   const packages = getMissingPlugins(pluginsOptions)
   if (packages.length === 0) {
     return
@@ -37,25 +37,25 @@ const installMissingPlugins = async function({ pluginsOptions, autoPluginsDir, m
   await addLatestDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
 }
 
-const getMissingPlugins = function(pluginsOptions) {
+const getMissingPlugins = function (pluginsOptions) {
   return pluginsOptions.filter(isMissingPlugin).map(getPackageName)
 }
 
-const isMissingPlugin = function({ pluginPath }) {
+const isMissingPlugin = function ({ pluginPath }) {
   return pluginPath === undefined
 }
 
-const getPackageName = function({ packageName }) {
+const getPackageName = function ({ packageName }) {
   return packageName
 }
 
-const createAutoPluginsDir = async function(autoPluginsDir) {
+const createAutoPluginsDir = async function (autoPluginsDir) {
   await ensureDir(autoPluginsDir)
   await createPackageJson(autoPluginsDir)
 }
 
 // Create the directory if it does not exist
-const ensureDir = async function(autoPluginsDir) {
+const ensureDir = async function (autoPluginsDir) {
   if (await pathExists(autoPluginsDir)) {
     return
   }
@@ -64,7 +64,7 @@ const ensureDir = async function(autoPluginsDir) {
 }
 
 // Create a dummy `package.json` so we can run `npm install` and get a lock file
-const createPackageJson = async function(autoPluginsDir) {
+const createPackageJson = async function (autoPluginsDir) {
   const packageJsonPath = `${autoPluginsDir}/package.json`
   if (await pathExists(packageJsonPath)) {
     return
@@ -94,7 +94,7 @@ const AUTO_PLUGINS_PACKAGE_JSON = {
 // because there is always a time gap between the moment when:
 //  - a plugin is shown in the UI (`plugins.json` in `netlify/build` updated)
 //  - a plugin is pre-installed in the `build-image` (`buildbot` deployed)
-const warnOnMissingPlugins = function({ pluginsOptions, buildImagePluginsDir, logs }) {
+const warnOnMissingPlugins = function ({ pluginsOptions, buildImagePluginsDir, logs }) {
   if (buildImagePluginsDir === undefined) {
     return
   }
@@ -107,7 +107,7 @@ const warnOnMissingPlugins = function({ pluginsOptions, buildImagePluginsDir, lo
   logMissingPluginsWarning(logs, packages)
 }
 
-const isAutomaticallyInstalled = function({ loadedFrom, origin }) {
+const isAutomaticallyInstalled = function ({ loadedFrom, origin }) {
   return loadedFrom === 'auto_install' && origin === 'config'
 }
 

--- a/packages/build/src/log/colors.js
+++ b/packages/build/src/log/colors.js
@@ -8,7 +8,7 @@ const supportsColor = require('supports-color')
 // non-interactive even if the parent is an interactive TTY. This means they
 // would normally lose colors. If the parent has colors, we pass an environment
 // variable to the child process to force colors.
-const getParentColorEnv = function() {
+const getParentColorEnv = function () {
   if (!hasColors()) {
     return {}
   }
@@ -21,7 +21,7 @@ const getParentColorEnv = function() {
 // `process.stdout.hasColors` which is always `undefined` when the TTY is
 // non-interactive. So we need to set `util.inspect.defaultOptions.colors`
 // manually both in plugin processes.
-const setInspectColors = function() {
+const setInspectColors = function () {
   if (!hasColors()) {
     return
   }
@@ -31,7 +31,7 @@ const setInspectColors = function() {
   defaultOptions.colors = true
 }
 
-const hasColors = function() {
+const hasColors = function () {
   return supportsColor.stdout !== false
 }
 

--- a/packages/build/src/log/description.js
+++ b/packages/build/src/log/description.js
@@ -1,5 +1,5 @@
 // Retrieve description of `build.command` or of an event handler
-const getCommandDescription = function({ event, buildCommandOrigin, packageName }) {
+const getCommandDescription = function ({ event, buildCommandOrigin, packageName }) {
   if (buildCommandOrigin !== undefined) {
     return getBuildCommandDescription(buildCommandOrigin)
   }
@@ -8,7 +8,7 @@ const getCommandDescription = function({ event, buildCommandOrigin, packageName 
 }
 
 // Retrieve description of `build.command`
-const getBuildCommandDescription = function(buildCommandOrigin) {
+const getBuildCommandDescription = function (buildCommandOrigin) {
   return BUILD_COMMAND_DESCRIPTIONS[buildCommandOrigin]
 }
 
@@ -18,7 +18,7 @@ const BUILD_COMMAND_DESCRIPTIONS = {
 }
 
 // Retrieve human-friendly plugin origin
-const getPluginOrigin = function(loadedFrom, origin) {
+const getPluginOrigin = function (loadedFrom, origin) {
   const originName = PLUGIN_ORIGINS[origin]
 
   if (loadedFrom === 'package.json') {

--- a/packages/build/src/log/header.js
+++ b/packages/build/src/log/header.js
@@ -1,7 +1,7 @@
 const stringWidth = require('string-width')
 
 // Print a rectangular header
-const getHeader = function(message) {
+const getHeader = function (message) {
   const messageWidth = stringWidth(message)
   const headerWidth = Math.max(HEADER_MIN_WIDTH, messageWidth + MIN_PADDING * 2)
   const line = '─'.repeat(headerWidth)

--- a/packages/build/src/log/header_func.js
+++ b/packages/build/src/log/header_func.js
@@ -3,7 +3,7 @@ const { parseErrorInfo } = require('../error/parse/parse')
 const { logHeader, logErrorHeader } = require('./logger')
 
 // Retrieve successful or error header depending on whether `error` exists
-const getLogHeaderFunc = function(error) {
+const getLogHeaderFunc = function (error) {
   if (error === undefined) {
     return logHeader
   }

--- a/packages/build/src/log/logger.js
+++ b/packages/build/src/log/logger.js
@@ -7,7 +7,7 @@ const { THEME } = require('./theme')
 
 // When the `buffer` option is true, we return logs instead of printing them
 // on the console. The logs are accumulated in a `logs` array variable.
-const getBufferLogs = function({ buffer = false }) {
+const getBufferLogs = function ({ buffer = false }) {
   if (!buffer) {
     return
   }
@@ -18,7 +18,7 @@ const getBufferLogs = function({ buffer = false }) {
 // Core logging utility, used by the other methods.
 // This should be used instead of `console.log()` as it allows us to instrument
 // how any build logs is being printed.
-const log = function(logs, string, { indent = false, color } = {}) {
+const log = function (logs, string, { indent = false, color } = {}) {
   const stringA = indent ? indentString(string, INDENT_SIZE) : string
   const stringB = String(stringA).replace(EMPTY_LINES_REGEXP, EMPTY_LINE)
   const stringC = color === undefined ? stringB : color(stringB)
@@ -40,42 +40,42 @@ const INDENT_SIZE = 2
 const EMPTY_LINES_REGEXP = /^\s*$/gm
 const EMPTY_LINE = '\u{200B}'
 
-const logError = function(logs, string, opts) {
+const logError = function (logs, string, opts) {
   log(logs, string, { color: THEME.errorLine, ...opts })
 }
 
 // Print a message that is under a header/subheader, i.e. indented
-const logMessage = function(logs, string, opts) {
+const logMessage = function (logs, string, opts) {
   log(logs, string, { indent: true, ...opts })
 }
 
 // Print an object
-const logObject = function(logs, object, opts) {
+const logObject = function (logs, object, opts) {
   logMessage(logs, serializeObject(object), opts)
 }
 
 // Print an array
-const logArray = function(logs, array, opts) {
+const logArray = function (logs, array, opts) {
   logMessage(logs, serializeArray(array), { color: THEME.none, ...opts })
 }
 
 // Print a main section header
-const logHeader = function(logs, string, opts) {
+const logHeader = function (logs, string, opts) {
   log(logs, `\n${getHeader(string)}`, { color: THEME.header, ...opts })
 }
 
 // Print a main section header, when an error happened
-const logErrorHeader = function(logs, string, opts) {
+const logErrorHeader = function (logs, string, opts) {
   logHeader(logs, string, { color: THEME.errorHeader, ...opts })
 }
 
 // Print a sub-section header
-const logSubHeader = function(logs, string, opts) {
+const logSubHeader = function (logs, string, opts) {
   log(logs, `\n${pointer} ${string}`, { color: THEME.subHeader, ...opts })
 }
 
 // Print a sub-section header, when an error happened
-const logErrorSubHeader = function(logs, string, opts) {
+const logErrorSubHeader = function (logs, string, opts) {
   logSubHeader(logs, string, { color: THEME.errorSubHeader, ...opts })
 }
 

--- a/packages/build/src/log/messages/commands.js
+++ b/packages/build/src/log/messages/commands.js
@@ -3,18 +3,18 @@ const { getLogHeaderFunc } = require('../header_func')
 const { log, logMessage } = require('../logger')
 const { THEME } = require('../theme')
 
-const logCommand = function({ logs, event, buildCommandOrigin, packageName, index, error }) {
+const logCommand = function ({ logs, event, buildCommandOrigin, packageName, index, error }) {
   const description = getCommandDescription({ event, buildCommandOrigin, packageName })
   const logHeaderFunc = getLogHeaderFunc(error)
   logHeaderFunc(logs, `${index + 1}. ${description}`)
   logMessage(logs, '')
 }
 
-const logBuildCommandStart = function(logs, buildCommand) {
+const logBuildCommandStart = function (logs, buildCommand) {
   log(logs, THEME.highlightWords(`$ ${buildCommand}`))
 }
 
-const logCommandSuccess = function(logs) {
+const logCommandSuccess = function (logs) {
   logMessage(logs, '')
 }
 

--- a/packages/build/src/log/messages/config.js
+++ b/packages/build/src/log/messages/config.js
@@ -4,7 +4,7 @@ const { omit } = require('../../utils/omit')
 const { logMessage, logObject, logSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
-const logFlags = function(logs, flags, { debug }) {
+const logFlags = function (logs, flags, { debug }) {
   const hiddenFlags = debug ? HIDDEN_DEBUG_FLAGS : HIDDEN_FLAGS
   const flagsA = omit(flags, hiddenFlags)
   logSubHeader(logs, 'Flags')
@@ -29,19 +29,19 @@ const INTERNAL_FLAGS = [
 const HIDDEN_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, ...INTERNAL_FLAGS]
 const HIDDEN_DEBUG_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS]
 
-const logBuildDir = function(logs, buildDir) {
+const logBuildDir = function (logs, buildDir) {
   logSubHeader(logs, 'Current directory')
   logMessage(logs, buildDir)
 }
 
-const logConfigPath = function(logs, configPath = NO_CONFIG_MESSAGE) {
+const logConfigPath = function (logs, configPath = NO_CONFIG_MESSAGE) {
   logSubHeader(logs, 'Config file')
   logMessage(logs, configPath)
 }
 
 const NO_CONFIG_MESSAGE = 'No config file was defined: using default values.'
 
-const logConfig = function({ logs, netlifyConfig, debug }) {
+const logConfig = function ({ logs, netlifyConfig, debug }) {
   if (!debug) {
     return
   }
@@ -50,7 +50,7 @@ const logConfig = function({ logs, netlifyConfig, debug }) {
   logObject(logs, cleanupConfig(netlifyConfig))
 }
 
-const logConfigOnError = function({ logs, netlifyConfig, severity }) {
+const logConfigOnError = function ({ logs, netlifyConfig, severity }) {
   if (netlifyConfig === undefined || severity === 'none') {
     return
   }
@@ -59,7 +59,7 @@ const logConfigOnError = function({ logs, netlifyConfig, severity }) {
   logObject(logs, cleanupConfig(netlifyConfig))
 }
 
-const logContext = function(logs, context) {
+const logContext = function (logs, context) {
   if (context === undefined) {
     return
   }

--- a/packages/build/src/log/messages/core.js
+++ b/packages/build/src/log/messages/core.js
@@ -11,13 +11,13 @@ const { THEME } = require('../theme')
 
 const { logConfigOnError } = require('./config')
 
-const logBuildStart = function(logs) {
+const logBuildStart = function (logs) {
   logHeader(logs, 'Netlify Build')
   logSubHeader(logs, 'Version')
   logMessage(logs, `${name} ${version}`)
 }
 
-const logBuildError = function({ error, netlifyConfig, mode, logs, debug, testOpts }) {
+const logBuildError = function ({ error, netlifyConfig, mode, logs, debug, testOpts }) {
   const fullErrorInfo = getFullErrorInfo({ error, colors: true, debug })
   const { severity } = fullErrorInfo
   const { title, body } = serializeLogError({ fullErrorInfo })
@@ -28,18 +28,18 @@ const logBuildError = function({ error, netlifyConfig, mode, logs, debug, testOp
   logOldCliVersionError({ mode, testOpts })
 }
 
-const logBuildSuccess = function(logs) {
+const logBuildSuccess = function (logs) {
   logHeader(logs, 'Netlify Build Complete')
   logMessage(logs, '')
 }
 
-const logTimer = function(logs, durationNs, timerName) {
+const logTimer = function (logs, durationNs, timerName) {
   const durationMs = roundTimerToMillisecs(durationNs)
   const duration = prettyMs(durationMs)
   log(logs, THEME.dimWords(`(${timerName} completed in ${duration})`))
 }
 
-const logLingeringProcesses = function(logs, processList) {
+const logLingeringProcesses = function (logs, processList) {
   log(
     logs,
     THEME.errorLine(`

--- a/packages/build/src/log/messages/dry.js
+++ b/packages/build/src/log/messages/dry.js
@@ -4,7 +4,7 @@ const { getBuildCommandDescription } = require('../description')
 const { logMessage, logSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
-const logDryRunStart = function({ logs, eventWidth, commandsCount }) {
+const logDryRunStart = function ({ logs, eventWidth, commandsCount }) {
   const columnWidth = getDryColumnWidth(eventWidth, commandsCount)
   const line = '─'.repeat(columnWidth)
   const secondLine = '─'.repeat(columnWidth)
@@ -22,7 +22,7 @@ ${THEME.header(`┌─${line}─┬─${secondLine}─┐
   )
 }
 
-const logDryRunCommand = function({
+const logDryRunCommand = function ({
   logs,
   command: { event, packageName, buildCommandOrigin },
   index,
@@ -44,7 +44,7 @@ ${THEME.header(`└─${line}─┘ `)}`,
   )
 }
 
-const getPluginFullName = function({ packageName, buildCommandOrigin }) {
+const getPluginFullName = function ({ packageName, buildCommandOrigin }) {
   if (buildCommandOrigin !== undefined) {
     return getBuildCommandDescription(buildCommandOrigin)
   }
@@ -52,14 +52,14 @@ const getPluginFullName = function({ packageName, buildCommandOrigin }) {
   return `Plugin ${THEME.highlightWords(packageName)}`
 }
 
-const getDryColumnWidth = function(eventWidth, commandsCount) {
+const getDryColumnWidth = function (eventWidth, commandsCount) {
   const symbolsWidth = `${commandsCount}`.length + 4
   return Math.max(eventWidth + symbolsWidth, DRY_HEADER_NAMES[1].length)
 }
 
 const DRY_HEADER_NAMES = ['Event', 'Location']
 
-const logDryRunEnd = function(logs) {
+const logDryRunEnd = function (logs) {
   logMessage(logs, `\nIf this looks good to you, run \`netlify build\` to execute the build\n`)
 }
 

--- a/packages/build/src/log/messages/install.js
+++ b/packages/build/src/log/messages/install.js
@@ -1,12 +1,12 @@
 const { log, logMessage, logArray, logSubHeader, logErrorSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
-const logInstallMissingPlugins = function(logs, packages) {
+const logInstallMissingPlugins = function (logs, packages) {
   logSubHeader(logs, 'Installing plugins')
   logArray(logs, packages)
 }
 
-const logMissingPluginsWarning = function(logs, packages) {
+const logMissingPluginsWarning = function (logs, packages) {
   logErrorSubHeader(logs, 'Missing plugins')
   logMessage(
     logs,
@@ -17,17 +17,17 @@ const logMissingPluginsWarning = function(logs, packages) {
   logArray(logs, packages, { color: THEME.errorSubHeader })
 }
 
-const logInstallLocalPluginsDeps = function(logs, localPluginsOptions) {
+const logInstallLocalPluginsDeps = function (logs, localPluginsOptions) {
   const packages = localPluginsOptions.map(getPackageName)
   logSubHeader(logs, 'Installing local plugins dependencies')
   logArray(logs, packages)
 }
 
-const logInstallFunctionDependencies = function() {
+const logInstallFunctionDependencies = function () {
   log(undefined, 'Installing functions dependencies')
 }
 
-const getPackageName = function({ packageName }) {
+const getPackageName = function ({ packageName }) {
   return packageName
 }
 

--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -2,7 +2,7 @@ const { getPluginOrigin } = require('../description')
 const { log, logArray, logError, logSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
-const logLoadingPlugins = function(logs, pluginsOptions) {
+const logLoadingPlugins = function (logs, pluginsOptions) {
   const loadingPlugins = pluginsOptions.filter(isNotCorePlugin).map(getPluginDescription)
 
   if (loadingPlugins.length === 0) {
@@ -14,17 +14,17 @@ const logLoadingPlugins = function(logs, pluginsOptions) {
 }
 
 // We only logs plugins explicitly enabled by users
-const isNotCorePlugin = function({ origin }) {
+const isNotCorePlugin = function ({ origin }) {
   return origin !== 'core'
 }
 
-const getPluginDescription = function({ packageName, pluginPackageJson: { version }, loadedFrom, origin }) {
+const getPluginDescription = function ({ packageName, pluginPackageJson: { version }, loadedFrom, origin }) {
   const versionA = version === undefined ? '' : `@${version}`
   const pluginOrigin = getPluginOrigin(loadedFrom, origin)
   return `${THEME.highlightWords(packageName)}${versionA} ${pluginOrigin}`
 }
 
-const logFailPluginWarning = function(methodName, event) {
+const logFailPluginWarning = function (methodName, event) {
   logError(
     undefined,
     `Plugin error: since "${event}" happens after deploy, the build has already succeeded and cannot fail anymore. This plugin should either:
@@ -34,7 +34,7 @@ const logFailPluginWarning = function(methodName, event) {
 }
 
 // Print the list of Netlify Functions about to be bundled
-const logFunctionsToBundle = function(functions, FUNCTIONS_SRC) {
+const logFunctionsToBundle = function (functions, FUNCTIONS_SRC) {
   if (functions.length === 0) {
     log(undefined, `No Functions were found in ${THEME.highlightWords(FUNCTIONS_SRC)} directory`)
     return
@@ -44,7 +44,7 @@ const logFunctionsToBundle = function(functions, FUNCTIONS_SRC) {
   logArray(undefined, functions, { indent: false })
 }
 
-const logDeploySuccess = function() {
+const logDeploySuccess = function () {
   log(undefined, 'Site deploy was successfully initiated')
 }
 

--- a/packages/build/src/log/messages/status.js
+++ b/packages/build/src/log/messages/status.js
@@ -1,12 +1,12 @@
 const { logMessage, logHeader, logSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
-const logStatuses = function(logs, statuses) {
+const logStatuses = function (logs, statuses) {
   logHeader(logs, 'Summary')
-  statuses.forEach(status => logStatus(logs, status))
+  statuses.forEach((status) => logStatus(logs, status))
 }
 
-const logStatus = function(logs, { packageName, title = `Plugin ${packageName} ran successfully`, summary, text }) {
+const logStatus = function (logs, { packageName, title = `Plugin ${packageName} ran successfully`, summary, text }) {
   const titleA = title.includes(packageName) ? title : `${packageName}: ${title}`
   const body = text === undefined ? summary : `${summary}\n${THEME.dimWords(text)}`
   logSubHeader(logs, titleA)

--- a/packages/build/src/log/old_version.js
+++ b/packages/build/src/log/old_version.js
@@ -9,7 +9,7 @@ const corePackageJson = require('../../package.json')
 // We only print this when Netlify CLI has been used. Programmatic usage might
 // come from a deep dependency calling `@netlify/build` and user might not be
 // able to take any upgrade action, making the message noisy.
-const logOldCliVersionError = function({ mode, testOpts }) {
+const logOldCliVersionError = function ({ mode, testOpts }) {
   if (mode !== 'cli') {
     return
   }
@@ -21,7 +21,7 @@ const logOldCliVersionError = function({ mode, testOpts }) {
   })
 }
 
-const getCorePackageJson = function(testOpts) {
+const getCorePackageJson = function (testOpts) {
   // TODO: Find a way to test this without injecting code in the `src/`
   if (testOpts.oldCliLogs) {
     // `update-notifier` does not do anything if not in a TTY.

--- a/packages/build/src/log/serialize.js
+++ b/packages/build/src/log/serialize.js
@@ -1,14 +1,14 @@
 const { dump } = require('js-yaml')
 
-const serializeObject = function(object) {
+const serializeObject = function (object) {
   return dump(object, { noRefs: true, sortKeys: true, lineWidth: Infinity }).trimRight()
 }
 
-const serializeArray = function(array) {
+const serializeArray = function (array) {
   return array.map(addDash).join('\n')
 }
 
-const addDash = function(string) {
+const addDash = function (string) {
   return ` - ${string}`
 }
 

--- a/packages/build/src/log/stream.js
+++ b/packages/build/src/log/stream.js
@@ -7,7 +7,7 @@ const pSetTimeout = promisify(setTimeout)
 // which solves many problems. However we can only do it in build.command.
 // Plugins have several events, so need to be switch on and off instead.
 // In buffer mode (`logs` not `undefined`), `pipe` is necessary.
-const getBuildCommandStdio = function(logs) {
+const getBuildCommandStdio = function (logs) {
   if (logs !== undefined) {
     return 'pipe'
   }
@@ -16,7 +16,7 @@ const getBuildCommandStdio = function(logs) {
 }
 
 // Add build command output
-const handleBuildCommandOutput = function({ stdout, stderr }, logs) {
+const handleBuildCommandOutput = function ({ stdout, stderr }, logs) {
   if (logs === undefined) {
     return
   }
@@ -25,7 +25,7 @@ const handleBuildCommandOutput = function({ stdout, stderr }, logs) {
   pushBuildCommandOutput(stderr, logs.stderr)
 }
 
-const pushBuildCommandOutput = function(output, logsArray) {
+const pushBuildCommandOutput = function (output, logsArray) {
   if (output === '') {
     return
   }
@@ -34,7 +34,7 @@ const pushBuildCommandOutput = function(output, logsArray) {
 }
 
 // Start plugin command output
-const pipePluginOutput = function(childProcess, logs) {
+const pipePluginOutput = function (childProcess, logs) {
   if (logs === undefined) {
     return streamOutput(childProcess)
   }
@@ -43,7 +43,7 @@ const pipePluginOutput = function(childProcess, logs) {
 }
 
 // Stop streaming/buffering plugin command output
-const unpipePluginOutput = async function(childProcess, logs, listeners) {
+const unpipePluginOutput = async function (childProcess, logs, listeners) {
   // Let `childProcess` `stdout` and `stderr` flush before stopping redirecting
   await pSetTimeout(0)
 
@@ -55,18 +55,18 @@ const unpipePluginOutput = async function(childProcess, logs, listeners) {
 }
 
 // Usually, we stream stdout/stderr because it is more efficient
-const streamOutput = function(childProcess) {
+const streamOutput = function (childProcess) {
   childProcess.stdout.pipe(stdout)
   childProcess.stderr.pipe(stderr)
 }
 
-const unstreamOutput = function(childProcess) {
+const unstreamOutput = function (childProcess) {
   childProcess.stdout.unpipe(stdout)
   childProcess.stderr.unpipe(stderr)
 }
 
 // In tests, we push to the `logs` array instead
-const pushOutputToLogs = function(childProcess, logs) {
+const pushOutputToLogs = function (childProcess, logs) {
   const stdoutListener = logsListener.bind(null, logs.stdout)
   const stderrListener = logsListener.bind(null, logs.stderr)
   childProcess.stdout.on('data', stdoutListener)
@@ -74,11 +74,11 @@ const pushOutputToLogs = function(childProcess, logs) {
   return { stdoutListener, stderrListener }
 }
 
-const logsListener = function(logs, chunk) {
+const logsListener = function (logs, chunk) {
   logs.push(chunk.toString().trimRight())
 }
 
-const unpushOutputToLogs = function(childProcess, logs, { stdoutListener, stderrListener }) {
+const unpushOutputToLogs = function (childProcess, logs, { stdoutListener, stderrListener }) {
   childProcess.stdout.removeListener('data', stdoutListener)
   childProcess.stderr.removeListener('data', stderrListener)
 }

--- a/packages/build/src/log/theme.js
+++ b/packages/build/src/log/theme.js
@@ -26,7 +26,7 @@ const THEME = {
   // One of several words that should be dimmed inside a line
   dimWords: gray,
   // No colors
-  none: string => string,
+  none: (string) => string,
 }
 
 module.exports = { THEME }

--- a/packages/build/src/plugins/child/error.js
+++ b/packages/build/src/plugins/child/error.js
@@ -6,7 +6,7 @@ const { normalizeError } = require('../../error/parse/normalize')
 const { sendEventToParent } = require('../ipc')
 
 // Handle any top-level error and communicate it back to parent
-const handleError = async function(error) {
+const handleError = async function (error) {
   const errorA = normalizeError(error)
   const errorPayload = errorToJson(errorA, { type: 'pluginInternal' })
   await sendEventToParent('error', errorPayload)
@@ -14,11 +14,11 @@ const handleError = async function(error) {
 
 // On uncaught exceptions and unhandled rejections, print the stack trace.
 // Also, prevent child processes from crashing on uncaught exceptions.
-const handleProcessErrors = function() {
+const handleProcessErrors = function () {
   logProcessErrors({ log: handleProcessError, exitOn: [], level: { multipleResolves: 'silent' } })
 }
 
-const handleProcessError = async function(error, level, originalError) {
+const handleProcessError = async function (error, level, originalError) {
   if (level !== 'error') {
     console[level](error)
     return

--- a/packages/build/src/plugins/child/lazy.js
+++ b/packages/build/src/plugins/child/lazy.js
@@ -2,7 +2,7 @@ const memoizeOne = require('memoize-one')
 
 // Add a `object[propName]` whose value is the return value of `getFunc()`, but
 // is only retrieved when accessed.
-const addLazyProp = function(object, propName, getFunc) {
+const addLazyProp = function (object, propName, getFunc) {
   const mGetFunc = memoizeOne(getFunc, returnTrue)
   // Mutation is required due to the usage of `Object.defineProperty()`
   // eslint-disable-next-line fp/no-mutating-methods
@@ -13,7 +13,7 @@ const addLazyProp = function(object, propName, getFunc) {
   })
 }
 
-const returnTrue = function() {
+const returnTrue = function () {
   return true
 }
 

--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -6,7 +6,7 @@ const { validatePlugin } = require('./validate')
 // This also validates the plugin.
 // Do it when parent requests it using the `load` event.
 // Also figure out the list of plugin commands. This is also passed to the parent.
-const load = function({ pluginPath, inputs, constants, netlifyConfig }) {
+const load = function ({ pluginPath, inputs, constants, netlifyConfig }) {
   const logic = getLogic({ pluginPath, inputs })
 
   validatePlugin(logic)
@@ -19,13 +19,13 @@ const load = function({ pluginPath, inputs, constants, netlifyConfig }) {
   return { pluginCommands, context }
 }
 
-const getPluginCommands = function(logic) {
+const getPluginCommands = function (logic) {
   return Object.entries(logic)
     .filter(isEventHandler)
     .map(([event, method]) => ({ event, method }))
 }
 
-const isEventHandler = function([, value]) {
+const isEventHandler = function ([, value]) {
   return typeof value === 'function'
 }
 

--- a/packages/build/src/plugins/child/logic.js
+++ b/packages/build/src/plugins/child/logic.js
@@ -1,12 +1,12 @@
 // Require the plugin file and fire its top-level function.
 // The returned object is the `logic` which includes all event handlers.
-const getLogic = function({ pluginPath, inputs }) {
+const getLogic = function ({ pluginPath, inputs }) {
   const logic = requireLogic(pluginPath)
   const logicA = loadLogic({ logic, inputs })
   return logicA
 }
 
-const requireLogic = function(pluginPath) {
+const requireLogic = function (pluginPath) {
   try {
     // eslint-disable-next-line node/global-require
     return require(pluginPath)
@@ -16,7 +16,7 @@ const requireLogic = function(pluginPath) {
   }
 }
 
-const loadLogic = function({ logic, inputs }) {
+const loadLogic = function ({ logic, inputs }) {
   if (typeof logic !== 'function') {
     return logic
   }

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -8,7 +8,7 @@ const { load } = require('./load')
 const { run } = require('./run')
 
 // Boot plugin child process.
-const bootPlugin = async function() {
+const bootPlugin = async function () {
   try {
     handleProcessErrors()
     setInspectColors()
@@ -24,12 +24,12 @@ const bootPlugin = async function() {
 }
 
 // Wait for events from parent to perform plugin methods
-const handleEvents = async function(state) {
+const handleEvents = async function (state) {
   await getEventsFromParent((callId, eventName, payload) => handleEvent(callId, eventName, payload, state))
 }
 
 // Each event can pass `context` information to the next event
-const handleEvent = async function(callId, eventName, payload, state) {
+const handleEvent = async function (callId, eventName, payload, state) {
   try {
     const { context, ...response } = await EVENTS[eventName](payload, state.context)
     state.context = { ...state.context, ...context }

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -3,11 +3,11 @@ const { getNewEnvChanges, setEnvChanges } = require('../../env/changes.js')
 const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
-const run = async function(
+const run = async function (
   { event, events, error, envChanges, loadedFrom },
   { pluginCommands, constants, inputs, netlifyConfig },
 ) {
-  const { method } = pluginCommands.find(pluginCommand => pluginCommand.event === event)
+  const { method } = pluginCommands.find((pluginCommand) => pluginCommand.event === event)
   const runState = {}
   const utils = getUtils({ event, constants, runState })
   const runOptions = { utils, constants, inputs, netlifyConfig, error, events }
@@ -20,7 +20,7 @@ const run = async function(
 }
 
 // Remove any runOptions that is only intended for core plugins
-const cleanRunOptions = function({
+const cleanRunOptions = function ({
   loadedFrom,
   runOptions: {
     constants: { BUILDBOT_SERVER_SOCKET, ...constants },

--- a/packages/build/src/plugins/child/status.js
+++ b/packages/build/src/plugins/child/status.js
@@ -4,14 +4,14 @@ const mapObj = require('map-obj')
 const { addErrorInfo } = require('../../error/info')
 
 // Report status information to the UI
-const show = function(runState, showArgs) {
+const show = function (runState, showArgs) {
   validateShowArgs(showArgs)
   const { title, summary, text } = removeEmptyStrings(showArgs)
   runState.status = { state: 'success', title, summary, text }
 }
 
 // Validate arguments of `utils.status.show()`
-const validateShowArgs = function(showArgs) {
+const validateShowArgs = function (showArgs) {
   try {
     validateShowArgsObject(showArgs)
     const { title, summary, text, ...otherArgs } = showArgs
@@ -25,7 +25,7 @@ const validateShowArgs = function(showArgs) {
   }
 }
 
-const validateShowArgsObject = function(showArgs) {
+const validateShowArgsObject = function (showArgs) {
   if (showArgs === undefined) {
     throw new Error('requires an argument')
   }
@@ -35,30 +35,30 @@ const validateShowArgsObject = function(showArgs) {
   }
 }
 
-const validateShowArgsKeys = function(otherArgs) {
-  const otherKeys = Object.keys(otherArgs).map(arg => `"${arg}"`)
+const validateShowArgsKeys = function (otherArgs) {
+  const otherKeys = Object.keys(otherArgs).map((arg) => `"${arg}"`)
   if (otherKeys.length !== 0) {
     throw new Error(`must only contain "title", "summary" or "text" properties, not ${otherKeys.join(', ')}`)
   }
 }
 
-const validateStringArg = function([key, value]) {
+const validateStringArg = function ([key, value]) {
   if (value !== undefined && typeof value !== 'string') {
     throw new Error(`"${key}" property must be a string`)
   }
 }
 
-const validateShowArgsSummary = function(summary) {
+const validateShowArgsSummary = function (summary) {
   if (summary === undefined || summary.trim() === '') {
     throw new Error('requires specifying a "summary" property')
   }
 }
 
-const removeEmptyStrings = function(showArgs) {
+const removeEmptyStrings = function (showArgs) {
   return mapObj(showArgs, removeEmptyString)
 }
 
-const removeEmptyString = function(key, value) {
+const removeEmptyString = function (key, value) {
   if (typeof value === 'string' && value.trim() === '') {
     return [key]
   }

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -5,7 +5,7 @@ const { addLazyProp } = require('./lazy')
 const { show } = require('./status')
 
 // Retrieve the `utils` argument.
-const getUtils = function({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runState }) {
+const getUtils = function ({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runState }) {
   const build = getBuildUtils(event)
   const utils = { build }
   addLazyProp(utils, 'git', getGitUtils)
@@ -16,7 +16,7 @@ const getUtils = function({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runS
   return utils
 }
 
-const getBuildUtils = function(event) {
+const getBuildUtils = function (event) {
   if (isSoftFailEvent(event)) {
     return {
       failPlugin,
@@ -28,32 +28,32 @@ const getBuildUtils = function(event) {
   return { failBuild, failPlugin, cancelBuild }
 }
 
-const getGitUtils = function() {
+const getGitUtils = function () {
   // eslint-disable-next-line node/global-require
   return require('@netlify/git-utils')()
 }
 
-const getCacheUtils = function(CACHE_DIR) {
+const getCacheUtils = function (CACHE_DIR) {
   // eslint-disable-next-line node/global-require
   const cacheUtils = require('@netlify/cache-utils')
   return cacheUtils.bindOpts({ cacheDir: CACHE_DIR })
 }
 
-const getRunUtils = function() {
+const getRunUtils = function () {
   // eslint-disable-next-line node/global-require
   return require('@netlify/run-utils')
 }
 
-const getFunctionsUtils = function(FUNCTIONS_SRC) {
+const getFunctionsUtils = function (FUNCTIONS_SRC) {
   // eslint-disable-next-line node/global-require
   const functionsUtils = require('@netlify/functions-utils')
-  const add = src => functionsUtils.add(src, FUNCTIONS_SRC, { fail: failBuild })
+  const add = (src) => functionsUtils.add(src, FUNCTIONS_SRC, { fail: failBuild })
   const list = functionsUtils.list.bind(null, FUNCTIONS_SRC, { fail: failBuild })
   const listAll = functionsUtils.listAll.bind(null, FUNCTIONS_SRC, { fail: failBuild })
   return { add, list, listAll }
 }
 
-const getStatusUtils = function(runState) {
+const getStatusUtils = function (runState) {
   return { show: show.bind(undefined, runState) }
 }
 

--- a/packages/build/src/plugins/child/validate.js
+++ b/packages/build/src/plugins/child/validate.js
@@ -5,7 +5,7 @@ const { serializeArray } = require('../../log/serialize')
 const { EVENTS } = require('../events')
 
 // Validate the shape of a plugin return value
-const validatePlugin = function(logic) {
+const validatePlugin = function (logic) {
   try {
     if (!isPlainObj(logic)) {
       throw new Error('Plugin must be an object or a function')
@@ -19,7 +19,7 @@ const validatePlugin = function(logic) {
 }
 
 // All other properties are event handlers
-const validateEventHandler = function(value, propName) {
+const validateEventHandler = function (value, propName) {
   if (!EVENTS.includes(propName)) {
     throw new Error(`Invalid event '${propName}'.
 Please use a valid event name. One of:

--- a/packages/build/src/plugins/error.js
+++ b/packages/build/src/plugins/error.js
@@ -4,37 +4,37 @@ const { logFailPluginWarning } = require('../log/messages/plugins')
 // Stop build.
 // As opposed to throwing an error directly or to uncaught exceptions, this is
 // displayed as a user error, not an implementation error.
-const failBuild = function(message, opts) {
+const failBuild = function (message, opts) {
   throw normalizeError('failBuild', failBuild, message, opts)
 }
 
 // Stop plugin. Same as `failBuild` but only stops plugin not whole build
-const failPlugin = function(message, opts) {
+const failPlugin = function (message, opts) {
   throw normalizeError('failPlugin', failPlugin, message, opts)
 }
 
 // Cancel build. Same as `failBuild` except it marks the build as "canceled".
-const cancelBuild = function(message, opts) {
+const cancelBuild = function (message, opts) {
   throw normalizeError('cancelBuild', cancelBuild, message, opts)
 }
 
 // `onSuccess`, `onEnd` and `onError` cannot cancel the build since they are run
 // or might be run after deployment. When calling `failBuild()` or
 // `cancelBuild()`, `failPlugin()` is run instead and a warning is printed.
-const failPluginWithWarning = function(methodName, event, message, opts) {
+const failPluginWithWarning = function (methodName, event, message, opts) {
   logFailPluginWarning(methodName, event)
   failPlugin(message, opts)
 }
 
 // An `error` option can be passed to keep the original error message and
 // stack trace. An additional `message` string is always required.
-const normalizeError = function(type, func, message, { error } = {}) {
+const normalizeError = function (type, func, message, { error } = {}) {
   const errorA = getError(error, message, func)
   addErrorInfo(errorA, { type })
   return errorA
 }
 
-const getError = function(error, message, func) {
+const getError = function (error, message, func) {
   if (error instanceof Error) {
     error.message = `${message}\n${error.message}`
     return error

--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -10,7 +10,7 @@ const { addErrorInfo } = require('../error/info')
 // Send event from child to parent process then wait for response
 // We need to fire them in parallel because `process.send()` can be slow
 // to await, i.e. child might send response before parent start listening for it
-const callChild = async function(childProcess, eventName, payload, { plugin, location }) {
+const callChild = async function (childProcess, eventName, payload, { plugin, location }) {
   const callId = uuidv4()
   const [response] = await Promise.all([
     getEventFromChild(childProcess, callId, { plugin, location }),
@@ -27,7 +27,7 @@ const callChild = async function(childProcess, eventName, payload, { plugin, loc
 //  - child process `exit`
 // In the later two cases, we propagate the error.
 // We need to make `p-event` listeners are properly cleaned up too.
-const getEventFromChild = async function(childProcess, callId, { plugin, location }) {
+const getEventFromChild = async function (childProcess, callId, { plugin, location }) {
   if (childProcessHasExited(childProcess)) {
     throwChildExit('Could not receive event from child process because it already exited.', { plugin, location })
   }
@@ -48,22 +48,22 @@ const getEventFromChild = async function(childProcess, callId, { plugin, locatio
   }
 }
 
-const childProcessHasExited = function(childProcess) {
+const childProcessHasExited = function (childProcess) {
   return !childProcess.connected || childProcess.signalCode !== null || childProcess.exitCode !== null
 }
 
-const getMessage = async function(messagePromise) {
+const getMessage = async function (messagePromise) {
   const [, response] = await messagePromise
   return response
 }
 
-const getError = async function(errorPromise, { plugin, location }) {
+const getError = async function (errorPromise, { plugin, location }) {
   const [, error] = await errorPromise
   const errorA = jsonToError(error, { plugin, location })
   throw errorA
 }
 
-const getExit = async function(exitPromise, { plugin, location }) {
+const getExit = async function (exitPromise, { plugin, location }) {
   const [exitCode, signal] = await exitPromise
   throwChildExit(`Plugin exited with exit code ${exitCode} and signal ${signal}.`, { plugin, location })
 }
@@ -74,7 +74,7 @@ const getExit = async function(exitPromise, { plugin, location }) {
 //  - It complicates child process orchestration. For example if an async operation
 //    of a previous event handler is still running, it would be aborted if another
 //    is terminating the process.
-const throwChildExit = function(message, { plugin, location }) {
+const throwChildExit = function (message, { plugin, location }) {
   const error = new Error(`${message}\n${EXIT_WARNING}`)
   addErrorInfo(error, { type: 'ipc', plugin, location })
   throw error
@@ -87,16 +87,16 @@ Plugin methods should instead:
   - on failure: call utils.build.failPlugin() or utils.build.failBuild()`
 
 // Send event from parent to child process
-const sendEventToChild = async function(childProcess, callId, eventName, payload) {
+const sendEventToChild = async function (childProcess, callId, eventName, payload) {
   const payloadA = serializePayload(payload)
   await promisify(childProcess.send.bind(childProcess))([callId, eventName, payloadA])
 }
 
 // Respond to events from parent to child process.
 // This runs forever until `childProcess.kill()` is called.
-const getEventsFromParent = function(callback) {
+const getEventsFromParent = function (callback) {
   return new Promise((resolve, reject) => {
-    process.on('message', async message => {
+    process.on('message', async (message) => {
       try {
         const [callId, eventName, payload] = message
         const payloadA = parsePayload(payload)
@@ -109,7 +109,7 @@ const getEventsFromParent = function(callback) {
 }
 
 // Send event from child to parent process
-const sendEventToParent = async function(callId, payload) {
+const sendEventToParent = async function (callId, payload) {
   await promisify(process.send.bind(process))([callId, payload])
 }
 
@@ -117,7 +117,7 @@ const sendEventToParent = async function(callId, payload) {
 // convert from/to plain objects.
 // TODO: use `child_process.spawn()` `serialization: 'advanced'` option after
 // dropping support for Node.js <=12.6.0
-const serializePayload = function({ error = {}, error: { name } = {}, ...payload }) {
+const serializePayload = function ({ error = {}, error: { name } = {}, ...payload }) {
   if (name === undefined) {
     return payload
   }
@@ -126,7 +126,7 @@ const serializePayload = function({ error = {}, error: { name } = {}, ...payload
   return { ...payload, error: errorA }
 }
 
-const parsePayload = function({ error = {}, error: { name } = {}, ...payload }) {
+const parsePayload = function ({ error = {}, error: { name } = {}, ...payload }) {
   if (name === undefined) {
     return payload
   }

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -5,7 +5,7 @@ const { callChild } = require('./ipc')
 
 // Retrieve all plugins commands
 // Can use either a module name or a file path to the plugin.
-const tLoadPlugins = async function({ pluginsOptions, childProcesses, netlifyConfig, constants, debug }) {
+const tLoadPlugins = async function ({ pluginsOptions, childProcesses, netlifyConfig, constants, debug }) {
   const pluginsCommands = await Promise.all(
     pluginsOptions.map((pluginOptions, index) =>
       loadPlugin(pluginOptions, { childProcesses, index, netlifyConfig, constants, debug }),
@@ -19,7 +19,7 @@ const loadPlugins = measureDuration(tLoadPlugins, 'load_plugins')
 
 // Retrieve plugin commands for one plugin.
 // Do it by executing the plugin `load` event handler.
-const loadPlugin = async function(
+const loadPlugin = async function (
   { packageName, pluginPackageJson, pluginPackageJson: { version } = {}, pluginPath, inputs, loadedFrom, origin },
   { childProcesses, index, netlifyConfig, constants, debug },
 ) {

--- a/packages/build/src/plugins/manifest/check.js
+++ b/packages/build/src/plugins/manifest/check.js
@@ -4,7 +4,7 @@ const { THEME } = require('../../log/theme')
 
 // Check that plugin inputs match the validation specified in "manifest.yml"
 // Also assign default values
-const checkInputs = function({
+const checkInputs = function ({
   inputs,
   manifest: { inputs: rules = [] },
   packageName,
@@ -27,22 +27,22 @@ ${serializeObject(inputs)}`
 }
 
 // Add "inputs[*].default"
-const addDefaults = function(inputs, rules) {
+const addDefaults = function (inputs, rules) {
   const defaults = rules.filter(hasDefault).map(getDefault)
   return Object.assign({}, ...defaults, inputs)
 }
 
-const hasDefault = function(rule) {
+const hasDefault = function (rule) {
   return rule.default !== undefined
 }
 
-const getDefault = function({ name, default: defaultValue }) {
+const getDefault = function ({ name, default: defaultValue }) {
   return { [name]: defaultValue }
 }
 
 // Check "inputs[*].required"
-const checkRequiredInputs = function({ inputs, rules, packageName, pluginPackageJson, loadedFrom, origin }) {
-  const missingInputs = rules.filter(rule => isMissingRequired(inputs, rule))
+const checkRequiredInputs = function ({ inputs, rules, packageName, pluginPackageJson, loadedFrom, origin }) {
+  const missingInputs = rules.filter((rule) => isMissingRequired(inputs, rule))
   if (missingInputs.length === 0) {
     return
   }
@@ -53,18 +53,18 @@ const checkRequiredInputs = function({ inputs, rules, packageName, pluginPackage
   throw error
 }
 
-const isMissingRequired = function(inputs, { name, required }) {
+const isMissingRequired = function (inputs, { name, required }) {
   return required && inputs[name] === undefined
 }
 
-const getName = function({ name }) {
+const getName = function ({ name }) {
   return name
 }
 
 // Check each "inputs[*].*" property for a specific input
-const checkUnknownInputs = function({ inputs, rules, packageName, pluginPackageJson, loadedFrom, origin }) {
+const checkUnknownInputs = function ({ inputs, rules, packageName, pluginPackageJson, loadedFrom, origin }) {
   const knownInputs = rules.map(getName)
-  const unknownInputs = Object.keys(inputs).filter(name => !knownInputs.includes(name))
+  const unknownInputs = Object.keys(inputs).filter((name) => !knownInputs.includes(name))
   if (unknownInputs.length === 0) {
     return
   }
@@ -80,7 +80,7 @@ Check your plugin configuration to be sure that:
   throw error
 }
 
-const getUnknownInputsMessage = function({ packageName, knownInputs, unknownInputs }) {
+const getUnknownInputsMessage = function ({ packageName, knownInputs, unknownInputs }) {
   const unknownInputsStr = unknownInputs.map(quoteWord).join(', ')
 
   if (knownInputs.length === 0) {
@@ -92,12 +92,12 @@ const getUnknownInputsMessage = function({ packageName, knownInputs, unknownInpu
 Plugin inputs should be one of: ${knownInputsStr}`
 }
 
-const quoteWord = function(word) {
+const quoteWord = function (word) {
   return `"${word}"`
 }
 
 // Add error information
-const addInputError = function({ error, name, packageName, pluginPackageJson, loadedFrom, origin }) {
+const addInputError = function ({ error, name, packageName, pluginPackageJson, loadedFrom, origin }) {
   addErrorInfo(error, {
     type: 'pluginInput',
     plugin: { packageName, pluginPackageJson },

--- a/packages/build/src/plugins/manifest/load.js
+++ b/packages/build/src/plugins/manifest/load.js
@@ -10,7 +10,7 @@ const { validateManifest } = require('./validate')
 const pReadFile = promisify(readFile)
 
 // Load "manifest.yml" using its file path
-const loadManifest = async function({ manifestPath, packageName, pluginPackageJson, loadedFrom, origin }) {
+const loadManifest = async function ({ manifestPath, packageName, pluginPackageJson, loadedFrom, origin }) {
   try {
     if (manifestPath === undefined) {
       throw new Error(
@@ -33,7 +33,7 @@ Please see the documentation at https://github.com/netlify/build#anatomy-of-a-pl
   }
 }
 
-const loadRawManifest = async function(manifestPath) {
+const loadRawManifest = async function (manifestPath) {
   try {
     return await pReadFile(manifestPath, 'utf8')
   } catch (error) {
@@ -42,7 +42,7 @@ const loadRawManifest = async function(manifestPath) {
   }
 }
 
-const parseManifest = async function(rawManifest) {
+const parseManifest = async function (rawManifest) {
   try {
     return await loadYaml(rawManifest, { schema: JSON_SCHEMA, json: true })
   } catch (error) {

--- a/packages/build/src/plugins/manifest/main.js
+++ b/packages/build/src/plugins/manifest/main.js
@@ -5,7 +5,7 @@ const { loadManifest } = require('./load')
 const { getManifestPath } = require('./path')
 
 // Load plugin's `manifest.yml`
-const useManifest = async function(
+const useManifest = async function (
   { packageName, loadedFrom, origin, inputs },
   { pluginDir, packageDir, pluginPackageJson, pluginPackageJson: { version }, debug },
 ) {

--- a/packages/build/src/plugins/manifest/path.js
+++ b/packages/build/src/plugins/manifest/path.js
@@ -1,8 +1,8 @@
 const locatePath = require('locate-path')
 
 // Retrieve "manifest.yml" path for a specific plugin
-const getManifestPath = async function(pluginDir, packageDir) {
-  const dirs = [pluginDir, packageDir].filter(Boolean).map(dir => `${dir}/${MANIFEST_FILENAME}`)
+const getManifestPath = async function (pluginDir, packageDir) {
+  const dirs = [pluginDir, packageDir].filter(Boolean).map((dir) => `${dir}/${MANIFEST_FILENAME}`)
   const manifestPath = await locatePath(dirs)
   return manifestPath
 }

--- a/packages/build/src/plugins/manifest/validate.js
+++ b/packages/build/src/plugins/manifest/validate.js
@@ -3,7 +3,7 @@ const isPlainObj = require('is-plain-obj')
 const { THEME } = require('../../log/theme')
 
 // Validate `manifest.yml` syntax
-const validateManifest = function(manifest, rawManifest) {
+const validateManifest = function (manifest, rawManifest) {
   try {
     validateBasic(manifest)
     validateUnknownProps(manifest)
@@ -18,14 +18,14 @@ ${rawManifest.trim()}`
   }
 }
 
-const validateBasic = function(manifest) {
+const validateBasic = function (manifest) {
   if (!isPlainObj(manifest)) {
     throw new Error('must be a plain object')
   }
 }
 
-const validateUnknownProps = function(manifest) {
-  const unknownProp = Object.keys(manifest).find(key => !VALID_PROPS.has(key))
+const validateUnknownProps = function (manifest) {
+  const unknownProp = Object.keys(manifest).find((key) => !VALID_PROPS.has(key))
   if (unknownProp !== undefined) {
     throw new Error(`unknown property "${unknownProp}"`)
   }
@@ -33,7 +33,7 @@ const validateUnknownProps = function(manifest) {
 
 const VALID_PROPS = new Set(['name', 'inputs'])
 
-const validateName = function({ name }) {
+const validateName = function ({ name }) {
   if (name === undefined) {
     throw new Error('must contain a "name" property')
   }
@@ -43,7 +43,7 @@ const validateName = function({ name }) {
   }
 }
 
-const validateInputs = function({ inputs }) {
+const validateInputs = function ({ inputs }) {
   if (inputs === undefined) {
     return
   }
@@ -55,11 +55,11 @@ const validateInputs = function({ inputs }) {
   inputs.forEach(validateInput)
 }
 
-const isArrayOfObjects = function(objects) {
+const isArrayOfObjects = function (objects) {
   return Array.isArray(objects) && objects.every(isPlainObj)
 }
 
-const validateInput = function(input, index) {
+const validateInput = function (input, index) {
   try {
     validateUnknownInputProps(input)
     validateInputName(input)
@@ -72,8 +72,8 @@ Input at position ${index} ${error.message}.`
   }
 }
 
-const validateUnknownInputProps = function(input) {
-  const unknownProp = Object.keys(input).find(key => !VALID_INPUT_PROPS.has(key))
+const validateUnknownInputProps = function (input) {
+  const unknownProp = Object.keys(input).find((key) => !VALID_INPUT_PROPS.has(key))
   if (unknownProp !== undefined) {
     throw new Error(`has an unknown property "${unknownProp}"`)
   }
@@ -81,7 +81,7 @@ const validateUnknownInputProps = function(input) {
 
 const VALID_INPUT_PROPS = new Set(['name', 'description', 'required', 'default'])
 
-const validateInputName = function({ name }) {
+const validateInputName = function ({ name }) {
   if (name === undefined) {
     throw new Error('must contain a "name" property')
   }
@@ -91,7 +91,7 @@ const validateInputName = function({ name }) {
   }
 }
 
-const validateInputDescription = function({ description }) {
+const validateInputDescription = function ({ description }) {
   if (description === undefined) {
     return
   }
@@ -101,7 +101,7 @@ const validateInputDescription = function({ description }) {
   }
 }
 
-const validateInputRequired = function({ required }) {
+const validateInputRequired = function ({ required }) {
   if (required !== undefined && typeof required !== 'boolean') {
     throw new Error('"required" property must be a boolean')
   }

--- a/packages/build/src/plugins/node_version.js
+++ b/packages/build/src/plugins/node_version.js
@@ -9,7 +9,7 @@ const {
 const { addErrorInfo } = require('../error/info')
 
 // Retrieve Node.js version from `--node-path`
-const getUserNodeVersion = async function(nodePath) {
+const getUserNodeVersion = async function (nodePath) {
   // No `--node-path` CLI flag
   if (nodePath === execPath) {
     return getCurrentNodeVersion()
@@ -34,12 +34,12 @@ const getUserNodeVersion = async function(nodePath) {
 const NVM_NODE_VERSION_REGEXP = /[/\\]v(\d+\.\d+\.\d+)[/\\](bin[/\\]node|node.exe)$/
 
 // Retrieve Node.js version from current process
-const getCurrentNodeVersion = function() {
+const getCurrentNodeVersion = function () {
   return cleanVersion(currentVersion)
 }
 
 // Ensure Node.js version is recent enough to run this plugin
-const checkNodeVersion = function({
+const checkNodeVersion = function ({
   childNodeVersion,
   packageName,
   pluginPackageJson: { engines: { node: pluginNodeVersionRange } = {} } = {},
@@ -65,7 +65,7 @@ const checkNodeVersion = function({
   }
 }
 
-const throwUserError = function(message) {
+const throwUserError = function (message) {
   const error = new Error(message)
   addErrorInfo(error, { type: 'resolveConfig' })
   throw error

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -11,7 +11,7 @@ const { resolvePluginsPath } = require('./resolve')
 
 // Load plugin options (specified by user in `config.plugins`)
 // Do not allow user override of core plugins
-const tGetPluginsOptions = async function({
+const tGetPluginsOptions = async function ({
   netlifyConfig: { plugins },
   buildDir,
   constants,
@@ -23,14 +23,14 @@ const tGetPluginsOptions = async function({
 }) {
   const corePlugins = await getCorePlugins({ constants, buildDir, featureFlags })
   const allCorePlugins = corePlugins
-    .map(corePlugin => addCoreProperties(corePlugin, plugins))
-    .filter(corePlugin => !isOptionalCore(corePlugin, plugins))
+    .map((corePlugin) => addCoreProperties(corePlugin, plugins))
+    .filter((corePlugin) => !isOptionalCore(corePlugin, plugins))
   const userPlugins = plugins.filter(isUserPlugin)
   const allPlugins = [...userPlugins, ...allCorePlugins]
   const pluginsOptions = allPlugins.map(normalizePluginOptions)
   const pluginsOptionsA = await resolvePluginsPath({ pluginsOptions, buildDir, mode, logs, buildImagePluginsDir })
   const pluginsOptionsB = await Promise.all(
-    pluginsOptionsA.map(pluginOptions => loadPluginFiles({ pluginOptions, debug })),
+    pluginsOptionsA.map((pluginOptions) => loadPluginFiles({ pluginOptions, debug })),
   )
   const pluginsOptionsC = pluginsOptionsB.filter(isNotRedundantCorePlugin)
   await installLocalPluginsDependencies({ plugins, pluginsOptions: pluginsOptionsC, buildDir, mode, logs })
@@ -39,14 +39,14 @@ const tGetPluginsOptions = async function({
 
 const getPluginsOptions = measureDuration(tGetPluginsOptions, 'get_plugins_options')
 
-const addCoreProperties = function(corePlugin, plugins) {
+const addCoreProperties = function (corePlugin, plugins) {
   const inputs = getCorePluginInputs(corePlugin, plugins)
   return { ...corePlugin, inputs, loadedFrom: 'core', origin: 'core' }
 }
 
 // Core plugins can get inputs too
-const getCorePluginInputs = function(corePlugin, plugins) {
-  const configuredCorePlugin = plugins.find(plugin => plugin.package === corePlugin.package)
+const getCorePluginInputs = function (corePlugin, plugins) {
+  const configuredCorePlugin = plugins.find((plugin) => plugin.package === corePlugin.package)
   if (configuredCorePlugin === undefined) {
     return {}
   }
@@ -55,21 +55,21 @@ const getCorePluginInputs = function(corePlugin, plugins) {
 }
 
 // Optional core plugins requires user opt-in
-const isOptionalCore = function(pluginA, plugins) {
-  return pluginA.optional && plugins.every(pluginB => pluginB.package !== pluginA.package)
+const isOptionalCore = function (pluginA, plugins) {
+  return pluginA.optional && plugins.every((pluginB) => pluginB.package !== pluginA.package)
 }
 
-const isUserPlugin = function(plugin) {
+const isUserPlugin = function (plugin) {
   return !isCorePlugin(plugin.package)
 }
 
-const normalizePluginOptions = function({ package: packageName, pluginPath, loadedFrom, origin, inputs }) {
+const normalizePluginOptions = function ({ package: packageName, pluginPath, loadedFrom, origin, inputs }) {
   return { packageName, pluginPath, loadedFrom, origin, inputs }
 }
 
 // Retrieve plugin's main file path.
 // Then load plugin's `package.json` and `manifest.yml`.
-const loadPluginFiles = async function({ pluginOptions: { pluginPath, ...pluginOptions }, debug }) {
+const loadPluginFiles = async function ({ pluginOptions: { pluginPath, ...pluginOptions }, debug }) {
   const pluginDir = dirname(pluginPath)
   const { packageDir, packageJson: pluginPackageJson } = await getPackageJson(pluginDir)
   const { manifest, inputs } = await useManifest(pluginOptions, { pluginDir, packageDir, pluginPackageJson, debug })
@@ -79,11 +79,11 @@ const loadPluginFiles = async function({ pluginOptions: { pluginPath, ...pluginO
 // Core plugins can only be included once.
 // For example, when testing core plugins, they might be included as local plugins,
 // in which case they should not be included twice.
-const isNotRedundantCorePlugin = function(pluginOptionsA, index, pluginsOptions) {
+const isNotRedundantCorePlugin = function (pluginOptionsA, index, pluginsOptions) {
   return (
     pluginOptionsA.loadedFrom !== 'core' ||
     pluginsOptions.every(
-      pluginOptionsB =>
+      (pluginOptionsB) =>
         pluginOptionsA.manifest.name !== pluginOptionsB.manifest.name || pluginOptionsA === pluginOptionsB,
     )
   )
@@ -91,7 +91,7 @@ const isNotRedundantCorePlugin = function(pluginOptionsA, index, pluginsOptions)
 
 // Retrieve information about @netlify/build when an error happens there and not
 // in a plugin
-const getSpawnInfo = function() {
+const getSpawnInfo = function () {
   const { name } = corePackageJson
   return {
     plugin: { packageName: name, pluginPackageJson: corePackageJson },

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -10,9 +10,9 @@ const { resolvePath } = require('../utils/resolve')
 //  - external plugin already installed in `node_modules`, most likely through `package.json`
 //  - cached in the build image
 //  - automatically installed by us (fallback)
-const resolvePluginsPath = async function({ pluginsOptions, buildDir, mode, logs, buildImagePluginsDir }) {
+const resolvePluginsPath = async function ({ pluginsOptions, buildDir, mode, logs, buildImagePluginsDir }) {
   const pluginsOptionsA = await Promise.all(
-    pluginsOptions.map(pluginOptions => resolvePluginPath({ pluginOptions, buildDir, buildImagePluginsDir })),
+    pluginsOptions.map((pluginOptions) => resolvePluginPath({ pluginOptions, buildDir, buildImagePluginsDir })),
   )
   const pluginsOptionsB = await handleMissingPlugins({
     pluginsOptions: pluginsOptionsA,
@@ -24,7 +24,7 @@ const resolvePluginsPath = async function({ pluginsOptions, buildDir, mode, logs
   return pluginsOptionsB
 }
 
-const resolvePluginPath = async function({
+const resolvePluginPath = async function ({
   pluginOptions,
   pluginOptions: { packageName, loadedFrom },
   buildDir,
@@ -61,7 +61,7 @@ const resolvePluginPath = async function({
 }
 
 // `packageName` starting with `/` are relative to the build directory
-const resolvePackagePath = function(packageName) {
+const resolvePackagePath = function (packageName) {
   if (packageName.startsWith('/')) {
     return `.${packageName}`
   }
@@ -70,7 +70,7 @@ const resolvePackagePath = function(packageName) {
 }
 
 // Try to `resolve()` a local plugin
-const tryLocalPath = async function(packageName, baseDir) {
+const tryLocalPath = async function (packageName, baseDir) {
   try {
     return await resolvePath(packageName, baseDir)
   } catch (error) {
@@ -82,7 +82,7 @@ const tryLocalPath = async function(packageName, baseDir) {
 
 // In production, we pre-install most Build plugins to that directory, for
 // performance reasons
-const tryBuildImagePath = async function({ packageName, buildDir, buildImagePluginsDir }) {
+const tryBuildImagePath = async function ({ packageName, buildDir, buildImagePluginsDir }) {
   if (buildImagePluginsDir === undefined) {
     return
   }
@@ -96,7 +96,7 @@ const tryBuildImagePath = async function({ packageName, buildDir, buildImagePlug
 }
 
 // Try to `resolve()` the plugin from the build directory
-const tryResolvePath = async function(packageName, baseDir) {
+const tryResolvePath = async function (packageName, baseDir) {
   try {
     return await resolvePath(packageName, baseDir)
   } catch (error) {}
@@ -104,18 +104,18 @@ const tryResolvePath = async function(packageName, baseDir) {
 
 // Handle plugins that were neither local, in the build image cache nor in
 // node_modules. We automatically install those, with a warning.
-const handleMissingPlugins = async function({ pluginsOptions, buildDir, mode, buildImagePluginsDir, logs }) {
+const handleMissingPlugins = async function ({ pluginsOptions, buildDir, mode, buildImagePluginsDir, logs }) {
   const autoPluginsDir = getAutoPluginsDirPath(buildDir)
   await installMissingPlugins({ pluginsOptions, autoPluginsDir, mode, logs })
   const pluginsOptionsA = await Promise.all(
-    pluginsOptions.map(pluginOptions => resolveMissingPluginPath({ pluginOptions, autoPluginsDir })),
+    pluginsOptions.map((pluginOptions) => resolveMissingPluginPath({ pluginOptions, autoPluginsDir })),
   )
   warnOnMissingPlugins({ pluginsOptions: pluginsOptionsA, buildImagePluginsDir, logs })
   return pluginsOptionsA
 }
 
 // Resolve the plugins that just got automatically installed
-const resolveMissingPluginPath = async function({
+const resolveMissingPluginPath = async function ({
   pluginOptions,
   pluginOptions: { packageName, pluginPath },
   autoPluginsDir,

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -17,7 +17,7 @@ const CHILD_MAIN_FILE = `${__dirname}/child/main.js`
 //    (for both security and safety reasons)
 //  - logs can be buffered which allows manipulating them for log shipping,
 //    transforming and parallel plugins
-const tStartPlugins = async function({ pluginsOptions, buildDir, nodePath, childEnv, mode, logs }) {
+const tStartPlugins = async function ({ pluginsOptions, buildDir, nodePath, childEnv, mode, logs }) {
   logLoadingPlugins(logs, pluginsOptions)
 
   const spawnInfo = getSpawnInfo()
@@ -43,7 +43,7 @@ const tStartPlugins = async function({ pluginsOptions, buildDir, nodePath, child
 
 const startPlugins = measureDuration(tStartPlugins, 'start_plugins')
 
-const startPlugin = async function({
+const startPlugin = async function ({
   buildDir,
   nodePath,
   childEnv,
@@ -75,7 +75,7 @@ const startPlugin = async function({
 // Local plugins, `package.json`-installed plugins and local builds use user's
 // preferred Node.js version.
 // Other plugins use `@netlify/build` Node.js version.
-const getChildNodePath = function({ loadedFrom, nodePath, userNodeVersion, mode }) {
+const getChildNodePath = function ({ loadedFrom, nodePath, userNodeVersion, mode }) {
   if (loadedFrom === 'local' || loadedFrom === 'package.json' || (loadedFrom !== 'core' && mode !== 'buildbot')) {
     return { childNodePath: nodePath, childNodeVersion: userNodeVersion }
   }
@@ -84,11 +84,11 @@ const getChildNodePath = function({ loadedFrom, nodePath, userNodeVersion, mode 
 }
 
 // Stop all plugins child processes
-const stopPlugins = function(childProcesses) {
+const stopPlugins = function (childProcesses) {
   childProcesses.forEach(stopPlugin)
 }
 
-const stopPlugin = function({ childProcess }) {
+const stopPlugin = function ({ childProcess }) {
   if (childProcess.connected) {
     childProcess.disconnect()
   }

--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -7,14 +7,14 @@ const { isDirectory } = require('path-type')
 const { runsAfterDeploy } = require('../../commands/get')
 const { addAsyncErrorMessage } = require('../../utils/errors')
 
-const createBuildbotClient = function(BUILDBOT_SERVER_SOCKET) {
+const createBuildbotClient = function (BUILDBOT_SERVER_SOCKET) {
   const connectionOpts = getConnectionOpts(BUILDBOT_SERVER_SOCKET)
   const client = net.createConnection(connectionOpts)
   return client
 }
 
 // Windows does not support Unix sockets well, so we also support `host:port`
-const getConnectionOpts = function(BUILDBOT_SERVER_SOCKET) {
+const getConnectionOpts = function (BUILDBOT_SERVER_SOCKET) {
   if (!BUILDBOT_SERVER_SOCKET.includes(':')) {
     return { path: BUILDBOT_SERVER_SOCKET }
   }
@@ -23,13 +23,13 @@ const getConnectionOpts = function(BUILDBOT_SERVER_SOCKET) {
   return { host, port }
 }
 
-const eConnectBuildbotClient = async function(client) {
+const eConnectBuildbotClient = async function (client) {
   await pEvent(client, 'connect')
 }
 
 const connectBuildbotClient = addAsyncErrorMessage(eConnectBuildbotClient, 'Could not connect to buildbot')
 
-const closeBuildbotClient = async function(client) {
+const closeBuildbotClient = async function (client) {
   if (client.destroyed) {
     return
   }
@@ -37,13 +37,13 @@ const closeBuildbotClient = async function(client) {
   await promisify(client.end.bind(client))()
 }
 
-const cWritePayload = async function(buildbotClient, payload) {
+const cWritePayload = async function (buildbotClient, payload) {
   await promisify(buildbotClient.write.bind(buildbotClient))(JSON.stringify(payload))
 }
 
 const writePayload = addAsyncErrorMessage(cWritePayload, 'Could not send payload to buildbot')
 
-const cGetNextParsedResponsePromise = async function(buildbotClient) {
+const cGetNextParsedResponsePromise = async function (buildbotClient) {
   const data = await pEvent(buildbotClient, 'data')
   return JSON.parse(data)
 }
@@ -53,7 +53,7 @@ const getNextParsedResponsePromise = addAsyncErrorMessage(
   'Invalid response from buildbot',
 )
 
-const deploySiteWithBuildbotClient = async function({ client, events, PUBLISH_DIR, failBuild }) {
+const deploySiteWithBuildbotClient = async function ({ client, events, PUBLISH_DIR, failBuild }) {
   if (!(await isDirectory(PUBLISH_DIR))) {
     return failBuild(`Publish directory does not exist: ${PUBLISH_DIR}`)
   }
@@ -72,7 +72,7 @@ const deploySiteWithBuildbotClient = async function({ client, events, PUBLISH_DI
 }
 
 // We distinguish between user errors and system errors during deploys
-const handleDeployError = function({ error, errorType, failBuild }) {
+const handleDeployError = function ({ error, errorType, failBuild }) {
   const errorMessage = `Deploy did not succeed: ${error}`
 
   if (errorType === 'user') {
@@ -84,11 +84,11 @@ const handleDeployError = function({ error, errorType, failBuild }) {
 
 // We only wait for post-processing (last stage before site deploy) if the build
 // has some plugins that do post-deploy logic
-const shouldWaitForPostProcessing = function(events) {
+const shouldWaitForPostProcessing = function (events) {
   return events.some(hasPostDeployLogic)
 }
 
-const hasPostDeployLogic = function(event) {
+const hasPostDeployLogic = function (event) {
   return runsAfterDeploy(event)
 }
 

--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -7,7 +7,7 @@ const {
   deploySiteWithBuildbotClient,
 } = require('./buildbot_client')
 
-const onPostBuild = async function({
+const onPostBuild = async function ({
   constants: { BUILDBOT_SERVER_SOCKET, PUBLISH_DIR },
   events,
   utils: {

--- a/packages/build/src/plugins_core/functions/error.js
+++ b/packages/build/src/plugins_core/functions/error.js
@@ -1,7 +1,7 @@
 const readdirp = require('readdirp')
 
 // Handle errors coming from zip-it-and-ship-it
-const getZipError = async function(error, FUNCTIONS_SRC) {
+const getZipError = async function (error, FUNCTIONS_SRC) {
   if (await isModuleNotFound(error, FUNCTIONS_SRC)) {
     return getModuleNotFoundError(error)
   }
@@ -11,7 +11,7 @@ const getZipError = async function(error, FUNCTIONS_SRC) {
 
 // A common mistake is to assume Netlify Functions dependencies are
 // automatically installed. This checks for this pattern.
-const isModuleNotFound = async function(error, FUNCTIONS_SRC) {
+const isModuleNotFound = async function (error, FUNCTIONS_SRC) {
   return (
     error instanceof Error &&
     error.code === MODULE_NOT_FOUND_CODE &&
@@ -23,7 +23,7 @@ const isModuleNotFound = async function(error, FUNCTIONS_SRC) {
 const MODULE_NOT_FOUND_CODE = 'MODULE_NOT_FOUND'
 
 // Netlify Functions has a `package.json` but no `node_modules`
-const lacksNodeModules = async function(FUNCTIONS_SRC) {
+const lacksNodeModules = async function (FUNCTIONS_SRC) {
   return (
     (await hasFunctionRootFile('package.json', FUNCTIONS_SRC)) &&
     !(await hasFunctionRootFile('node_modules', FUNCTIONS_SRC))
@@ -32,19 +32,19 @@ const lacksNodeModules = async function(FUNCTIONS_SRC) {
 
 // Functions can be either files or directories, so we need to check on two
 // depth levels
-const hasFunctionRootFile = async function(filename, FUNCTIONS_SRC) {
+const hasFunctionRootFile = async function (filename, FUNCTIONS_SRC) {
   const files = await readdirp.promise(FUNCTIONS_SRC, { depth: 1, fileFilter: filename })
   return files.length !== 0
 }
 
-const getModuleNotFoundError = function(error) {
+const getModuleNotFoundError = function (error) {
   const moduleName = getModuleName(error)
   error.message = `${getWarning(moduleName)}\n${error.message}`
   return error
 }
 
 // This error message always include the same words
-const getModuleName = function(error) {
+const getModuleName = function (error) {
   if (typeof error.message !== 'string') {
     return
   }
@@ -59,7 +59,7 @@ const getModuleName = function(error) {
 
 const MODULE_NOT_FOUND_REGEXP = /Cannot find module '(@[^'/]+\/[^'/]+|[^.'/][^'/]*)/
 
-const getWarning = function(moduleName) {
+const getWarning = function (moduleName) {
   return `A Netlify Function is using "${moduleName}" but that dependency has not been installed yet.
 
 By default, dependencies inside a Netlify Function's "package.json" are not automatically installed.

--- a/packages/build/src/plugins_core/functions/index.js
+++ b/packages/build/src/plugins_core/functions/index.js
@@ -9,7 +9,7 @@ const { logFunctionsToBundle } = require('../../log/messages/plugins')
 const { getZipError } = require('./error')
 
 // Plugin to package Netlify functions with @netlify/zip-it-and-ship-it
-const onBuild = async function({
+const onBuild = async function ({
   constants: { FUNCTIONS_SRC, FUNCTIONS_DIST },
   utils: {
     build: { failBuild },
@@ -40,7 +40,7 @@ const onBuild = async function({
   }
 }
 
-const getFunctionPaths = async function(FUNCTIONS_SRC) {
+const getFunctionPaths = async function (FUNCTIONS_SRC) {
   const functions = await listFunctions(FUNCTIONS_SRC)
   return functions.map(({ mainFile }) => relative(FUNCTIONS_SRC, mainFile))
 }

--- a/packages/build/src/plugins_core/functions_install/index.js
+++ b/packages/build/src/plugins_core/functions_install/index.js
@@ -3,7 +3,7 @@ const pathExists = require('path-exists')
 const { installFunctionDependencies } = require('../../install/functions')
 
 // Plugin to package Netlify functions with @netlify/zip-it-and-ship-it
-const onPreBuild = async function({ constants: { FUNCTIONS_SRC, IS_LOCAL } }) {
+const onPreBuild = async function ({ constants: { FUNCTIONS_SRC, IS_LOCAL } }) {
   if (!(await pathExists(FUNCTIONS_SRC))) {
     return
   }

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -22,7 +22,7 @@ const CORE_PLUGINS = new Set([
 const EDGE_HANDLERS_PLUGIN_PATH = require.resolve(EDGE_HANDLERS_PLUGIN_NAME)
 
 // Plugins that are installed and enabled by default
-const getCorePlugins = async function({
+const getCorePlugins = async function ({
   constants: { FUNCTIONS_SRC, EDGE_HANDLERS_SRC, BUILDBOT_SERVER_SOCKET },
   buildDir,
   featureFlags,
@@ -39,7 +39,7 @@ const getCorePlugins = async function({
 // However when it is defined but points to a non-existing directory, this
 // might mean the directory is created later one, so we cannot do that check
 // yet.
-const getFunctionsPlugin = function(FUNCTIONS_SRC) {
+const getFunctionsPlugin = function (FUNCTIONS_SRC) {
   if (FUNCTIONS_SRC === undefined) {
     return
   }
@@ -47,7 +47,7 @@ const getFunctionsPlugin = function(FUNCTIONS_SRC) {
   return { package: FUNCTIONS_PLUGIN_NAME, pluginPath: FUNCTIONS_PLUGIN }
 }
 
-const getFunctionsInstallPlugin = function(FUNCTIONS_SRC) {
+const getFunctionsInstallPlugin = function (FUNCTIONS_SRC) {
   if (FUNCTIONS_SRC === undefined) {
     return
   }
@@ -55,7 +55,7 @@ const getFunctionsInstallPlugin = function(FUNCTIONS_SRC) {
   return { package: FUNCTIONS_INSTALL_PLUGIN_NAME, pluginPath: FUNCTIONS_INSTALL_PLUGIN, optional: true }
 }
 
-const getEdgeHandlersPlugin = async function({ buildDir, EDGE_HANDLERS_SRC }) {
+const getEdgeHandlersPlugin = async function ({ buildDir, EDGE_HANDLERS_SRC }) {
   if (!(await usesEdgeHandlers({ buildDir, EDGE_HANDLERS_SRC }))) {
     return
   }
@@ -67,11 +67,11 @@ const getEdgeHandlersPlugin = async function({ buildDir, EDGE_HANDLERS_SRC }) {
 // directory.
 // The location can be overridden using the `build.edge_handlers` property in
 // `netlify.toml`.
-const usesEdgeHandlers = function({ buildDir, EDGE_HANDLERS_SRC }) {
+const usesEdgeHandlers = function ({ buildDir, EDGE_HANDLERS_SRC }) {
   return isDirectory(`${buildDir}/${EDGE_HANDLERS_SRC}`)
 }
 
-const getDeployPlugin = function(featureFlags, BUILDBOT_SERVER_SOCKET) {
+const getDeployPlugin = function (featureFlags, BUILDBOT_SERVER_SOCKET) {
   if (!featureFlags.service_buildbot_enable_deploy_server || BUILDBOT_SERVER_SOCKET === undefined) {
     return
   }
@@ -79,7 +79,7 @@ const getDeployPlugin = function(featureFlags, BUILDBOT_SERVER_SOCKET) {
   return { package: DEPLOY_PLUGIN_NAME, pluginPath: DEPLOY_PLUGIN }
 }
 
-const isCorePlugin = function(packageName) {
+const isCorePlugin = function (packageName) {
   return CORE_PLUGINS.has(packageName)
 }
 

--- a/packages/build/src/status/add.js
+++ b/packages/build/src/status/add.js
@@ -1,5 +1,5 @@
 // Merge plugin status to the list of plugin statuses.
-const addStatus = function({ newStatus, statuses, event, packageName, pluginPackageJson: { version } = {} }) {
+const addStatus = function ({ newStatus, statuses, event, packageName, pluginPackageJson: { version } = {} }) {
   // Either:
   //  - `build.command`
   //  - no status was set
@@ -7,17 +7,17 @@ const addStatus = function({ newStatus, statuses, event, packageName, pluginPack
     return statuses
   }
 
-  const formerStatus = statuses.find(status => status.packageName === packageName)
+  const formerStatus = statuses.find((status) => status.packageName === packageName)
   if (!canOverrideStatus(formerStatus, newStatus)) {
     return statuses
   }
 
   // Overrides plugin's previous status and add more information
-  const newStatuses = statuses.filter(status => status !== formerStatus)
+  const newStatuses = statuses.filter((status) => status !== formerStatus)
   return [...newStatuses, { ...newStatus, event, packageName, version }]
 }
 
-const canOverrideStatus = function(formerStatus, newStatus) {
+const canOverrideStatus = function (formerStatus, newStatus) {
   // No previous status
   if (formerStatus === undefined) {
     return true

--- a/packages/build/src/status/colors.js
+++ b/packages/build/src/status/colors.js
@@ -1,18 +1,18 @@
 const stripAnsi = require('strip-ansi')
 
 // Remove colors from statuses
-const removeStatusesColors = function(statuses) {
+const removeStatusesColors = function (statuses) {
   return statuses.map(removeStatusColors)
 }
 
-const removeStatusColors = function(status) {
-  const attributes = COLOR_ATTRIBUTES.map(attribute => removeAttrColor(status, attribute))
+const removeStatusColors = function (status) {
+  const attributes = COLOR_ATTRIBUTES.map((attribute) => removeAttrColor(status, attribute))
   return Object.assign({}, status, ...attributes)
 }
 
 const COLOR_ATTRIBUTES = ['title', 'summary', 'text']
 
-const removeAttrColor = function(status, attribute) {
+const removeAttrColor = function (status, attribute) {
   const value = status[attribute]
   if (value === undefined) {
     return {}

--- a/packages/build/src/status/load_error.js
+++ b/packages/build/src/status/load_error.js
@@ -3,7 +3,7 @@ const { getFullErrorInfo } = require('../error/parse/parse')
 const { serializeErrorStatus } = require('../error/parse/serialize_status')
 
 // Errors that happen during plugin loads should be reported as error statuses
-const addPluginLoadErrorStatus = function({ error, packageName, version, debug }) {
+const addPluginLoadErrorStatus = function ({ error, packageName, version, debug }) {
   const fullErrorInfo = getFullErrorInfo({ error, colors: false, debug })
   const errorStatus = serializeErrorStatus({ fullErrorInfo, state: 'failed_build' })
   const statuses = [{ ...errorStatus, event: 'load', packageName, version }]

--- a/packages/build/src/status/report.js
+++ b/packages/build/src/status/report.js
@@ -4,7 +4,7 @@ const { logStatuses } = require('../log/messages/status')
 const { removeStatusesColors } = require('./colors')
 
 // Report plugin statuses to the console and API
-const reportStatuses = async function({
+const reportStatuses = async function ({
   statuses,
   childEnv,
   api,
@@ -40,7 +40,7 @@ const reportStatuses = async function({
 
 // When not in production, print statuses to console.
 // Only print successful ones, since errors are logged afterwards.
-const printStatuses = function({ statuses, mode, logs }) {
+const printStatuses = function ({ statuses, mode, logs }) {
   if (mode === 'buildbot') {
     return
   }
@@ -54,12 +54,12 @@ const printStatuses = function({ statuses, mode, logs }) {
   logStatuses(logs, successStatuses)
 }
 
-const shouldPrintStatus = function({ state, summary }) {
+const shouldPrintStatus = function ({ state, summary }) {
   return state === 'success' && summary !== undefined
 }
 
 // In production, send statuses to the API
-const sendApiStatuses = async function({
+const sendApiStatuses = async function ({
   statuses,
   childEnv,
   api,
@@ -77,13 +77,13 @@ const sendApiStatuses = async function({
   }
 
   await Promise.all(
-    statuses.map(status =>
+    statuses.map((status) =>
       sendApiStatus({ api, status, childEnv, mode, netlifyConfig, errorMonitor, deployId, logs, debug, testOpts }),
     ),
   )
 }
 
-const sendApiStatus = async function({
+const sendApiStatus = async function ({
   api,
   status: { packageName, version, state, event, title, summary, text },
   childEnv,

--- a/packages/build/src/status/success.js
+++ b/packages/build/src/status/success.js
@@ -2,7 +2,7 @@ const { runsOnlyOnBuildFailure } = require('../commands/get')
 
 // The last event handler of a plugin (except for `onError` and `onEnd`)
 // defaults to `utils.status.show({ state: 'success' })` without any `summary`.
-const getSuccessStatus = function(newStatus, { commands, event, packageName }) {
+const getSuccessStatus = function (newStatus, { commands, event, packageName }) {
   if (newStatus === undefined && isLastNonErrorCommand({ commands, event, packageName })) {
     return IMPLICIT_STATUS
   }
@@ -10,9 +10,9 @@ const getSuccessStatus = function(newStatus, { commands, event, packageName }) {
   return newStatus
 }
 
-const isLastNonErrorCommand = function({ commands, event, packageName }) {
+const isLastNonErrorCommand = function ({ commands, event, packageName }) {
   const nonErrorCommands = commands.filter(
-    command => command.packageName === packageName && !runsOnlyOnBuildFailure(command.event),
+    (command) => command.packageName === packageName && !runsOnlyOnBuildFailure(command.event),
   )
   return nonErrorCommands.length === 0 || nonErrorCommands[nonErrorCommands.length - 1].event === event
 }

--- a/packages/build/src/telemetry/complete.js
+++ b/packages/build/src/telemetry/complete.js
@@ -10,7 +10,7 @@ const { roundTimerToMillisecs } = require('../time/measure')
 const { track } = require('./track')
 
 // Send telemetry request when build completes
-const trackBuildComplete = async function({
+const trackBuildComplete = async function ({
   commandsCount,
   netlifyConfig,
   durationNs,
@@ -28,7 +28,7 @@ const trackBuildComplete = async function({
 }
 
 // Retrieve telemetry information
-const getPayload = function({ commandsCount, netlifyConfig, durationNs, siteInfo: { id: siteId }, mode }) {
+const getPayload = function ({ commandsCount, netlifyConfig, durationNs, siteInfo: { id: siteId }, mode }) {
   const durationMs = roundTimerToMillisecs(durationNs)
   const plugins = Object.values(netlifyConfig.plugins).map(getPluginPackageName)
   return {
@@ -56,7 +56,7 @@ const getPayload = function({ commandsCount, netlifyConfig, durationNs, siteInfo
   }
 }
 
-const getPluginPackageName = function({ packageName }) {
+const getPluginPackageName = function ({ packageName }) {
   return packageName
 }
 

--- a/packages/build/src/telemetry/request.js
+++ b/packages/build/src/telemetry/request.js
@@ -5,7 +5,7 @@ const got = require('got')
 const { version } = require('../../package.json')
 
 // Send HTTP request to telemetry.
-const sendRequest = async function() {
+const sendRequest = async function () {
   const json = JSON.parse(argv[2])
   const origin = argv[3] || DEFAULT_ORIGIN
   const url = `${origin}/collect`

--- a/packages/build/src/telemetry/track.js
+++ b/packages/build/src/telemetry/track.js
@@ -7,7 +7,7 @@ const REQUEST_FILE = `${__dirname}/request.js`
 // to complete, by using a child process.
 // We also ignore any errors. Those might happen for example if the current
 // directory was removed by the build command.
-const track = async function({ payload, testOpts: { telemetryOrigin = '' } = {} }) {
+const track = async function ({ payload, testOpts: { telemetryOrigin = '' } = {} }) {
   try {
     const childProcess = execa('node', [REQUEST_FILE, JSON.stringify(payload), telemetryOrigin], {
       detached: true,

--- a/packages/build/src/time/aggregate.js
+++ b/packages/build/src/time/aggregate.js
@@ -4,7 +4,7 @@ const { createTimer, TOP_PARENT_TAG } = require('./main')
 //   - `others` is `total` minus the other timers
 //   - `run_plugins` is the sum of all plugins
 //   - each plugin timer is the sum of its event handlers
-const addAggregatedTimers = function(timers) {
+const addAggregatedTimers = function (timers) {
   const timersA = addPluginTimers(timers)
   const timersB = addOthersTimers(timersA)
   return timersB
@@ -13,23 +13,23 @@ const addAggregatedTimers = function(timers) {
 // Having a `total` timer is redundant since the buildbot already measures this.
 // The buildbot measurement is better since it includes the time to load Node.
 // Instead, we only use `total` to measure what did not get `measureDuration()`.
-const addOthersTimers = function(timers) {
+const addOthersTimers = function (timers) {
   const totalTimer = timers.find(isTotalTimer)
-  const timersA = timers.filter(timer => !isTotalTimer(timer))
+  const timersA = timers.filter((timer) => !isTotalTimer(timer))
   const topTimers = timersA.filter(isTopTimer)
   const othersTimer = createOthersTimer(topTimers, totalTimer)
   return [...timersA, othersTimer]
 }
 
-const isTotalTimer = function({ stageTag, parentTag }) {
+const isTotalTimer = function ({ stageTag, parentTag }) {
   return stageTag === 'total' && parentTag === 'build_site'
 }
 
-const isTopTimer = function({ parentTag }) {
+const isTopTimer = function ({ parentTag }) {
   return parentTag === TOP_PARENT_TAG
 }
 
-const createOthersTimer = function(topTimers, { durationNs: totalTimerDurationNs }) {
+const createOthersTimer = function (topTimers, { durationNs: totalTimerDurationNs }) {
   const topTimersDurationNs = computeTimersDuration(topTimers)
   const otherTimersDurationNs = Math.max(0, totalTimerDurationNs - topTimersDurationNs)
   const othersTimer = createTimer(OTHERS_STAGE_TAG, otherTimersDurationNs)
@@ -38,7 +38,7 @@ const createOthersTimer = function(topTimers, { durationNs: totalTimerDurationNs
 
 const OTHERS_STAGE_TAG = 'others'
 
-const addPluginTimers = function(timers) {
+const addPluginTimers = function (timers) {
   const pluginsTimers = timers.filter(isPluginTimer)
   if (pluginsTimers.length === 0) {
     return timers
@@ -50,7 +50,7 @@ const addPluginTimers = function(timers) {
 }
 
 // Check if a timer relates to a Build plugin
-const isPluginTimer = function({ category }) {
+const isPluginTimer = function ({ category }) {
   return category === 'pluginEvent'
 }
 
@@ -58,42 +58,42 @@ const RUN_PLUGINS_STAGE_TAG = 'run_plugins'
 
 // Retrieve one timer for each plugin, summing all its individual timers
 // (one per event handler)
-const getWholePluginsTimers = function(pluginsTimers) {
+const getWholePluginsTimers = function (pluginsTimers) {
   const pluginPackages = getPluginPackages(pluginsTimers)
-  return pluginPackages.map(pluginPackage => getWholePluginTimer(pluginPackage, pluginsTimers))
+  return pluginPackages.map((pluginPackage) => getWholePluginTimer(pluginPackage, pluginsTimers))
 }
 
-const getPluginPackages = function(pluginsTimers) {
+const getPluginPackages = function (pluginsTimers) {
   const pluginPackages = pluginsTimers.map(getPluginTimerPackage)
   return [...new Set(pluginPackages)]
 }
 
-const getWholePluginTimer = function(pluginPackage, pluginsTimers) {
-  const pluginTimers = pluginsTimers.filter(pluginTimer => getPluginTimerPackage(pluginTimer) === pluginPackage)
+const getWholePluginTimer = function (pluginPackage, pluginsTimers) {
+  const pluginTimers = pluginsTimers.filter((pluginTimer) => getPluginTimerPackage(pluginTimer) === pluginPackage)
   const wholePluginsTimer = createSumTimer(pluginTimers, pluginPackage, RUN_PLUGINS_STAGE_TAG)
   return wholePluginsTimer
 }
 
-const getPluginTimerPackage = function({ parentTag }) {
+const getPluginTimerPackage = function ({ parentTag }) {
   return parentTag
 }
 
 // Creates a timer that sums up the duration of several others
-const createSumTimer = function(timers, stageTag, parentTag) {
+const createSumTimer = function (timers, stageTag, parentTag) {
   const durationNs = computeTimersDuration(timers)
   const timer = createTimer(stageTag, durationNs, { parentTag })
   return timer
 }
 
-const computeTimersDuration = function(timers) {
+const computeTimersDuration = function (timers) {
   return timers.map(getTimerDuration).reduce(reduceSum, 0)
 }
 
-const getTimerDuration = function({ durationNs }) {
+const getTimerDuration = function ({ durationNs }) {
   return durationNs
 }
 
-const reduceSum = function(sum, number) {
+const reduceSum = function (sum, number) {
   return sum + number
 }
 

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -4,7 +4,7 @@ const keepFuncProps = require('keep-func-props')
 const { startTimer, endTimer } = require('./measure')
 
 // Initialize the `timers` array
-const initTimers = function() {
+const initTimers = function () {
   return []
 }
 
@@ -14,8 +14,8 @@ const initTimers = function() {
 //   - return a plain object. This may or may not contain a modified `timers`.
 // The `durationNs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
-const kMeasureDuration = function(func, stageTag, { parentTag, category } = {}) {
-  return async function({ timers, ...opts }, ...args) {
+const kMeasureDuration = function (func, stageTag, { parentTag, category } = {}) {
+  return async function ({ timers, ...opts }, ...args) {
     const timerNs = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
     const durationNs = endTimer(timerNs)
@@ -29,7 +29,7 @@ const kMeasureDuration = function(func, stageTag, { parentTag, category } = {}) 
 const measureDuration = keepFuncProps(kMeasureDuration)
 
 // Create a new object representing a completed timer
-const createTimer = function(
+const createTimer = function (
   stageTag,
   durationNs,
   { metricName = DEFAULT_METRIC_NAME, parentTag = TOP_PARENT_TAG, category } = {},
@@ -42,7 +42,7 @@ const TOP_PARENT_TAG = 'run_netlify_build'
 
 // Make sure the timer name does not include special characters.
 // For example, the `packageName` of local plugins includes dots.
-const normalizeTimerName = function(name) {
+const normalizeTimerName = function (name) {
   return slugify(name, { separator: '_' })
 }
 

--- a/packages/build/src/time/measure.js
+++ b/packages/build/src/time/measure.js
@@ -1,12 +1,12 @@
 const { hrtime } = require('process')
 
 // Starts a timer
-const startTimer = function() {
+const startTimer = function () {
   return hrtime()
 }
 
 // Stops a timer
-const endTimer = function([startSecs, startNsecs]) {
+const endTimer = function ([startSecs, startNsecs]) {
   const [endSecs, endNsecs] = hrtime()
   const durationNs = (endSecs - startSecs) * NANOSECS_TO_SECS + endNsecs - startNsecs
   return durationNs
@@ -14,7 +14,7 @@ const endTimer = function([startSecs, startNsecs]) {
 
 // statsd expects milliseconds integers.
 // To prevent double rounding errors, rounding should only be applied once.
-const roundTimerToMillisecs = function(durationNs) {
+const roundTimerToMillisecs = function (durationNs) {
   return Math.round(durationNs / NANOSECS_TO_MSECS)
 }
 

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -9,7 +9,7 @@ const pSetTimeout = promisify(setTimeout)
 
 // Record the duration of a build phase, for monitoring.
 // Sends to statsd daemon.
-const reportTimers = async function({ timers, statsdOpts: { host, port }, framework }) {
+const reportTimers = async function ({ timers, statsdOpts: { host, port }, framework }) {
   if (host === undefined) {
     return
   }
@@ -18,9 +18,9 @@ const reportTimers = async function({ timers, statsdOpts: { host, port }, framew
   await sendTimers({ timers: timersA, host, port, framework })
 }
 
-const sendTimers = async function({ timers, host, port, framework }) {
+const sendTimers = async function ({ timers, host, port, framework }) {
   const client = await startClient(host, port)
-  timers.forEach(timer => sendTimer({ timer, client, framework }))
+  timers.forEach((timer) => sendTimer({ timer, client, framework }))
   await closeClient(client)
 }
 
@@ -28,13 +28,13 @@ const sendTimers = async function({ timers, host, port, framework }) {
 // case, this happens just before `client.close()` is called, which is too
 // late and make it not send anything. We need to manually create it using
 // the internal API.
-const startClient = async function(host, port) {
+const startClient = async function (host, port) {
   const client = new StatsdClient({ host, port, socketTimeout: 0 })
   await promisify(client._socket._createSocket.bind(client._socket))()
   return client
 }
 
-const sendTimer = function({ timer: { metricName, stageTag, parentTag, durationNs }, client, framework }) {
+const sendTimer = function ({ timer: { metricName, stageTag, parentTag, durationNs }, client, framework }) {
   const durationMs = roundTimerToMillisecs(durationNs)
   const frameworkTag = framework === undefined ? {} : { framework }
   client.timing(metricName, durationMs, { stage: stageTag, parent: parentTag, ...frameworkTag })
@@ -42,7 +42,7 @@ const sendTimer = function({ timer: { metricName, stageTag, parentTag, durationN
 
 // UDP packets are buffered and flushed at regular intervals by statsd-client.
 // Closing force flushing all of them.
-const closeClient = async function(client) {
+const closeClient = async function (client) {
   client.close()
 
   // statsd-clent does not provide with a way of knowing when the socket is done

--- a/packages/build/src/utils/errors.js
+++ b/packages/build/src/utils/errors.js
@@ -1,6 +1,6 @@
 // Wrap an async function so it prepends an error message on exceptions.
 // This helps locate errors.
-const addAsyncErrorMessage = function(asyncFunc, message) {
+const addAsyncErrorMessage = function (asyncFunc, message) {
   return async (...args) => {
     try {
       return await asyncFunc(...args)

--- a/packages/build/src/utils/omit.js
+++ b/packages/build/src/utils/omit.js
@@ -1,8 +1,8 @@
 const filterObj = require('filter-obj')
 
 // lodash.omit is 1400 lines of codes. filter-obj is much smaller and simpler.
-const omit = function(obj, keys) {
-  return filterObj(obj, key => !keys.includes(key))
+const omit = function (obj, keys) {
+  return filterObj(obj, (key) => !keys.includes(key))
 }
 
 module.exports = { omit }

--- a/packages/build/src/utils/package.js
+++ b/packages/build/src/utils/package.js
@@ -3,7 +3,7 @@ const { dirname } = require('path')
 const readPkgUp = require('read-pkg-up')
 
 // Retrieve `package.json` from a specific directory
-const getPackageJson = async function(cwd, { normalize = true } = {}) {
+const getPackageJson = async function (cwd, { normalize = true } = {}) {
   const packageObj = await readPkgUp({ cwd, normalize })
   if (packageObj === undefined) {
     return { packageJson: {} }

--- a/packages/build/src/utils/remove_falsy.js
+++ b/packages/build/src/utils/remove_falsy.js
@@ -1,11 +1,11 @@
 const filterObj = require('filter-obj')
 
 // Remove falsy values from object
-const removeFalsy = function(obj) {
+const removeFalsy = function (obj) {
   return filterObj(obj, isDefined)
 }
 
-const isDefined = function(key, value) {
+const isDefined = function (key, value) {
   return value !== undefined && value !== ''
 }
 

--- a/packages/build/src/utils/resolve.js
+++ b/packages/build/src/utils/resolve.js
@@ -8,7 +8,7 @@ const { gte: gteVersion } = require('semver')
 //   https://github.com/browserify/resolve/issues/223
 // Ideally we would use async I/O but that is not an option with
 // `require.resolve()`
-const resolvePath = function(path, basedir) {
+const resolvePath = function (path, basedir) {
   if (gteVersion(nodeVersion, REQUEST_RESOLVE_MIN_VERSION)) {
     return require.resolve(path, { paths: [basedir] })
   }
@@ -24,7 +24,7 @@ const REQUEST_RESOLVE_MIN_VERSION = '8.9.0'
 // We need to use `new Promise()` due to a bug with `utils.promisify()` on
 // `resolve`:
 //   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
-const resolvePathFallback = function(path, basedir) {
+const resolvePathFallback = function (path, basedir) {
   return new Promise((resolve, reject) => {
     resolveLib(path, { basedir }, (error, resolvedPath) => {
       if (error) {

--- a/packages/build/tests/README.md
+++ b/packages/build/tests/README.md
@@ -64,7 +64,7 @@ const test = require('ava')
 
 const { runFixture } = require('../../helpers/main')
 
-test('test title', async t => {
+test('test title', async (t) => {
   await runFixture(t, 'fixture_name')
 })
 ```
@@ -74,7 +74,7 @@ This calls under the hood:
 ```js
 const netlifyBuild = require('@netlify/build')
 
-const runTest = async function() {
+const runTest = async function () {
   const output = await netlifyBuild({ repositoryRoot: './fixtures/fixture_name' })
   return output
 }
@@ -155,7 +155,7 @@ This basically performs a series of regular expressions replacements.
 If you want to remove the normalization during debugging, use the `normalize` option:
 
 ```js
-test('test title', async t => {
+test('test title', async (t) => {
   await runFixture(t, 'fixture_name', { normalize: false })
 })
 ```

--- a/packages/build/tests/commands/tests.js
+++ b/packages/build/tests/commands/tests.js
@@ -5,32 +5,32 @@ const test = require('ava')
 const { runFixture } = require('../helpers/main')
 
 if (platform !== 'win32') {
-  test('build.command uses Bash', async t => {
+  test('build.command uses Bash', async (t) => {
     await runFixture(t, 'bash')
   })
 
-  test('build.command can execute shell commands', async t => {
+  test('build.command can execute shell commands', async (t) => {
     await runFixture(t, 'shell')
   })
 }
 
-test('build.command can execute global binaries', async t => {
+test('build.command can execute global binaries', async (t) => {
   await runFixture(t, 'global_bin')
 })
 
-test('build.command can execute local binaries', async t => {
+test('build.command can execute local binaries', async (t) => {
   await runFixture(t, 'local_bin')
 })
 
-test('build.command use correct PWD', async t => {
+test('build.command use correct PWD', async (t) => {
   await runFixture(t, 'pwd')
 })
 
-test('build.command from UI settings', async t => {
+test('build.command from UI settings', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: 'node --version' } })
   await runFixture(t, 'none', { flags: { defaultConfig } })
 })
 
-test('Invalid package.json does not make build fail', async t => {
+test('Invalid package.json does not make build fail', async (t) => {
   await runFixture(t, 'invalid_package_json')
 })

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -9,139 +9,139 @@ const { version } = require('../../package.json')
 const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 const { startServer } = require('../helpers/server.js')
 
-test('--help', async t => {
+test('--help', async (t) => {
   await runFixture(t, '', { flags: { help: true }, useBinary: true })
 })
 
-test('--version', async t => {
+test('--version', async (t) => {
   const { returnValue } = await runFixture(t, '', { flags: { version: true }, useBinary: true })
   t.is(returnValue, version)
 })
 
-test('Exit code is 0 on success', async t => {
+test('Exit code is 0 on success', async (t) => {
   const { exitCode } = await runFixture(t, 'empty', { useBinary: true, snapshot: false })
   t.is(exitCode, 0)
 })
 
-test('Exit code is 1 on build cancellation', async t => {
+test('Exit code is 1 on build cancellation', async (t) => {
   const { exitCode } = await runFixture(t, 'cancel', { useBinary: true, snapshot: false })
   t.is(exitCode, 1)
 })
 
-test('Exit code is 2 on user error', async t => {
+test('Exit code is 2 on user error', async (t) => {
   const { exitCode } = await runFixture(t, '', { flags: { config: '/invalid' }, useBinary: true, snapshot: false })
   t.is(exitCode, 2)
 })
 
-test('Exit code is 3 on plugin error', async t => {
+test('Exit code is 3 on plugin error', async (t) => {
   const { exitCode } = await runFixture(t, 'plugin_error', { useBinary: true, snapshot: false })
   t.is(exitCode, 3)
 })
 
-test('Success is true on success', async t => {
+test('Success is true on success', async (t) => {
   const {
     returnValue: { success },
   } = await runFixture(t, 'empty', { programmatic: true, snapshot: false })
   t.true(success)
 })
 
-test('Success is false on build cancellation', async t => {
+test('Success is false on build cancellation', async (t) => {
   const {
     returnValue: { success },
   } = await runFixture(t, 'cancel', { programmatic: true, snapshot: false })
   t.false(success)
 })
 
-test('Success is false on failure', async t => {
+test('Success is false on failure', async (t) => {
   const {
     returnValue: { success },
   } = await runFixture(t, 'plugin_error', { programmatic: true, snapshot: false })
   t.false(success)
 })
 
-test('severityCode is 0 on success', async t => {
+test('severityCode is 0 on success', async (t) => {
   const {
     returnValue: { severityCode },
   } = await runFixture(t, 'empty', { programmatic: true, snapshot: false })
   t.is(severityCode, 0)
 })
 
-test('severityCode is 1 on build cancellation', async t => {
+test('severityCode is 1 on build cancellation', async (t) => {
   const {
     returnValue: { severityCode },
   } = await runFixture(t, 'cancel', { programmatic: true, snapshot: false })
   t.is(severityCode, 1)
 })
 
-test('severityCode is 2 on user error', async t => {
+test('severityCode is 2 on user error', async (t) => {
   const {
     returnValue: { severityCode },
   } = await runFixture(t, '', { flags: { config: '/invalid' }, programmatic: true, snapshot: false })
   t.is(severityCode, 2)
 })
 
-test('severityCode is 3 on plugin error', async t => {
+test('severityCode is 3 on plugin error', async (t) => {
   const {
     returnValue: { severityCode },
   } = await runFixture(t, 'plugin_error', { programmatic: true, snapshot: false })
   t.is(severityCode, 3)
 })
 
-test('--cwd', async t => {
+test('--cwd', async (t) => {
   await runFixture(t, '', { flags: { cwd: `${FIXTURES_DIR}/empty` } })
 })
 
-test('--repository-root', async t => {
+test('--repository-root', async (t) => {
   await runFixture(t, '', { flags: { repositoryRoot: `${FIXTURES_DIR}/empty` } })
 })
 
-test('--config', async t => {
+test('--config', async (t) => {
   await runFixture(t, '', { flags: { config: `${FIXTURES_DIR}/empty/netlify.toml` } })
 })
 
-test('--defaultConfig', async t => {
+test('--defaultConfig', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: 'echo commandDefault' } })
   await runFixture(t, 'empty', { flags: { defaultConfig } })
 })
 
-test('--cachedConfig', async t => {
+test('--cachedConfig', async (t) => {
   const { returnValue } = await runFixtureConfig(t, 'cached_config', { snapshot: false })
   await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue } })
 })
 
-test('--context', async t => {
+test('--context', async (t) => {
   await runFixture(t, 'context', { flags: { context: 'testContext' } })
 })
 
-test('--branch', async t => {
+test('--branch', async (t) => {
   await runFixture(t, 'context', { flags: { branch: 'testContext' } })
 })
 
-test('--baseRelDir', async t => {
+test('--baseRelDir', async (t) => {
   await runFixtureConfig(t, 'basereldir', { flags: { baseRelDir: false } })
 })
 
-test('User error', async t => {
+test('User error', async (t) => {
   await runFixture(t, '', { flags: { config: '/invalid' } })
 })
 
-test('No configuration file', async t => {
+test('No configuration file', async (t) => {
   await runFixture(t, 'none')
 })
 
-test('--dry with one event', async t => {
+test('--dry with one event', async (t) => {
   await runFixture(t, 'single', { flags: { dry: true } })
 })
 
-test('--dry with several events', async t => {
+test('--dry with several events', async (t) => {
   await runFixture(t, 'several', { flags: { dry: true } })
 })
 
-test('--dry-run', async t => {
+test('--dry-run', async (t) => {
   await runFixture(t, 'single', { flags: { dryRun: true }, useBinary: true })
 })
 
-test('--dry with build.command but no netlify.toml', async t => {
+test('--dry with build.command but no netlify.toml', async (t) => {
   await runFixture(t, 'none', { flags: { dry: true, defaultConfig: '{"build":{"command":"echo"}}' } })
 })
 
@@ -149,7 +149,7 @@ const CHILD_NODE_VERSION = '8.3.0'
 const VERY_OLD_NODE_VERSION = '4.0.0'
 
 // Try `get-node` several times because it sometimes fails due to network failures
-const getNodeBinary = async function(version, retries = 1) {
+const getNodeBinary = async function (version, retries = 1) {
   try {
     return await getNode(version)
   } catch (error) {
@@ -166,27 +166,27 @@ const MAX_RETRIES = 10
 // Memoize `get-node`
 const mGetNode = moize(getNodeBinary, { isPromise: true })
 
-test('--node-path is used by build.command', async t => {
+test('--node-path is used by build.command', async (t) => {
   const { path } = await mGetNode(CHILD_NODE_VERSION)
   await runFixture(t, 'build_command', { flags: { nodePath: path }, env: { TEST_NODE_PATH: path } })
 })
 
-test('--node-path is used by local plugins', async t => {
+test('--node-path is used by local plugins', async (t) => {
   const { path } = await mGetNode(CHILD_NODE_VERSION)
   await runFixture(t, 'local_node_path', { flags: { nodePath: path }, env: { TEST_NODE_PATH: path } })
 })
 
-test('--node-path is used by plugins added to package.json', async t => {
+test('--node-path is used by plugins added to package.json', async (t) => {
   const { path } = await mGetNode(CHILD_NODE_VERSION)
   await runFixture(t, 'package', { flags: { nodePath: path }, env: { TEST_NODE_PATH: path } })
 })
 
-test('--node-path is not used by core plugins', async t => {
+test('--node-path is not used by core plugins', async (t) => {
   const { path } = await mGetNode(VERY_OLD_NODE_VERSION)
   await runFixture(t, 'core', { flags: { nodePath: path } })
 })
 
-test('--node-path is not used by build-image cached plugins', async t => {
+test('--node-path is not used by build-image cached plugins', async (t) => {
   const { path } = await mGetNode(CHILD_NODE_VERSION)
   await runFixture(t, 'build_image', {
     flags: {
@@ -198,16 +198,16 @@ test('--node-path is not used by build-image cached plugins', async t => {
   })
 })
 
-test('--featureFlags can be used', async t => {
+test('--featureFlags can be used', async (t) => {
   await runFixture(t, 'empty', { flags: { featureFlags: 'test,test,testTwo' } })
 })
 
 // Normalize telemetry request so it can be snapshot
-const normalizeSnapshot = function({ body, ...request }) {
+const normalizeSnapshot = function ({ body, ...request }) {
   return { ...request, body: normalizeBody(body) }
 }
 
-const normalizeBody = function({
+const normalizeBody = function ({
   anonymousId,
   meta: { timestamp, ...meta } = {},
   properties: { duration, isCI, buildVersion, nodeVersion, osPlatform, osName, ...properties } = {},
@@ -230,7 +230,7 @@ const normalizeBody = function({
 }
 
 if (platform !== 'win32') {
-  test('Print warning on lingering processes', async t => {
+  test('Print warning on lingering processes', async (t) => {
     const { returnValue } = await runFixture(t, 'lingering', {
       flags: { testOpts: { silentLingeringProcesses: false }, mode: 'buildbot' },
       snapshot: false,
@@ -249,7 +249,7 @@ if (platform !== 'win32') {
 
 const TELEMETRY_PATH = '/collect'
 
-test('Telemetry success', async t => {
+test('Telemetry success', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: true },
@@ -260,7 +260,7 @@ test('Telemetry success', async t => {
   t.snapshot(snapshot)
 })
 
-test('Telemetry disabled', async t => {
+test('Telemetry disabled', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` } },
@@ -271,7 +271,7 @@ test('Telemetry disabled', async t => {
   t.is(requests.length, 0)
 })
 
-test('Telemetry disabled with flag', async t => {
+test('Telemetry disabled with flag', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: false },
@@ -281,7 +281,7 @@ test('Telemetry disabled with flag', async t => {
   t.is(requests.length, 0)
 })
 
-test('Telemetry disabled with mode', async t => {
+test('Telemetry disabled with mode', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: undefined },
@@ -291,7 +291,7 @@ test('Telemetry disabled with mode', async t => {
   t.is(requests.length, 0)
 })
 
-test('Telemetry error', async t => {
+test('Telemetry error', async (t) => {
   const { stopServer } = await startServer(TELEMETRY_PATH)
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `https://...` }, telemetry: true },

--- a/packages/build/tests/env/tests.js
+++ b/packages/build/tests/env/tests.js
@@ -5,79 +5,79 @@ const test = require('ava')
 const { runFixture } = require('../helpers/main')
 const { startServer } = require('../helpers/server')
 
-test('Environment variable git', async t => {
+test('Environment variable git', async (t) => {
   await runFixture(t, 'git')
 })
 
-test('Environment variable git with --branch', async t => {
+test('Environment variable git with --branch', async (t) => {
   await runFixture(t, 'git_branch', { flags: { branch: 'test' } })
 })
 
-test('Environment variable git no repository', async t => {
+test('Environment variable git no repository', async (t) => {
   await runFixture(t, 'git', { copyRoot: { git: false } })
 })
 
 // Windows environment variables work differently
 if (platform !== 'win32') {
-  test('Environment variable in build.command', async t => {
+  test('Environment variable in build.command', async (t) => {
     await runFixture(t, 'command')
   })
 }
 
-test('Environment variable GATSBY_TELEMETRY_DISABLED', async t => {
+test('Environment variable GATSBY_TELEMETRY_DISABLED', async (t) => {
   await runFixture(t, 'gatsby_telemetry')
 })
 
-test('Environment variable NEXT_TELEMETRY_DISABLED', async t => {
+test('Environment variable NEXT_TELEMETRY_DISABLED', async (t) => {
   await runFixture(t, 'next_telemetry')
 })
 
-test('Environment variable NETLIFY local', async t => {
+test('Environment variable NETLIFY local', async (t) => {
   await runFixture(t, 'netlify')
 })
 
-test('Environment variable NETLIFY CI', async t => {
+test('Environment variable NETLIFY CI', async (t) => {
   await runFixture(t, 'netlify', { flags: { mode: 'buildbot' }, env: { NETLIFY: 'true' } })
 })
 
-test('Environment variable LANG', async t => {
+test('Environment variable LANG', async (t) => {
   await runFixture(t, 'lang')
 })
 
-test('Environment variable LANGUAGE', async t => {
+test('Environment variable LANGUAGE', async (t) => {
   await runFixture(t, 'language')
 })
 
-test('Environment variable LC_ALL', async t => {
+test('Environment variable LC_ALL', async (t) => {
   await runFixture(t, 'lc_all')
 })
 
-test('Environment variable CONTEXT', async t => {
+test('Environment variable CONTEXT', async (t) => {
   await runFixture(t, 'context')
 })
 
 const SITE_INFO_PATH = '/api/v1/sites/test'
 const SITE_INFO_DATA = { url: 'test', build_settings: { repo_url: 'test' } }
 
-test('Environment variable siteInfo success', async t => {
+test('Environment variable siteInfo success', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'site_info', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Empty string environment variables', async t => {
+test('Empty string environment variables', async (t) => {
   await runFixture(t, 'empty_string')
 })
 
-test('build.environment', async t => {
+test('build.environment', async (t) => {
   await runFixture(t, 'build')
 })
 
-test('build.environment readonly', async t => {
+test('build.environment readonly', async (t) => {
   await runFixture(t, 'build_readonly')
 })
 
 const BUGSNAG_TEST_KEY = '00000000000000000000000000000000'
-test('Does not pass BUGSNAG_KEY to build command and plugins', async t => {
+test('Does not pass BUGSNAG_KEY to build command and plugins', async (t) => {
   await runFixture(t, 'bugsnag_key', { env: { BUGSNAG_KEY: BUGSNAG_TEST_KEY } })
 })

--- a/packages/build/tests/error/fixtures/cancel_error_option/plugin.js
+++ b/packages/build/tests/error/fixtures/cancel_error_option/plugin.js
@@ -1,4 +1,4 @@
-const getError = function() {
+const getError = function () {
   return new Error('innerTest')
 }
 

--- a/packages/build/tests/error/fixtures/command_full_stack/command.js
+++ b/packages/build/tests/error/fixtures/command_full_stack/command.js
@@ -1,6 +1,6 @@
 const { exit } = require('process')
 
-const test = function() {
+const test = function () {
   console.log(new Error('test'))
   exit(2)
 }

--- a/packages/build/tests/error/fixtures/fail_build_error_option/plugin.js
+++ b/packages/build/tests/error/fixtures/fail_build_error_option/plugin.js
@@ -1,4 +1,4 @@
-const getError = function() {
+const getError = function () {
   return new Error('innerTest')
 }
 

--- a/packages/build/tests/error/fixtures/fail_plugin_error_option/plugin.js
+++ b/packages/build/tests/error/fixtures/fail_plugin_error_option/plugin.js
@@ -1,4 +1,4 @@
-const getError = function() {
+const getError = function () {
   return new Error('innerTest')
 }
 

--- a/packages/build/tests/error/fixtures/plugin_load/plugin.js
+++ b/packages/build/tests/error/fixtures/plugin_load/plugin.js
@@ -1,4 +1,4 @@
-const test = function() {
+const test = function () {
   throw new Error('test')
 }
 

--- a/packages/build/tests/error/fixtures/top/plugin.js
+++ b/packages/build/tests/error/fixtures/top/plugin.js
@@ -1,6 +1,6 @@
 module.exports = {}
 
-const throwError = function() {
+const throwError = function () {
   throw new Error('test')
 }
 

--- a/packages/build/tests/error/fixtures/unhandled_promise/plugin.js
+++ b/packages/build/tests/error/fixtures/unhandled_promise/plugin.js
@@ -10,6 +10,6 @@ module.exports = {
   },
 }
 
-const unhandledPromise = function() {
+const unhandledPromise = function () {
   return Promise.reject(new Error('test'))
 }

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -8,61 +8,61 @@ const { startServer } = require('../helpers/server')
 
 const CANCEL_PATH = '/api/v1/deploys/test/cancel'
 
-test('build.failBuild()', async t => {
+test('build.failBuild()', async (t) => {
   await runFixture(t, 'fail_build')
 })
 
-test('build.failBuild() error option', async t => {
+test('build.failBuild() error option', async (t) => {
   await runFixture(t, 'fail_build_error_option')
 })
 
-test('build.failBuild() inside a callback', async t => {
+test('build.failBuild() inside a callback', async (t) => {
   await runFixture(t, 'fail_build_callback')
 })
 
-test('build.failBuild() is not available within post-deploy events', async t => {
+test('build.failBuild() is not available within post-deploy events', async (t) => {
   await runFixture(t, 'fail_build_post_deploy')
 })
 
-test('build.failPlugin()', async t => {
+test('build.failPlugin()', async (t) => {
   await runFixture(t, 'fail_plugin')
 })
 
-test('build.failPlugin() inside a callback', async t => {
+test('build.failPlugin() inside a callback', async (t) => {
   await runFixture(t, 'fail_plugin_callback')
 })
 
-test('build.failPlugin() error option', async t => {
+test('build.failPlugin() error option', async (t) => {
   await runFixture(t, 'fail_plugin_error_option')
 })
 
-test('build.cancelBuild()', async t => {
+test('build.cancelBuild()', async (t) => {
   await runFixture(t, 'cancel')
 })
 
-test('build.cancelBuild() inside a callback', async t => {
+test('build.cancelBuild() inside a callback', async (t) => {
   await runFixture(t, 'cancel_callback')
 })
 
-test('build.cancelBuild() error option', async t => {
+test('build.cancelBuild() error option', async (t) => {
   await runFixture(t, 'cancel_error_option')
 })
 
-test('build.cancelBuild() API call', async t => {
+test('build.cancelBuild() API call', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
   await runFixture(t, 'cancel', { flags: { token: 'test', deployId: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.snapshot(requests)
 })
 
-test('build.cancelBuild() API call no DEPLOY_ID', async t => {
+test('build.cancelBuild() API call no DEPLOY_ID', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
   await runFixture(t, 'cancel', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.is(requests.length, 0)
 })
 
-test('build.cancelBuild() API call no token', async t => {
+test('build.cancelBuild() API call no token', async (t) => {
   const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
   await runFixture(t, 'cancel', { flags: { deployId: 'test', testOpts: { scheme, host } } })
   await stopServer()
@@ -73,36 +73,36 @@ test('build.cancelBuild() API call no token', async t => {
 // inconsistent test snapshots
 // TODO: remove once dropping Node 8
 if (!version.startsWith('v8.')) {
-  test('build.cancelBuild() API call failure', async t => {
+  test('build.cancelBuild() API call failure', async (t) => {
     await runFixture(t, 'cancel', { flags: { token: 'test', deployId: 'test', testOpts: { host: '...' } } })
   })
 }
 
-test('build.cancelBuild() is not available within post-deploy events', async t => {
+test('build.cancelBuild() is not available within post-deploy events', async (t) => {
   await runFixture(t, 'cancel_post_deploy')
 })
 
-test('exception', async t => {
+test('exception', async (t) => {
   await runFixture(t, 'exception')
 })
 
-test('exception with static properties', async t => {
+test('exception with static properties', async (t) => {
   await runFixture(t, 'exception_props')
 })
 
-test('exception with circular references', async t => {
+test('exception with circular references', async (t) => {
   await runFixture(t, 'exception_circular')
 })
 
-test('exception that are strings', async t => {
+test('exception that are strings', async (t) => {
   await runFixture(t, 'exception_string')
 })
 
-test('exception that are arrays', async t => {
+test('exception that are arrays', async (t) => {
   await runFixture(t, 'exception_array')
 })
 
-test('Clean stack traces of build.command', async t => {
+test('Clean stack traces of build.command', async (t) => {
   const { returnValue } = await runFixture(t, 'build_command', {
     flags: { debug: false },
     snapshot: false,
@@ -112,19 +112,19 @@ test('Clean stack traces of build.command', async t => {
   t.is(count, 0)
 })
 
-test('Clean stack traces of plugin event handlers', async t => {
+test('Clean stack traces of plugin event handlers', async (t) => {
   const { returnValue } = await runFixture(t, 'plugin', { flags: { debug: false }, snapshot: false, normalize: false })
   const count = getStackLinesCount(returnValue)
   t.is(count, 1)
 })
 
-test('Do not clean stack traces in debug mode', async t => {
+test('Do not clean stack traces in debug mode', async (t) => {
   const { returnValue } = await runFixture(t, 'plugin', { flags: { debug: true }, snapshot: false, normalize: false })
   const count = getStackLinesCount(returnValue)
   t.not(count, 1)
 })
 
-test('Does not clean stack traces of exceptions', async t => {
+test('Does not clean stack traces of exceptions', async (t) => {
   const { returnValue } = await runFixture(t, 'stack_exception', {
     flags: { debug: false },
     snapshot: false,
@@ -134,7 +134,7 @@ test('Does not clean stack traces of exceptions', async t => {
   t.not(count, 1)
 })
 
-test('Clean stack traces of config validation', async t => {
+test('Clean stack traces of config validation', async (t) => {
   const { returnValue } = await runFixture(t, 'config_validation', {
     false: { debug: false },
     snapshot: false,
@@ -144,115 +144,115 @@ test('Clean stack traces of config validation', async t => {
   t.is(count, 0)
 })
 
-const getStackLinesCount = function(returnValue) {
+const getStackLinesCount = function (returnValue) {
   return returnValue.split('\n').filter(isStackLine).length
 }
 
-const isStackLine = function(line) {
+const isStackLine = function (line) {
   return line.trim().startsWith('at ')
 }
 
-test('Clean stack traces from cwd', async t => {
+test('Clean stack traces from cwd', async (t) => {
   const { returnValue } = await runFixture(t, 'plugin', { flags: { debug: false }, snapshot: false, normalize: false })
   t.false(returnValue.includes(`onPreBuild (${cwd()}`))
 })
 
-test('Clean stack traces but keep error message', async t => {
+test('Clean stack traces but keep error message', async (t) => {
   const { returnValue } = await runFixture(t, 'plugin', { flags: { debug: false }, snapshot: false, normalize: false })
   t.true(returnValue.includes('Error: test'))
 })
 
-test('Do not log secret values on build errors', async t => {
+test('Do not log secret values on build errors', async (t) => {
   await runFixture(t, 'log_secret')
 })
 
 const BUGSNAG_TEST_KEY = '00000000000000000000000000000000'
 const flags = { testOpts: { errorMonitor: true }, bugsnagKey: BUGSNAG_TEST_KEY }
 
-test('Report build.command failure', async t => {
+test('Report build.command failure', async (t) => {
   await runFixture(t, 'command', { flags })
 })
 
-test('Report configuration user error', async t => {
+test('Report configuration user error', async (t) => {
   await runFixture(t, 'config', { flags })
 })
 
-test('Report plugin input error', async t => {
+test('Report plugin input error', async (t) => {
   await runFixture(t, 'plugin_input', { flags })
 })
 
-test('Report plugin validation error', async t => {
+test('Report plugin validation error', async (t) => {
   await runFixture(t, 'plugin_validation', { flags })
 })
 
-test('Report plugin internal error', async t => {
+test('Report plugin internal error', async (t) => {
   await runFixture(t, 'plugin_internal', { flags })
 })
 
-test('Report utils.build.failBuild()', async t => {
+test('Report utils.build.failBuild()', async (t) => {
   await runFixture(t, 'monitor_fail_build', { flags })
 })
 
-test('Report utils.build.failPlugin()', async t => {
+test('Report utils.build.failPlugin()', async (t) => {
   await runFixture(t, 'monitor_fail_plugin', { flags })
 })
 
-test('Report utils.build.cancelBuild()', async t => {
+test('Report utils.build.cancelBuild()', async (t) => {
   await runFixture(t, 'cancel_build', { flags })
 })
 
-test('Report IPC error', async t => {
+test('Report IPC error', async (t) => {
   await runFixture(t, 'ipc', { flags })
 })
 
-test('Report API error', async t => {
+test('Report API error', async (t) => {
   await runFixture(t, 'cancel_build', { flags: { ...flags, token: 'test', deployId: 'test' } })
 })
 
 // Node v8 uses a different error message format
 // TODO: remove once dropping Node 8
 if (!version.startsWith('v8.')) {
-  test('Report dependencies error', async t => {
+  test('Report dependencies error', async (t) => {
     await runFixture(t, 'dependencies', { flags })
   })
 }
 
-test('Report buildbot mode as releaseStage', async t => {
+test('Report buildbot mode as releaseStage', async (t) => {
   await runFixture(t, 'command', { flags: { ...flags, mode: 'buildbot' }, useBinary: true })
 })
 
-test('Report CLI mode as releaseStage', async t => {
+test('Report CLI mode as releaseStage', async (t) => {
   await runFixture(t, 'command', { flags: { ...flags, mode: 'cli' }, useBinary: true })
 })
 
-test('Report programmatic mode as releaseStage', async t => {
+test('Report programmatic mode as releaseStage', async (t) => {
   await runFixture(t, 'command', { flags: { ...flags, mode: 'require' }, useBinary: true })
 })
 
-test('Remove colors in error.message', async t => {
+test('Remove colors in error.message', async (t) => {
   const { returnValue } = await runFixture(t, 'colors', { flags, snapshot: false })
-  const lines = returnValue.split('\n').filter(line => line.includes('ColorTest'))
-  t.true(lines.every(line => !hasAnsi(line)))
+  const lines = returnValue.split('\n').filter((line) => line.includes('ColorTest'))
+  t.true(lines.every((line) => !hasAnsi(line)))
 })
 
-test('Report BUILD_ID', async t => {
+test('Report BUILD_ID', async (t) => {
   await runFixture(t, 'command', { flags, env: { BUILD_ID: 'test' }, useBinary: true })
 })
 
-test('Report plugin homepage', async t => {
+test('Report plugin homepage', async (t) => {
   await runFixture(t, 'plugin_homepage', { flags })
 })
 
-test('Report plugin homepage without a repository', async t => {
+test('Report plugin homepage without a repository', async (t) => {
   await runFixture(t, 'plugin_homepage_no_repo', { flags })
 })
 
-test('Report plugin origin', async t => {
+test('Report plugin origin', async (t) => {
   const defaultConfig = JSON.stringify({ plugins: [{ package: './plugin.js' }] })
   await runFixture(t, 'plugin_origin', { flags: { ...flags, defaultConfig } })
 })
 
-test('Report build logs URLs', async t => {
+test('Report build logs URLs', async (t) => {
   await runFixture(t, 'command', {
     flags,
     env: { DEPLOY_ID: 'testDeployId', SITE_NAME: 'testSiteName' },
@@ -260,71 +260,71 @@ test('Report build logs URLs', async t => {
   })
 })
 
-test('Top-level errors', async t => {
+test('Top-level errors', async (t) => {
   await runFixture(t, 'top')
 })
 
-test('Top function errors local', async t => {
+test('Top function errors local', async (t) => {
   await runFixture(t, 'function')
 })
 
-test('Node module all fields', async t => {
+test('Node module all fields', async (t) => {
   await runFixture(t, 'full')
 })
 
-test('Node module partial fields', async t => {
+test('Node module partial fields', async (t) => {
   await runFixture(t, 'partial')
 })
 
-test('No repository root', async t => {
+test('No repository root', async (t) => {
   await runFixture(t, 'no_root', { copyRoot: { git: false } })
 })
 
-test('Process warnings', async t => {
+test('Process warnings', async (t) => {
   await runFixture(t, 'warning')
 })
 
-test('Uncaught exception', async t => {
+test('Uncaught exception', async (t) => {
   await runFixture(t, 'uncaught')
 })
 
-test('Unhandled promises', async t => {
+test('Unhandled promises', async (t) => {
   await runFixture(t, 'unhandled_promise')
 })
 
-test('Exits in plugins', async t => {
+test('Exits in plugins', async (t) => {
   await runFixture(t, 'plugin_exit')
 })
 
 // Process exit is different on Windows
 if (platform !== 'win32') {
-  test('Early exit', async t => {
+  test('Early exit', async (t) => {
     await runFixture(t, 'early_exit')
   })
 }
 
-test('Print stack trace of plugin errors', async t => {
+test('Print stack trace of plugin errors', async (t) => {
   await runFixture(t, 'plugin_stack')
 })
 
-test('Print stack trace of plugin errors during load', async t => {
+test('Print stack trace of plugin errors during load', async (t) => {
   await runFixture(t, 'plugin_load')
 })
 
-test('Print stack trace of build.command errors', async t => {
+test('Print stack trace of build.command errors', async (t) => {
   await runFixture(t, 'command_stack')
 })
 
-test('Print stack trace of build.command errors with stack traces', async t => {
+test('Print stack trace of build.command errors with stack traces', async (t) => {
   await runFixture(t, 'command_full_stack')
 })
 
-test('Print stack trace of Build command UI settings', async t => {
+test('Print stack trace of Build command UI settings', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: 'node --invalid' } })
   await runFixture(t, 'none', { flags: { defaultConfig } })
 })
 
-test('Print stack trace of validation errors', async t => {
+test('Print stack trace of validation errors', async (t) => {
   await runFixture(t, '', { flags: { config: '/invalid' } })
 })
 
@@ -332,7 +332,7 @@ test('Print stack trace of validation errors', async t => {
 // inconsistent test snapshots
 // TODO: remove once dropping Node 8
 if (!version.startsWith('v8.')) {
-  test('Redact API token on errors', async t => {
+  test('Redact API token on errors', async (t) => {
     await runFixture(t, 'api_token_redact', {
       flags: { token: '0123456789abcdef', deployId: 'test', mode: 'buildbot', testOpts: { host: '...' } },
     })

--- a/packages/build/tests/helpers/common.js
+++ b/packages/build/tests/helpers/common.js
@@ -18,7 +18,7 @@ const FIXTURES_DIR = normalize(`${testFile}/../fixtures`)
 
 // Run a CLI using a fixture directory, then snapshot the output.
 // Options: see tests/README.md
-const runFixtureCommon = async function(
+const runFixtureCommon = async function (
   t,
   fixtureName,
   {
@@ -54,14 +54,14 @@ const runFixtureCommon = async function(
 }
 
 // Retrieve flags to the main entry point
-const getMainFlags = function({ fixtureName, copyRoot, copyRootDir, repositoryRoot, flags }) {
+const getMainFlags = function ({ fixtureName, copyRoot, copyRootDir, repositoryRoot, flags }) {
   const repositoryRootFlag = getRepositoryRootFlag({ fixtureName, copyRoot, copyRootDir, repositoryRoot })
   return { ...repositoryRootFlag, ...flags }
 }
 
 // The `repositoryRoot` flag can be overriden, but defaults to the fixture
 // directory
-const getRepositoryRootFlag = function({ fixtureName, copyRoot: { cwd } = {}, copyRootDir, repositoryRoot }) {
+const getRepositoryRootFlag = function ({ fixtureName, copyRoot: { cwd } = {}, copyRootDir, repositoryRoot }) {
   if (fixtureName === '') {
     return {}
   }
@@ -77,7 +77,7 @@ const getRepositoryRootFlag = function({ fixtureName, copyRoot: { cwd } = {}, co
   return { repositoryRoot: normalize(copyRootDir) }
 }
 
-const getCopyRootDir = function({ copyRoot, copyRoot: { git } = {} }) {
+const getCopyRootDir = function ({ copyRoot, copyRoot: { git } = {} }) {
   if (copyRoot === undefined) {
     return
   }
@@ -85,7 +85,7 @@ const getCopyRootDir = function({ copyRoot, copyRoot: { git } = {} }) {
   return createRepoDir({ git })
 }
 
-const runCommand = async function({
+const runCommand = async function ({
   mainFunc,
   binaryPath,
   useBinary,
@@ -113,7 +113,7 @@ const runCommand = async function({
   }
 }
 
-const execCommand = function({ mainFunc, binaryPath, useBinary, mainFlags, commandEnv }) {
+const execCommand = function ({ mainFunc, binaryPath, useBinary, mainFlags, commandEnv }) {
   if (useBinary) {
     return execCliCommand({ binaryPath, mainFlags, commandEnv })
   }
@@ -121,7 +121,7 @@ const execCommand = function({ mainFunc, binaryPath, useBinary, mainFlags, comma
   return execMainFunc({ mainFunc, mainFlags, commandEnv })
 }
 
-const execCliCommand = async function({ binaryPath, mainFlags, commandEnv }) {
+const execCliCommand = async function ({ binaryPath, mainFlags, commandEnv }) {
   const cliFlags = getCliFlags(mainFlags)
   const { all, exitCode } = await execa.command(`${binaryPath} ${cliFlags}`, {
     all: true,
@@ -131,13 +131,13 @@ const execCliCommand = async function({ binaryPath, mainFlags, commandEnv }) {
   return { returnValue: all, exitCode }
 }
 
-const getCliFlags = function(mainFlags, prefix = []) {
+const getCliFlags = function (mainFlags, prefix = []) {
   return Object.entries(mainFlags)
     .flatMap(([name, value]) => getCliFlag({ name, value, prefix }))
     .join(' ')
 }
 
-const getCliFlag = function({ name, value, prefix }) {
+const getCliFlag = function ({ name, value, prefix }) {
   if (isPlainObj(value)) {
     return getCliFlags(value, [...prefix, name])
   }
@@ -146,7 +146,7 @@ const getCliFlag = function({ name, value, prefix }) {
   return [`--${key}=${value}`]
 }
 
-const execMainFunc = async function({ mainFunc, mainFlags, commandEnv }) {
+const execMainFunc = async function ({ mainFunc, mainFlags, commandEnv }) {
   try {
     const returnValue = await mainFunc({ ...mainFlags, env: commandEnv })
     return { returnValue }
@@ -159,7 +159,7 @@ const execMainFunc = async function({ mainFunc, mainFlags, commandEnv }) {
 // The `PRINT` environment variable can be set to `1` to run the test in print
 // mode. Print mode is a debugging mode which shows the test output but does
 // not create nor compare its snapshot.
-const doTestAction = function({ t, returnValue, normalize, snapshot }) {
+const doTestAction = function ({ t, returnValue, normalize, snapshot }) {
   if (!snapshot) {
     return
   }
@@ -178,7 +178,7 @@ const doTestAction = function({ t, returnValue, normalize, snapshot }) {
   t.snapshot(normalizedReturn)
 }
 
-const normalizeOutputString = function(outputString, normalize) {
+const normalizeOutputString = function (outputString, normalize) {
   if (!normalize) {
     return outputString
   }
@@ -186,7 +186,7 @@ const normalizeOutputString = function(outputString, normalize) {
   return normalizeOutput(outputString)
 }
 
-const printOutput = function(t, normalizedReturn) {
+const printOutput = function (t, normalizedReturn) {
   console.log(`
 ${magentaBright.bold(`${LINE}
   ${t.title}
@@ -198,8 +198,8 @@ ${normalizedReturn}`)
 
 const LINE = '='.repeat(50)
 
-const shouldIgnoreSnapshot = function(normalizedReturn) {
-  return IGNORE_REGEXPS.some(regExp => regExp.test(normalizedReturn))
+const shouldIgnoreSnapshot = function (normalizedReturn) {
+  return IGNORE_REGEXPS.some((regExp) => regExp.test(normalizedReturn))
 }
 
 const IGNORE_REGEXPS = [
@@ -208,7 +208,7 @@ const IGNORE_REGEXPS = [
 ]
 
 // When running tests with PRINT=1, print the results instead of snapshotting
-const isPrint = function() {
+const isPrint = function () {
   return env.PRINT === '1'
 }
 

--- a/packages/build/tests/helpers/dir.js
+++ b/packages/build/tests/helpers/dir.js
@@ -5,13 +5,13 @@ const { getTempDir } = require('./temp')
 
 // Create a temporary directory with a `.git` directory, which can be used as
 // the current directory of a build. Otherwise the `git` utility does not load.
-const createRepoDir = async function({ git = true } = {}) {
+const createRepoDir = async function ({ git = true } = {}) {
   const cwd = await getTempDir()
   await createGit(cwd, git)
   return cwd
 }
 
-const createGit = async function(cwd, git) {
+const createGit = async function (cwd, git) {
   if (!git) {
     return
   }
@@ -27,7 +27,7 @@ const createGit = async function(cwd, git) {
 // Removing a directory sometimes fails on Windows in CI due to Windows
 // directory locking.
 // This results in `EBUSY: resource busy or locked, rmdir /path/to/dir`
-const removeDir = async function(dir) {
+const removeDir = async function (dir) {
   try {
     await del(dir, { force: true })
   } catch (error) {}

--- a/packages/build/tests/helpers/main.js
+++ b/packages/build/tests/helpers/main.js
@@ -11,7 +11,7 @@ const { runFixtureCommon, FIXTURES_DIR } = require('./common')
 const ROOT_DIR = `${__dirname}/../..`
 const BUILD_BIN_DIR = normalize(`${ROOT_DIR}/node_modules/.bin`)
 
-const runFixture = async function(
+const runFixture = async function (
   t,
   fixtureName,
   { flags = {}, env: envOption = {}, programmatic = false, ...opts } = {},
@@ -39,7 +39,7 @@ const runFixture = async function(
   return runFixtureCommon(t, fixtureName, { ...opts, flags: flagsA, env: envOptionA, mainFunc, binaryPath })
 }
 
-const getNetlifyBuildLogs = async function(flags) {
+const getNetlifyBuildLogs = async function (flags) {
   const { logs } = await netlifyBuild(flags)
   return [logs.stdout.join('\n'), logs.stderr.join('\n')].filter(Boolean).join('\n\n')
 }

--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -2,12 +2,12 @@ const { tick, pointer, arrowDown } = require('figures')
 const stripAnsi = require('strip-ansi')
 
 // Normalize log output so it can be snapshot consistently across test runs
-const normalizeOutput = function(output) {
+const normalizeOutput = function (output) {
   const outputA = stripAnsi(output)
   return NORMALIZE_REGEXPS.reduce(replaceOutput, outputA)
 }
 
-const replaceOutput = function(output, [regExp, replacement]) {
+const replaceOutput = function (output, [regExp, replacement]) {
   return output.replace(regExp, replacement)
 }
 

--- a/packages/build/tests/helpers/server.js
+++ b/packages/build/tests/helpers/server.js
@@ -4,7 +4,7 @@ const { promisify } = require('util')
 // Start an HTTP server to mock API calls (telemetry server and Bitballoon)
 // Tests are using child processes, so we cannot use `nock` or similar library
 // that relies on monkey-patching global variables.
-const startServer = async function(path, response = {}, { status = 200 } = {}) {
+const startServer = async function (path, response = {}, { status = 200 } = {}) {
   const requests = []
   const server = createServer((req, res) => requestHandler({ req, res, requests, response, status, path }))
   await promisify(server.listen.bind(server))(0)
@@ -15,16 +15,16 @@ const startServer = async function(path, response = {}, { status = 200 } = {}) {
   return { scheme: 'http', host, requests, stopServer }
 }
 
-const getHost = function(server) {
+const getHost = function (server) {
   const port = server.address().port
   return `localhost:${port}`
 }
 
-const requestHandler = function({ req, res, requests, response, status, path }) {
+const requestHandler = function ({ req, res, requests, response, status, path }) {
   // A stateful variable is required due to `http` using events
   // eslint-disable-next-line fp/no-let
   let rawBody = ''
-  req.on('data', data => {
+  req.on('data', (data) => {
     rawBody += data.toString()
   })
   req.on('end', () => {
@@ -32,26 +32,24 @@ const requestHandler = function({ req, res, requests, response, status, path }) 
   })
 }
 
-const onRequestEnd = function({ req: { method, url, headers }, res, requests, response, status, path, rawBody }) {
+const onRequestEnd = function ({ req: { method, url, headers }, res, requests, response, status, path, rawBody }) {
   addRequestInfo({ method, url, headers, requests, path, rawBody })
   res.statusCode = status
   res.setHeader('Content-Type', 'application/json')
   res.end(JSON.stringify(response))
 }
 
-const addRequestInfo = function({ method, url, headers, requests, path, rawBody }) {
+const addRequestInfo = function ({ method, url, headers, requests, path, rawBody }) {
   if (url !== path) {
     return
   }
 
   const body = parseBody(rawBody)
-  const headersA = Object.keys(headers)
-    .sort()
-    .join(' ')
+  const headersA = Object.keys(headers).sort().join(' ')
   requests.push({ method, headers: headersA, body })
 }
 
-const parseBody = function(rawBody) {
+const parseBody = function (rawBody) {
   try {
     return JSON.parse(rawBody)
   } catch (error) {

--- a/packages/build/tests/helpers/tcp_server.js
+++ b/packages/build/tests/helpers/tcp_server.js
@@ -5,7 +5,7 @@ const getPort = require('get-port')
 const { tmpName } = require('tmp-promise')
 
 // Start a TCP server to mock calls.
-const startTcpServer = async function({ response = '', useUnixSocket = true } = {}) {
+const startTcpServer = async function ({ response = '', useUnixSocket = true } = {}) {
   const requests = []
   const { connectionOpts, address } = await getConnectionOpts({ useUnixSocket })
   const server = createServer(onConnection.bind(null, { response, requests }))
@@ -15,7 +15,7 @@ const startTcpServer = async function({ response = '', useUnixSocket = true } = 
   return { address, requests, stopServer }
 }
 
-const getConnectionOpts = async function({ useUnixSocket }) {
+const getConnectionOpts = async function ({ useUnixSocket }) {
   if (useUnixSocket) {
     const path = await tmpName()
     return { connectionOpts: { path }, address: path }
@@ -26,11 +26,11 @@ const getConnectionOpts = async function({ useUnixSocket }) {
   return { connectionOpts: { host, port }, address: `${host}:${port}` }
 }
 
-const onConnection = function({ response, requests }, socket) {
+const onConnection = function ({ response, requests }, socket) {
   socket.on('data', onRequest.bind(null, { response, requests, socket }))
 }
 
-const onRequest = function({ response, requests, socket }, data) {
+const onRequest = function ({ response, requests, socket }, data) {
   const json = typeof response !== 'string'
   const dataString = data.toString()
   const parsedData = json ? JSON.parse(dataString) : dataString

--- a/packages/build/tests/helpers/temp.js
+++ b/packages/build/tests/helpers/temp.js
@@ -10,13 +10,13 @@ const makeDir = require('make-dir')
 const pRealpath = promisify(realpath)
 
 // Create and retrieve a new temporary sub-directory
-const getTempDir = async function() {
+const getTempDir = async function () {
   const tempDir = await getTempName()
   await makeDir(tempDir)
   return tempDir
 }
 
-const getTempName = async function() {
+const getTempName = async function () {
   const tempDir = tmpdir()
   const tempDirA = await pRealpath(tempDir)
   const id = String(Math.random()).replace('.', '')

--- a/packages/build/tests/helpers/udp_server.js
+++ b/packages/build/tests/helpers/udp_server.js
@@ -2,9 +2,9 @@ const { createSocket } = require('dgram')
 const { promisify } = require('util')
 
 // Start an UDP server to mock calls.
-const startUdpServer = async function() {
+const startUdpServer = async function () {
   const requests = []
-  const server = createSocket('udp4', buffer => {
+  const server = createSocket('udp4', (buffer) => {
     requests.push(buffer.toString())
   })
   await promisify(server.bind.bind(server))(0)

--- a/packages/build/tests/install/tests.js
+++ b/packages/build/tests/install/tests.js
@@ -8,12 +8,12 @@ const { getTempDir } = require('../helpers/temp')
 // Run fixture and ensure:
 //  - specific directories exist after run
 //  - specific directories are removed before/after test
-const runInstallFixture = async function(t, fixtureName, dirs, opts) {
+const runInstallFixture = async function (t, fixtureName, dirs, opts) {
   await removeDir(dirs)
   try {
     await runFixture(t, fixtureName, opts)
     await Promise.all(
-      dirs.map(async dir => {
+      dirs.map(async (dir) => {
         t.true(await pathExists(dir))
       }),
     )
@@ -22,25 +22,25 @@ const runInstallFixture = async function(t, fixtureName, dirs, opts) {
   }
 }
 
-test('Functions: install dependencies nested', async t => {
+test('Functions: install dependencies nested', async (t) => {
   await runInstallFixture(t, 'dir', [
     `${FIXTURES_DIR}/dir/.netlify/functions/`,
     `${FIXTURES_DIR}/dir/functions/function/node_modules/`,
   ])
 })
 
-test('Functions: ignore package.json inside node_modules', async t => {
+test('Functions: ignore package.json inside node_modules', async (t) => {
   await runInstallFixture(t, 'node_modules', [`${FIXTURES_DIR}/node_modules/.netlify/functions/`])
 })
 
-test('Functions: install dependencies with npm', async t => {
+test('Functions: install dependencies with npm', async (t) => {
   await runInstallFixture(t, 'functions_npm', [
     `${FIXTURES_DIR}/functions_npm/.netlify/functions/`,
     `${FIXTURES_DIR}/functions_npm/functions/node_modules/`,
   ])
 })
 
-test('Functions: install dependencies with Yarn locally', async t => {
+test('Functions: install dependencies with Yarn locally', async (t) => {
   await runInstallFixture(
     t,
     'functions_yarn',
@@ -49,72 +49,72 @@ test('Functions: install dependencies with Yarn locally', async t => {
   )
 })
 
-test('Functions: install dependencies with Yarn in CI', async t => {
+test('Functions: install dependencies with Yarn in CI', async (t) => {
   await runInstallFixture(t, 'functions_yarn_ci', [`${FIXTURES_DIR}/functions_yarn_ci/functions/node_modules/`], {
     useBinary: true,
     flags: { mode: 'buildbot', deployId: 'functions_yarn_ci' },
   })
 })
 
-test('Functions: does not install dependencies unless opting in', async t => {
+test('Functions: does not install dependencies unless opting in', async (t) => {
   await runInstallFixture(t, 'optional', [])
   t.false(await pathExists(`${FIXTURES_DIR}/optional/functions/node_modules/`))
 })
 
-test('Functions: install dependencies handles errors', async t => {
+test('Functions: install dependencies handles errors', async (t) => {
   await runInstallFixture(t, 'functions_error', [])
 })
 
-test('Functions: does not print warnings when dependency was mispelled', async t => {
+test('Functions: does not print warnings when dependency was mispelled', async (t) => {
   await runInstallFixture(t, 'mispelled_dep', [])
   t.false(await pathExists(`${FIXTURES_DIR}/mispelled_dep/functions/node_modules/`))
 })
 
-test('Functions: does not print warnings when dependency was local', async t => {
+test('Functions: does not print warnings when dependency was local', async (t) => {
   await runInstallFixture(t, 'local_dep', [])
   t.false(await pathExists(`${FIXTURES_DIR}/local_dep/functions/node_modules/`))
 })
 
-test('Install local plugin dependencies: with npm', async t => {
+test('Install local plugin dependencies: with npm', async (t) => {
   await runInstallFixture(t, 'npm', [`${FIXTURES_DIR}/npm/plugin/node_modules/`])
 })
 
-test('Install local plugin dependencies: with yarn locally', async t => {
+test('Install local plugin dependencies: with yarn locally', async (t) => {
   await runInstallFixture(t, 'yarn', [`${FIXTURES_DIR}/yarn/plugin/node_modules/`], { useBinary: true })
 })
 
-test('Install local plugin dependencies: with yarn in CI', async t => {
+test('Install local plugin dependencies: with yarn in CI', async (t) => {
   await runInstallFixture(t, 'yarn_ci', [`${FIXTURES_DIR}/yarn_ci/plugin/node_modules/`], {
     useBinary: true,
     flags: { mode: 'buildbot' },
   })
 })
 
-test('Install local plugin dependencies: propagate errors', async t => {
+test('Install local plugin dependencies: propagate errors', async (t) => {
   await runFixture(t, 'error')
 })
 
-test('Install local plugin dependencies: already installed', async t => {
+test('Install local plugin dependencies: already installed', async (t) => {
   await runFixture(t, 'already')
 })
 
-test('Install local plugin dependencies: no package.json', async t => {
+test('Install local plugin dependencies: no package.json', async (t) => {
   await runFixture(t, 'no_package')
 })
 
-test('Install local plugin dependencies: no root package.json', async t => {
+test('Install local plugin dependencies: no root package.json', async (t) => {
   await runFixture(t, 'no_root_package', { copyRoot: {} })
 })
 
-test('Install local plugin dependencies: missing plugin in netlify.toml', async t => {
+test('Install local plugin dependencies: missing plugin in netlify.toml', async (t) => {
   await runFixture(t, 'local_missing')
 })
 
-test('Automatically install missing plugins locally', async t => {
+test('Automatically install missing plugins locally', async (t) => {
   await runFixture(t, 'missing', { copyRoot: {} })
 })
 
-test('Automatically install missing plugins in CI', async t => {
+test('Automatically install missing plugins in CI', async (t) => {
   const buildImagePluginsDir = await getTempDir()
   try {
     await runFixture(t, 'missing', { copyRoot: {}, flags: { buildImagePluginsDir } })
@@ -123,12 +123,12 @@ test('Automatically install missing plugins in CI', async t => {
   }
 })
 
-test('Automatically install missing plugins locally when picked in UI', async t => {
+test('Automatically install missing plugins locally when picked in UI', async (t) => {
   const defaultConfig = JSON.stringify({ plugins: [{ package: 'netlify-plugin-contextual-env' }] })
   await runFixture(t, 'empty', { copyRoot: {}, flags: { mode: 'buildbot', defaultConfig } })
 })
 
-test('Re-use previously automatically installed plugins', async t => {
+test('Re-use previously automatically installed plugins', async (t) => {
   await runFixture(t, 'already_installed', { snapshot: false })
   await runFixture(t, 'already_installed')
 })

--- a/packages/build/tests/log/tests.js
+++ b/packages/build/tests/log/tests.js
@@ -8,17 +8,17 @@ const { runFixture } = require('../helpers/main')
 // Common options for color-related tests
 const opts = { snapshot: false, normalize: false, useBinary: true }
 
-test('Colors in parent process', async t => {
+test('Colors in parent process', async (t) => {
   const { returnValue } = await runFixture(t, 'parent', { ...opts, flags: { dry: true }, env: { FORCE_COLOR: '1' } })
   t.true(hasAnsi(returnValue))
 })
 
-test('Colors in child process', async t => {
+test('Colors in child process', async (t) => {
   const { returnValue } = await runFixture(t, 'child', { ...opts, env: { FORCE_COLOR: '1' } })
   t.true(returnValue.includes(red('onPreBuild')))
 })
 
-test('Netlify CI', async t => {
+test('Netlify CI', async (t) => {
   const { returnValue } = await runFixture(t, 'parent', {
     ...opts,
     flags: { dry: true, mode: 'buildbot' },
@@ -27,14 +27,14 @@ test('Netlify CI', async t => {
   t.true(hasAnsi(returnValue))
 })
 
-test('No TTY', async t => {
+test('No TTY', async (t) => {
   const { returnValue } = await runFixture(t, 'parent', { ...opts, flags: { dry: true } })
   t.false(hasAnsi(returnValue))
 })
 
 // In GitHub actions, `update-notifier` is never enabled
 if (!isCI) {
-  test.skip('Print a warning when using an old version through Netlify CLI', async t => {
+  test.skip('Print a warning when using an old version through Netlify CLI', async (t) => {
     // We need to unset some environment variables which would otherwise disable `update-notifier`
     await runFixture(t, 'error', {
       flags: { mode: 'cli', testOpts: { oldCliLogs: true } },
@@ -44,7 +44,7 @@ if (!isCI) {
   })
 }
 
-test('Logs whether the build commands came from the UI', async t => {
+test('Logs whether the build commands came from the UI', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: 'node --invalid' } })
   await runFixture(t, 'empty', { flags: { defaultConfig } })
 })

--- a/packages/build/tests/manifest/tests.js
+++ b/packages/build/tests/manifest/tests.js
@@ -2,90 +2,90 @@ const test = require('ava')
 
 const { runFixture } = require('../helpers/main')
 
-test('manifest.yml check required inputs', async t => {
+test('manifest.yml check required inputs', async (t) => {
   await runFixture(t, 'required')
 })
 
-test('manifest.yml check unknown property when plugin has none', async t => {
+test('manifest.yml check unknown property when plugin has none', async (t) => {
   await runFixture(t, 'unknown_none')
 })
 
-test('manifest.yml check unknown property when plugin has some', async t => {
+test('manifest.yml check unknown property when plugin has some', async (t) => {
   await runFixture(t, 'unknown_some')
 })
 
-test('manifest.yml check default value', async t => {
+test('manifest.yml check default value', async (t) => {
   await runFixture(t, 'default')
 })
 
-test('manifest.yml same directory', async t => {
+test('manifest.yml same directory', async (t) => {
   await runFixture(t, 'same_directory')
 })
 
-test('manifest.yml root directory', async t => {
+test('manifest.yml root directory', async (t) => {
   await runFixture(t, 'root_directory')
 })
 
-test('manifest.yml not root directory', async t => {
+test('manifest.yml not root directory', async (t) => {
   await runFixture(t, 'not_root_directory')
 })
 
-test('manifest.yml missing', async t => {
+test('manifest.yml missing', async (t) => {
   await runFixture(t, 'missing')
 })
 
-test('manifest.yml parse error', async t => {
+test('manifest.yml parse error', async (t) => {
   await runFixture(t, 'parse_error')
 })
 
-test('manifest.yml advanced YAML', async t => {
+test('manifest.yml advanced YAML', async (t) => {
   await runFixture(t, 'advanced_yaml')
 })
 
-test('manifest.yml plain object', async t => {
+test('manifest.yml plain object', async (t) => {
   await runFixture(t, 'plain_object')
 })
 
-test('manifest.yml unknown properties', async t => {
+test('manifest.yml unknown properties', async (t) => {
   await runFixture(t, 'manifest_unknown')
 })
 
-test('manifest.yml name undefined', async t => {
+test('manifest.yml name undefined', async (t) => {
   await runFixture(t, 'name_undefined')
 })
 
-test('manifest.yml name is a string', async t => {
+test('manifest.yml name is a string', async (t) => {
   await runFixture(t, 'name_string')
 })
 
-test('manifest.yml inputs array', async t => {
+test('manifest.yml inputs array', async (t) => {
   await runFixture(t, 'inputs_array')
 })
 
-test('manifest.yml inputs array of objects', async t => {
+test('manifest.yml inputs array of objects', async (t) => {
   await runFixture(t, 'inputs_array_objects')
 })
 
-test('manifest.yml inputs unknown property', async t => {
+test('manifest.yml inputs unknown property', async (t) => {
   await runFixture(t, 'inputs_unknown')
 })
 
-test('manifest.yml inputs name is undefined', async t => {
+test('manifest.yml inputs name is undefined', async (t) => {
   await runFixture(t, 'inputs_name_undefined')
 })
 
-test('manifest.yml inputs name is string', async t => {
+test('manifest.yml inputs name is string', async (t) => {
   await runFixture(t, 'inputs_name_string')
 })
 
-test('manifest.yml inputs description is a string', async t => {
+test('manifest.yml inputs description is a string', async (t) => {
   await runFixture(t, 'inputs_description_string')
 })
 
-test('manifest.yml inputs required is a boolean', async t => {
+test('manifest.yml inputs required is a boolean', async (t) => {
   await runFixture(t, 'inputs_required_boolean')
 })
 
-test('manifest.yml node module', async t => {
+test('manifest.yml node module', async (t) => {
   await runFixture(t, 'module')
 })

--- a/packages/build/tests/plugins/fixtures/defined/plugin.js
+++ b/packages/build/tests/plugins/fixtures/defined/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onPreBuild({ utils: { cache } }) {
-    console.log(
-      Object.keys(cache)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(cache).sort().join(' '))
   },
 }

--- a/packages/build/tests/plugins/fixtures/keys/plugin.js
+++ b/packages/build/tests/plugins/fixtures/keys/plugin.js
@@ -1,9 +1,5 @@
 module.exports = {
   onPreBuild({ utils }) {
-    console.log(
-      Object.keys(utils)
-        .sort()
-        .join(' '),
-    )
+    console.log(Object.keys(utils).sort().join(' '))
   },
 }

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -9,100 +9,100 @@ const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 const { startTcpServer } = require('../helpers/tcp_server')
 const { getTempDir } = require('../helpers/temp')
 
-test('constants.CONFIG_PATH', async t => {
+test('constants.CONFIG_PATH', async (t) => {
   await runFixture(t, 'config')
 })
 
-test('constants.PUBLISH_DIR default value', async t => {
+test('constants.PUBLISH_DIR default value', async (t) => {
   await runFixture(t, 'publish_default')
 })
 
-test('constants.PUBLISH_DIR default value with build.base', async t => {
+test('constants.PUBLISH_DIR default value with build.base', async (t) => {
   await runFixture(t, 'publish_default_base')
 })
 
-test('constants.PUBLISH_DIR absolute path', async t => {
+test('constants.PUBLISH_DIR absolute path', async (t) => {
   await runFixture(t, 'publish_absolute')
 })
 
-test('constants.PUBLISH_DIR relative path', async t => {
+test('constants.PUBLISH_DIR relative path', async (t) => {
   await runFixture(t, 'publish_relative')
 })
 
-test('constants.PUBLISH_DIR missing path', async t => {
+test('constants.PUBLISH_DIR missing path', async (t) => {
   await runFixture(t, 'publish_missing')
 })
 
-test('constants.FUNCTIONS_SRC default value', async t => {
+test('constants.FUNCTIONS_SRC default value', async (t) => {
   await runFixture(t, 'functions_src_default')
 })
 
-test('constants.FUNCTIONS_SRC relative path', async t => {
+test('constants.FUNCTIONS_SRC relative path', async (t) => {
   await runFixture(t, 'functions_src_relative')
 })
 
-test('constants.FUNCTIONS_SRC automatic value', async t => {
+test('constants.FUNCTIONS_SRC automatic value', async (t) => {
   await runFixture(t, 'functions_src_auto')
 })
 
-test('constants.FUNCTIONS_SRC missing path', async t => {
+test('constants.FUNCTIONS_SRC missing path', async (t) => {
   await runFixture(t, 'functions_src_missing')
 })
 
-test('constants.FUNCTIONS_DIST', async t => {
+test('constants.FUNCTIONS_DIST', async (t) => {
   await runFixture(t, 'functions_dist')
 })
 
-test('constants.CACHE_DIR local', async t => {
+test('constants.CACHE_DIR local', async (t) => {
   await runFixture(t, 'cache')
 })
 
-test('constants.CACHE_DIR CI', async t => {
+test('constants.CACHE_DIR CI', async (t) => {
   await runFixture(t, 'cache', { flags: { mode: 'buildbot' } })
 })
 
-test('constants.IS_LOCAL CI', async t => {
+test('constants.IS_LOCAL CI', async (t) => {
   await runFixture(t, 'is_local', { flags: { mode: 'buildbot' } })
 })
 
-test('constants.SITE_ID', async t => {
+test('constants.SITE_ID', async (t) => {
   await runFixture(t, 'site_id', { flags: { siteId: 'test' } })
 })
 
-test('constants.IS_LOCAL local', async t => {
+test('constants.IS_LOCAL local', async (t) => {
   await runFixture(t, 'is_local')
 })
 
-test('constants.NETLIFY_BUILD_VERSION', async t => {
+test('constants.NETLIFY_BUILD_VERSION', async (t) => {
   await runFixture(t, 'netlify_build_version')
 })
 
-test('constants.NETLIFY_API_TOKEN', async t => {
+test('constants.NETLIFY_API_TOKEN', async (t) => {
   await runFixture(t, 'netlify_api_token', { flags: { token: 'test' } })
 })
 
-test('Functions: simple setup', async t => {
+test('Functions: simple setup', async (t) => {
   await removeDir(`${FIXTURES_DIR}/simple/.netlify/functions/`)
   await runFixture(t, 'simple')
 })
 
-test('Functions: missing source directory', async t => {
+test('Functions: missing source directory', async (t) => {
   await runFixture(t, 'missing')
 })
 
-test('Functions: must not be a regular file', async t => {
+test('Functions: must not be a regular file', async (t) => {
   await runFixture(t, 'regular_file')
 })
 
-test('Functions: no functions', async t => {
+test('Functions: no functions', async (t) => {
   await runFixture(t, 'none')
 })
 
-test('Functions: default directory', async t => {
+test('Functions: default directory', async (t) => {
   await runFixture(t, 'default')
 })
 
-test('Functions: --functionsDistDir', async t => {
+test('Functions: --functionsDistDir', async (t) => {
   const functionsDistDir = await getTempDir()
   try {
     await runFixture(t, 'simple', { flags: { functionsDistDir } })
@@ -111,20 +111,20 @@ test('Functions: --functionsDistDir', async t => {
   }
 })
 
-test('Functions: not included twice', async t => {
+test('Functions: not included twice', async (t) => {
   await runFixture(t, 'functions_twice')
 })
 
 const EDGE_HANDLERS_LOCAL_DIR = '.netlify/edge-handlers'
 const EDGE_HANDLERS_MANIFEST = 'manifest.json'
 
-const getEdgeHandlersPaths = function(fixtureName) {
+const getEdgeHandlersPaths = function (fixtureName) {
   const outputDir = `${FIXTURES_DIR}/${fixtureName}/${EDGE_HANDLERS_LOCAL_DIR}`
   const manifestPath = `${outputDir}/${EDGE_HANDLERS_MANIFEST}`
   return { outputDir, manifestPath }
 }
 
-const loadEdgeHandlerBundle = async function({ outputDir, manifestPath }) {
+const loadEdgeHandlerBundle = async function ({ outputDir, manifestPath }) {
   const bundlePath = getEdgeHandlerBundlePath({ outputDir, manifestPath })
 
   try {
@@ -134,13 +134,13 @@ const loadEdgeHandlerBundle = async function({ outputDir, manifestPath }) {
   }
 }
 
-const getEdgeHandlerBundlePath = function({ outputDir, manifestPath }) {
+const getEdgeHandlerBundlePath = function ({ outputDir, manifestPath }) {
   // eslint-disable-next-line node/global-require
   const { sha } = require(manifestPath)
   return `${outputDir}/${sha}`
 }
 
-const requireEdgeHandleBundle = function(bundlePath) {
+const requireEdgeHandleBundle = function (bundlePath) {
   const set = spy()
   global.netlifyRegistry = { set }
   // eslint-disable-next-line node/global-require
@@ -149,30 +149,30 @@ const requireEdgeHandleBundle = function(bundlePath) {
   return set.args.map(normalizeEdgeHandler)
 }
 
-const normalizeEdgeHandler = function([handlerName, { onRequest }]) {
+const normalizeEdgeHandler = function ([handlerName, { onRequest }]) {
   return { handlerName, onRequest }
 }
 
 // Edge handlers are not supported in Node 8
 // TODO: remove once Node 8 support is removed
 if (!version.startsWith('v8.')) {
-  test('constants.EDGE_HANDLERS_SRC default value', async t => {
+  test('constants.EDGE_HANDLERS_SRC default value', async (t) => {
     await runFixture(t, 'edge_handlers_src_default')
   })
 
-  test('constants.EDGE_HANDLERS_SRC automatic value', async t => {
+  test('constants.EDGE_HANDLERS_SRC automatic value', async (t) => {
     await runFixture(t, 'edge_handlers_src_auto')
   })
 
-  test('constants.EDGE_HANDLERS_SRC relative path', async t => {
+  test('constants.EDGE_HANDLERS_SRC relative path', async (t) => {
     await runFixture(t, 'edge_handlers_src_relative')
   })
 
-  test('constants.EDGE_HANDLERS_SRC missing path', async t => {
+  test('constants.EDGE_HANDLERS_SRC missing path', async (t) => {
     await runFixture(t, 'edge_handlers_src_missing')
   })
 
-  test('Edge handlers: simple setup', async t => {
+  test('Edge handlers: simple setup', async (t) => {
     const { outputDir, manifestPath } = getEdgeHandlersPaths('handlers_simple')
     await runFixture(t, 'handlers_simple')
 
@@ -181,7 +181,7 @@ if (!version.startsWith('v8.')) {
     t.deepEqual(onRequest('test'), [true, 'test', 'test'])
   })
 
-  test('Edge handlers: can configure directory', async t => {
+  test('Edge handlers: can configure directory', async (t) => {
     const { outputDir, manifestPath } = getEdgeHandlersPaths('handlers_custom_dir')
     await runFixture(t, 'handlers_custom_dir')
 
@@ -190,7 +190,7 @@ if (!version.startsWith('v8.')) {
   })
 }
 
-test('Deploy plugin succeeds', async t => {
+test('Deploy plugin succeeds', async (t) => {
   const { address, requests, stopServer } = await startDeployServer()
   try {
     await runFixture(t, 'empty', {
@@ -203,7 +203,7 @@ test('Deploy plugin succeeds', async t => {
   t.true(requests.every(isValidDeployReponse))
 })
 
-test('Deploy plugin is not run unless --buildbotServerSocket is passed', async t => {
+test('Deploy plugin is not run unless --buildbotServerSocket is passed', async (t) => {
   const { requests, stopServer } = await startDeployServer()
   try {
     await runFixture(t, 'empty', { flags: { featureFlags: 'service_buildbot_enable_deploy_server' }, snapshot: false })
@@ -214,7 +214,7 @@ test('Deploy plugin is not run unless --buildbotServerSocket is passed', async t
   t.is(requests.length, 0)
 })
 
-test('Deploy plugin is not run unless --featureFlags=service_buildbot_enable_deploy_server is passed', async t => {
+test('Deploy plugin is not run unless --featureFlags=service_buildbot_enable_deploy_server is passed', async (t) => {
   const { address, requests, stopServer } = await startDeployServer()
   try {
     await runFixture(t, 'empty', { flags: { buildbotServerSocket: address }, snapshot: false })
@@ -225,7 +225,7 @@ test('Deploy plugin is not run unless --featureFlags=service_buildbot_enable_dep
   t.is(requests.length, 0)
 })
 
-test('Deploy plugin connection error', async t => {
+test('Deploy plugin connection error', async (t) => {
   const { address, stopServer } = await startDeployServer()
   await stopServer()
   const { exitCode, returnValue } = await runFixture(t, 'empty', {
@@ -236,7 +236,7 @@ test('Deploy plugin connection error', async t => {
   t.true(returnValue.includes('Could not connect to buildbot: Error: connect'))
 })
 
-test('Deploy plugin response syntax error', async t => {
+test('Deploy plugin response syntax error', async (t) => {
   const { address, stopServer } = await startDeployServer({ response: 'test' })
   try {
     await runFixture(t, 'empty', {
@@ -247,7 +247,7 @@ test('Deploy plugin response syntax error', async t => {
   }
 })
 
-test('Deploy plugin response system error', async t => {
+test('Deploy plugin response system error', async (t) => {
   const { address, stopServer } = await startDeployServer({
     response: { succeeded: false, values: { error: 'test', error_type: 'system' } },
   })
@@ -260,7 +260,7 @@ test('Deploy plugin response system error', async t => {
   }
 })
 
-test('Deploy plugin response user error', async t => {
+test('Deploy plugin response user error', async (t) => {
   const { address, stopServer } = await startDeployServer({
     response: { succeeded: false, values: { error: 'test', error_type: 'user' } },
   })
@@ -273,7 +273,7 @@ test('Deploy plugin response user error', async t => {
   }
 })
 
-test('Deploy plugin does not wait for post-processing if not using onSuccess nor onEnd', async t => {
+test('Deploy plugin does not wait for post-processing if not using onSuccess nor onEnd', async (t) => {
   const { address, requests, stopServer } = await startDeployServer()
   try {
     await runFixture(t, 'empty', {
@@ -287,7 +287,7 @@ test('Deploy plugin does not wait for post-processing if not using onSuccess nor
   t.true(requests.every(doesNotWaitForPostProcessing))
 })
 
-test('Deploy plugin waits for post-processing if using onSuccess', async t => {
+test('Deploy plugin waits for post-processing if using onSuccess', async (t) => {
   const { address, requests, stopServer } = await startDeployServer()
   try {
     await runFixture(t, 'success', {
@@ -301,7 +301,7 @@ test('Deploy plugin waits for post-processing if using onSuccess', async t => {
   t.true(requests.every(waitsForPostProcessing))
 })
 
-test('Deploy plugin waits for post-processing if using onEnd', async t => {
+test('Deploy plugin waits for post-processing if using onEnd', async (t) => {
   const { address, requests, stopServer } = await startDeployServer()
   try {
     await runFixture(t, 'end', {
@@ -315,7 +315,7 @@ test('Deploy plugin waits for post-processing if using onEnd', async t => {
   t.true(requests.every(waitsForPostProcessing))
 })
 
-test('Deploy plugin when publish directory does not exist', async t => {
+test('Deploy plugin when publish directory does not exist', async (t) => {
   const { address, stopServer } = await startDeployServer()
   try {
     const { exitCode, returnValue } = await runFixture(t, 'invalid_publish', {
@@ -329,235 +329,235 @@ test('Deploy plugin when publish directory does not exist', async t => {
   }
 })
 
-const startDeployServer = function(opts = {}) {
+const startDeployServer = function (opts = {}) {
   const useUnixSocket = platform !== 'win32'
   return startTcpServer({ useUnixSocket, response: { succeeded: true, ...opts.response }, ...opts })
 }
 
-const isValidDeployReponse = function(request) {
+const isValidDeployReponse = function (request) {
   return ['deploySite', 'deploySiteAndAwaitLive'].includes(request.action)
 }
 
-const doesNotWaitForPostProcessing = function(request) {
+const doesNotWaitForPostProcessing = function (request) {
   return request.action === 'deploySite'
 }
 
-const waitsForPostProcessing = function(request) {
+const waitsForPostProcessing = function (request) {
   return request.action === 'deploySiteAndAwaitLive'
 }
 
-test('plugin.onSuccess is triggered on success', async t => {
+test('plugin.onSuccess is triggered on success', async (t) => {
   await runFixture(t, 'success_ok')
 })
 
-test('plugin.onSuccess is not triggered on failure', async t => {
+test('plugin.onSuccess is not triggered on failure', async (t) => {
   await runFixture(t, 'success_not_ok')
 })
 
-test('plugin.onSuccess is not triggered on failPlugin()', async t => {
+test('plugin.onSuccess is not triggered on failPlugin()', async (t) => {
   await runFixture(t, 'success_fail_plugin')
 })
 
-test('plugin.onSuccess is not triggered on cancelBuild()', async t => {
+test('plugin.onSuccess is not triggered on cancelBuild()', async (t) => {
   await runFixture(t, 'success_cancel_build')
 })
 
-test('plugin.onSuccess can fail but does not stop builds', async t => {
+test('plugin.onSuccess can fail but does not stop builds', async (t) => {
   await runFixture(t, 'success_fail')
 })
 
-test('plugin.onError is not triggered on success', async t => {
+test('plugin.onError is not triggered on success', async (t) => {
   await runFixture(t, 'error_ok')
 })
 
-test('plugin.onError is triggered on failure', async t => {
+test('plugin.onError is triggered on failure', async (t) => {
   await runFixture(t, 'error_not_ok')
 })
 
-test('plugin.onError is not triggered on failPlugin()', async t => {
+test('plugin.onError is not triggered on failPlugin()', async (t) => {
   await runFixture(t, 'error_fail_plugin')
 })
 
-test('plugin.onError is triggered on cancelBuild()', async t => {
+test('plugin.onError is triggered on cancelBuild()', async (t) => {
   await runFixture(t, 'error_cancel_build')
 })
 
-test('plugin.onError can fail', async t => {
+test('plugin.onError can fail', async (t) => {
   await runFixture(t, 'error_fail')
 })
 
-test('plugin.onError gets an error argument', async t => {
+test('plugin.onError gets an error argument', async (t) => {
   await runFixture(t, 'error_argument')
 })
 
-test('plugin.onError can be used in several plugins', async t => {
+test('plugin.onError can be used in several plugins', async (t) => {
   await runFixture(t, 'error_several')
 })
 
-test('plugin.onEnd is triggered on success', async t => {
+test('plugin.onEnd is triggered on success', async (t) => {
   await runFixture(t, 'end_ok')
 })
 
-test('plugin.onEnd is triggered on failure', async t => {
+test('plugin.onEnd is triggered on failure', async (t) => {
   await runFixture(t, 'end_not_ok')
 })
 
-test('plugin.onEnd is not triggered on failPlugin()', async t => {
+test('plugin.onEnd is not triggered on failPlugin()', async (t) => {
   await runFixture(t, 'end_fail_plugin')
 })
 
-test('plugin.onEnd is triggered on cancelBuild()', async t => {
+test('plugin.onEnd is triggered on cancelBuild()', async (t) => {
   await runFixture(t, 'end_cancel_build')
 })
 
-test('plugin.onEnd can fail but it does not stop builds', async t => {
+test('plugin.onEnd can fail but it does not stop builds', async (t) => {
   await runFixture(t, 'end_fail')
 })
 
-test('plugin.onEnd and plugin.onError can be used together', async t => {
+test('plugin.onEnd and plugin.onError can be used together', async (t) => {
   await runFixture(t, 'end_error')
 })
 
-test('plugin.onEnd can be used in several plugins', async t => {
+test('plugin.onEnd can be used in several plugins', async (t) => {
   await runFixture(t, 'end_several')
 })
 
-test('Local plugins', async t => {
+test('Local plugins', async (t) => {
   await runFixture(t, 'local')
 })
 
-test('Local plugins directory', async t => {
+test('Local plugins directory', async (t) => {
   await runFixture(t, 'local_dir')
 })
 
-test('Local plugins absolute path', async t => {
+test('Local plugins absolute path', async (t) => {
   await runFixture(t, 'local_absolute')
 })
 
-test('Local plugins invalid path', async t => {
+test('Local plugins invalid path', async (t) => {
   await runFixture(t, 'local_invalid')
 })
 
-test('Node module plugins', async t => {
+test('Node module plugins', async (t) => {
   await runFixture(t, 'module')
 })
 
-test('UI plugins', async t => {
+test('UI plugins', async (t) => {
   const defaultConfig = JSON.stringify({ plugins: [{ package: 'netlify-plugin-test' }] })
   await runFixture(t, 'ui', { flags: { defaultConfig } })
 })
 
-test('Resolution is relative to the build directory', async t => {
+test('Resolution is relative to the build directory', async (t) => {
   await runFixture(t, 'basedir', { flags: { config: `${FIXTURES_DIR}/basedir/base/netlify.toml` } })
 })
 
-test('Non-existing plugins', async t => {
+test('Non-existing plugins', async (t) => {
   await runFixture(t, 'non_existing')
 })
 
-test('Do not allow overriding core plugins', async t => {
+test('Do not allow overriding core plugins', async (t) => {
   await runFixture(t, 'core_override')
 })
 
-test('Can use plugins cached in the build image', async t => {
+test('Can use plugins cached in the build image', async (t) => {
   await runFixture(t, 'build_image', {
     flags: { buildImagePluginsDir: `${FIXTURES_DIR}/build_image_cache/node_modules` },
   })
 })
 
-test('Does not use plugins cached in the build image in local builds', async t => {
+test('Does not use plugins cached in the build image in local builds', async (t) => {
   await runFixture(t, 'build_image')
 })
 
-test('Can execute local binaries when using plugins cached in the build image', async t => {
+test('Can execute local binaries when using plugins cached in the build image', async (t) => {
   await runFixture(t, 'build_image_bin', {
     flags: { buildImagePluginsDir: `${FIXTURES_DIR}/build_image_cache_bin/node_modules` },
   })
 })
 
-const getNodePath = function(version) {
+const getNodePath = function (version) {
   return `/home/ether/.nvm/versions/node/v${version}/bin/node`
 }
 
-test('Validate --node-path version is supported by our codebase', async t => {
+test('Validate --node-path version is supported by our codebase', async (t) => {
   const nodePath = getNodePath('8.2.0')
   await runFixture(t, 'node_version_simple', { flags: { nodePath } })
 })
 
-test('Validate --node-path unsupported version does not fail when no plugins are used', async t => {
+test('Validate --node-path unsupported version does not fail when no plugins are used', async (t) => {
   const nodePath = getNodePath('8.2.0')
   await runFixture(t, 'empty', { flags: { nodePath } })
 })
 
-test('Validate --node-path version is supported by the plugin', async t => {
+test('Validate --node-path version is supported by the plugin', async (t) => {
   const nodePath = getNodePath('9.0.0')
   await runFixture(t, 'engines', { flags: { nodePath } })
 })
 
-test('Validate --node-path', async t => {
+test('Validate --node-path', async (t) => {
   await runFixture(t, 'node_version_simple', { flags: { nodePath: '/doesNotExist' } })
 })
 
-test('Plugins can execute local binaries', async t => {
+test('Plugins can execute local binaries', async (t) => {
   await runFixture(t, 'local_bin')
 })
 
-test('Plugin output can interleave stdout and stderr', async t => {
+test('Plugin output can interleave stdout and stderr', async (t) => {
   await runFixture(t, 'interleave')
 })
 
 // TODO: check output length once big outputs are actually fixed
-test.serial('Big plugin output is not truncated', async t => {
+test.serial('Big plugin output is not truncated', async (t) => {
   await runFixture(t, 'big', { snapshot: false })
   t.pass()
 })
 
-test('Plugins can have inputs', async t => {
+test('Plugins can have inputs', async (t) => {
   await runFixture(t, 'inputs')
 })
 
-test('process.env changes are propagated to other plugins', async t => {
+test('process.env changes are propagated to other plugins', async (t) => {
   await runFixture(t, 'env_changes_plugin')
 })
 
-test('process.env changes are propagated to onError and onEnd', async t => {
+test('process.env changes are propagated to onError and onEnd', async (t) => {
   await runFixture(t, 'env_changes_on_error')
 })
 
-test('process.env changes are propagated to build.command', async t => {
+test('process.env changes are propagated to build.command', async (t) => {
   await runFixture(t, 'env_changes_command')
 })
 
-test('Expose some utils', async t => {
+test('Expose some utils', async (t) => {
   await runFixture(t, 'keys')
 })
 
-test('Utils are defined', async t => {
+test('Utils are defined', async (t) => {
   await runFixture(t, 'defined')
 })
 
-test('Can run utils', async t => {
+test('Can run utils', async (t) => {
   await removeDir(`${FIXTURES_DIR}/functions/functions`)
   await runFixture(t, 'functions')
   await removeDir(`${FIXTURES_DIR}/functions/functions`)
 })
 
-test('Git utils fails if no root', async t => {
+test('Git utils fails if no root', async (t) => {
   await runFixture(t, 'git_no_root', { copyRoot: { git: false } })
 })
 
-test('Git utils does not fail if no root and not used', async t => {
+test('Git utils does not fail if no root and not used', async (t) => {
   await runFixture(t, 'keys', { copyRoot: { git: false } })
 })
 
-test('Validate plugin is an object', async t => {
+test('Validate plugin is an object', async (t) => {
   await runFixture(t, 'object')
 })
 
-test('Validate plugin event handler names', async t => {
+test('Validate plugin event handler names', async (t) => {
   await runFixture(t, 'handler_name')
 })
 
-test('Validate plugin event handler function', async t => {
+test('Validate plugin event handler function', async (t) => {
   await runFixture(t, 'handler_function')
 })

--- a/packages/build/tests/status/fixtures/error_load_uncaught/plugin.js
+++ b/packages/build/tests/status/fixtures/error_load_uncaught/plugin.js
@@ -1,4 +1,4 @@
-const throwError = function() {
+const throwError = function () {
   throw new Error('test')
 }
 

--- a/packages/build/tests/status/fixtures/error_plugin_load/one/index.js
+++ b/packages/build/tests/status/fixtures/error_plugin_load/one/index.js
@@ -1,6 +1,6 @@
 module.exports = {}
 
-const throwError = function() {
+const throwError = function () {
   throw new Error('test')
 }
 

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -6,32 +6,29 @@ const { startServer } = require('../helpers/server')
 const STATUS_PATH = '/api/v1/deploys/test/plugin_runs'
 
 // Normalize API request body so it can be snapshot in a stable way
-const normalizeRequest = function({ body: { version, text, ...body }, ...request }) {
+const normalizeRequest = function ({ body: { version, text, ...body }, ...request }) {
   const versionA = version.replace(VERSION_REGEXP, '1.0.0')
   const textA = normalizeText(text)
   return { ...request, body: { ...body, version: versionA, text: textA } }
 }
 
-const normalizeText = function(text) {
+const normalizeText = function (text) {
   if (typeof text !== 'string') {
     return text
   }
 
-  return text
-    .replace(STACK_TRACE_REGEXP, '')
-    .replace(WHITESPACE_REGEXP, ' ')
-    .trim()
+  return text.replace(STACK_TRACE_REGEXP, '').replace(WHITESPACE_REGEXP, ' ').trim()
 }
 
 const VERSION_REGEXP = /\d+\.\d+\.\d+/g
 const STACK_TRACE_REGEXP = /^\s+at .*/gm
 const WHITESPACE_REGEXP = /\s+/g
 
-const comparePackage = function({ body: { package: packageA } }, { body: { package: packageB } }) {
+const comparePackage = function ({ body: { package: packageA } }, { body: { package: packageB } }) {
   return packageA < packageB ? -1 : 1
 }
 
-const runWithApiMock = async function(t, fixture, { flags = { token: 'test' }, status } = {}) {
+const runWithApiMock = async function (t, fixture, { flags = { token: 'test' }, status } = {}) {
   const { scheme, host, requests, stopServer } = await startServer(STATUS_PATH, {}, { status })
   await runFixture(t, fixture, {
     flags: { deployId: 'test', ...flags, sendStatus: true, testOpts: { scheme, host } },
@@ -41,166 +38,166 @@ const runWithApiMock = async function(t, fixture, { flags = { token: 'test' }, s
   t.snapshot(snapshots)
 }
 
-test('utils.status.show() can override a success status', async t => {
+test('utils.status.show() can override a success status', async (t) => {
   await runWithApiMock(t, 'success_status_override')
 })
 
-test('utils.status.show() cannot override an error status with a success status', async t => {
+test('utils.status.show() cannot override an error status with a success status', async (t) => {
   await runWithApiMock(t, 'error_status_override')
 })
 
-test('utils.status.show() plugin error cannot override a build error', async t => {
+test('utils.status.show() plugin error cannot override a build error', async (t) => {
   await runWithApiMock(t, 'error_status_error_override')
 })
 
-test('utils.status.show() implicit status is not used when an explicit call was made', async t => {
+test('utils.status.show() implicit status is not used when an explicit call was made', async (t) => {
   await runWithApiMock(t, 'no_implicit')
 })
 
-test('utils.status.show() implicit status is not used when there are no events', async t => {
+test('utils.status.show() implicit status is not used when there are no events', async (t) => {
   await runWithApiMock(t, 'no_implicit_none')
 })
 
-test('utils.status.show() implicit status is not used when plugin did not complete', async t => {
+test('utils.status.show() implicit status is not used when plugin did not complete', async (t) => {
   await runWithApiMock(t, 'no_implicit_incomplete')
 })
 
-test('utils.status.show() implicit status is not used when no call was made, with only onError', async t => {
+test('utils.status.show() implicit status is not used when no call was made, with only onError', async (t) => {
   await runWithApiMock(t, 'no_implicit_onerror')
 })
 
-test('utils.status.show() implicit status is used when no call was made', async t => {
+test('utils.status.show() implicit status is used when no call was made', async (t) => {
   await runWithApiMock(t, 'implicit_one')
 })
 
-test('utils.status.show() implicit status is used when no events have made a call', async t => {
+test('utils.status.show() implicit status is used when no events have made a call', async (t) => {
   await runWithApiMock(t, 'implicit_several')
 })
 
-test('utils.status.show() implicit status is used when no call was made, with only onEnd', async t => {
+test('utils.status.show() implicit status is used when no call was made, with only onEnd', async (t) => {
   await runWithApiMock(t, 'implicit_onend')
 })
 
-test('utils.status.show() are printed locally', async t => {
+test('utils.status.show() are printed locally', async (t) => {
   await runFixture(t, 'print')
 })
 
-test('utils.status.show() are not printed in production', async t => {
+test('utils.status.show() are not printed in production', async (t) => {
   await runFixture(t, 'print', { flags: { mode: 'buildbot' } })
 })
 
-test('utils.status.show() statuses are sent to the API', async t => {
+test('utils.status.show() statuses are sent to the API', async (t) => {
   await runWithApiMock(t, 'print')
 })
 
-test('utils.status.show() statuses are not sent to the API without a token', async t => {
+test('utils.status.show() statuses are not sent to the API without a token', async (t) => {
   await runWithApiMock(t, 'print', { flags: { token: '' } })
 })
 
-test('utils.status.show() statuses are not sent to the API without a DEPLOY_ID', async t => {
+test('utils.status.show() statuses are not sent to the API without a DEPLOY_ID', async (t) => {
   await runWithApiMock(t, 'print', { flags: { deployId: '' } })
 })
 
-test('utils.status.show() statuses API errors are handled', async t => {
+test('utils.status.show() statuses API errors are handled', async (t) => {
   await runWithApiMock(t, 'simple', { status: 502 })
 })
 
-test('utils.status.show() statuses are sent to the API without colors', async t => {
+test('utils.status.show() statuses are sent to the API without colors', async (t) => {
   await runWithApiMock(t, 'colors')
 })
 
-test('report error statuses from failBuild()', async t => {
+test('report error statuses from failBuild()', async (t) => {
   await runWithApiMock(t, 'error_fail_build')
 })
 
-test('report error statuses from failPlugin()', async t => {
+test('report error statuses from failPlugin()', async (t) => {
   await runWithApiMock(t, 'error_fail_plugin')
 })
 
-test('report error statuses from cancelBuild()', async t => {
+test('report error statuses from cancelBuild()', async (t) => {
   await runWithApiMock(t, 'error_cancel_build')
 })
 
-test('does not report error statuses from build.command errors', async t => {
+test('does not report error statuses from build.command errors', async (t) => {
   await runWithApiMock(t, 'error_build_command')
 })
 
-test('report error statuses from uncaught exceptions with static properties', async t => {
+test('report error statuses from uncaught exceptions with static properties', async (t) => {
   await runWithApiMock(t, 'error_properties')
 })
 
-test('report error statuses from uncaught exceptions during plugin load', async t => {
+test('report error statuses from uncaught exceptions during plugin load', async (t) => {
   await runWithApiMock(t, 'error_load_uncaught')
 })
 
-test('report error statuses from uncaught exceptions during onSuccess', async t => {
+test('report error statuses from uncaught exceptions during onSuccess', async (t) => {
   await runWithApiMock(t, 'error_onsuccess')
 })
 
-test('report error statuses from uncaught exceptions during onEnd', async t => {
+test('report error statuses from uncaught exceptions during onEnd', async (t) => {
   await runWithApiMock(t, 'error_onend')
 })
 
-test('report error statuses from plugin invalid shape', async t => {
+test('report error statuses from plugin invalid shape', async (t) => {
   await runWithApiMock(t, 'error_plugin_shape')
 })
 
-test('report error statuses from plugin inputs validation', async t => {
+test('report error statuses from plugin inputs validation', async (t) => {
   await runWithApiMock(t, 'error_inputs_validation')
 })
 
-test('report error statuses from plugin loads with other plugins loading', async t => {
+test('report error statuses from plugin loads with other plugins loading', async (t) => {
   await runWithApiMock(t, 'error_plugin_load')
 })
 
-const runUtilsStatusShow = function(t, argument) {
+const runUtilsStatusShow = function (t, argument) {
   return runFixture(t, 'show_util', { env: { SHOW_ARG: JSON.stringify(argument) } })
 }
 
-test('utils.status.show() does not fail', async t => {
+test('utils.status.show() does not fail', async (t) => {
   await runUtilsStatusShow(t, { title: 'title', summary: 'summary', text: 'text' })
 })
 
-test('utils.status.show() argument should be defined', async t => {
+test('utils.status.show() argument should be defined', async (t) => {
   await runUtilsStatusShow(t, '')
 })
 
-test('utils.status.show() argument should be an object', async t => {
+test('utils.status.show() argument should be an object', async (t) => {
   await runUtilsStatusShow(t, 'summary')
 })
 
-test('utils.status.show() argument should not contain typos', async t => {
+test('utils.status.show() argument should not contain typos', async (t) => {
   await runUtilsStatusShow(t, { titles: 'title', summary: 'summary', text: 'text' })
 })
 
-test('utils.status.show() requires a summary', async t => {
+test('utils.status.show() requires a summary', async (t) => {
   await runUtilsStatusShow(t, { title: 'title', text: 'text' })
 })
 
-test('utils.status.show() allow other fields to be optional', async t => {
+test('utils.status.show() allow other fields to be optional', async (t) => {
   await runUtilsStatusShow(t, { summary: 'summary' })
 })
 
-test('utils.status.show() title should be a string', async t => {
+test('utils.status.show() title should be a string', async (t) => {
   await runUtilsStatusShow(t, { title: true, summary: 'summary', text: 'text' })
 })
 
-test('utils.status.show() title can be empty', async t => {
+test('utils.status.show() title can be empty', async (t) => {
   await runUtilsStatusShow(t, { title: ' ', summary: 'summary', text: 'text' })
 })
 
-test('utils.status.show() summary should be a string', async t => {
+test('utils.status.show() summary should be a string', async (t) => {
   await runUtilsStatusShow(t, { title: 'title', summary: true, text: 'text' })
 })
 
-test('utils.status.show() summary should not be empty', async t => {
+test('utils.status.show() summary should not be empty', async (t) => {
   await runUtilsStatusShow(t, { title: 'title', summary: ' ', text: 'text' })
 })
 
-test('utils.status.show() text should be a string', async t => {
+test('utils.status.show() text should be a string', async (t) => {
   await runUtilsStatusShow(t, { title: 'title', summary: 'summary', text: true })
 })
 
-test('utils.status.show() text can be empty', async t => {
+test('utils.status.show() text can be empty', async (t) => {
   await runUtilsStatusShow(t, { title: 'title', summary: 'summary', text: ' ' })
 })

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -3,32 +3,32 @@ const test = require('ava')
 const { runFixture } = require('../helpers/main')
 const { startUdpServer } = require('../helpers/udp_server')
 
-test('Sends timings to --statsd.host|port', async t => {
+test('Sends timings to --statsd.host|port', async (t) => {
   t.snapshot(await getTimerRequestsString(t, 'simple'))
 })
 
-test('Sends timings of plugins', async t => {
+test('Sends timings of plugins', async (t) => {
   t.snapshot(await getTimerRequestsString(t, 'plugin'))
 })
 
-test('Allow passing --framework CLI flag', async t => {
+test('Allow passing --framework CLI flag', async (t) => {
   const timerRequests = await getAllTimerRequests(t, 'simple', { framework: 'test' })
-  t.true(timerRequests.every(timerRequest => timerRequest.includes('framework:test')))
+  t.true(timerRequests.every((timerRequest) => timerRequest.includes('framework:test')))
 })
 
-test('Default --framework CLI flag to nothing', async t => {
+test('Default --framework CLI flag to nothing', async (t) => {
   const timerRequests = await getAllTimerRequests(t, 'simple')
-  t.true(timerRequests.every(timerRequest => !timerRequest.includes('framework:')))
+  t.true(timerRequests.every((timerRequest) => !timerRequest.includes('framework:')))
 })
 
 // Retrieve statsd packets sent to --statsd.host|port, and get their snapshot
-const getTimerRequestsString = async function(t, fixtureName, flags) {
+const getTimerRequestsString = async function (t, fixtureName, flags) {
   const timerRequests = await getAllTimerRequests(t, fixtureName, flags)
   const timerRequestsString = serializeTimerRequests(timerRequests)
   return timerRequestsString
 }
 
-const getAllTimerRequests = async function(t, fixtureName, flags = {}) {
+const getAllTimerRequests = async function (t, fixtureName, flags = {}) {
   const { host, port, requests, stopServer } = await startUdpServer()
   try {
     await runFixture(t, fixtureName, { flags: { statsd: { host, port }, ...flags }, snapshot: false })
@@ -40,19 +40,15 @@ const getAllTimerRequests = async function(t, fixtureName, flags = {}) {
   return timerRequests
 }
 
-const flattenRequest = function(request) {
+const flattenRequest = function (request) {
   return request.trim().split('\n')
 }
 
-const serializeTimerRequests = function(timerRequests) {
-  return timerRequests
-    .map(normalizeRequest)
-    .sort()
-    .join('\n')
-    .trim()
+const serializeTimerRequests = function (timerRequests) {
+  return timerRequests.map(normalizeRequest).sort().join('\n').trim()
 }
 
-const normalizeRequest = function(request) {
+const normalizeRequest = function (request) {
   return request.replace(NUMBERS_REGEXP, 0)
 }
 

--- a/packages/cache-utils/src/dir.js
+++ b/packages/cache-utils/src/dir.js
@@ -4,7 +4,7 @@ const { platform } = require('process')
 const globalCacheDir = require('global-cache-dir')
 
 // Retrieve the cache directory location
-const getCacheDir = function({ cacheDir, mode, isTest } = {}) {
+const getCacheDir = function ({ cacheDir, mode, isTest } = {}) {
   if (cacheDir !== undefined) {
     return resolve(cacheDir)
   }

--- a/packages/cache-utils/src/expire.js
+++ b/packages/cache-utils/src/expire.js
@@ -1,5 +1,5 @@
 // Retrieve the expiration date when caching a file
-const getExpires = function(ttl) {
+const getExpires = function (ttl) {
   if (!Number.isInteger(ttl) || ttl < 1) {
     return
   }
@@ -10,7 +10,7 @@ const getExpires = function(ttl) {
 const SECS_TO_MSECS = 1e3
 
 // Check if a file about to be restored is expired
-const checkExpires = function(expires) {
+const checkExpires = function (expires) {
   return expires !== undefined && Date.now() > expires
 }
 

--- a/packages/cache-utils/src/fs.js
+++ b/packages/cache-utils/src/fs.js
@@ -9,7 +9,7 @@ const moveFile = require('move-file')
 const pStat = promisify(stat)
 
 // Move or copy a cached file/directory from/to a local one
-const moveCacheFile = async function(src, dest, move) {
+const moveCacheFile = async function (src, dest, move) {
   // Moving is faster but removes the source files locally
   if (move) {
     return moveFile(src, dest, { overwrite: false })
@@ -20,13 +20,13 @@ const moveCacheFile = async function(src, dest, move) {
 }
 
 // Non-existing files and empty directories are always skipped
-const hasFiles = async function(src) {
+const hasFiles = async function (src) {
   const { srcGlob, cwd, isDir } = await getSrcGlob(src)
   return srcGlob !== undefined && !(await isEmptyDir({ srcGlob, cwd, isDir }))
 }
 
 // Replicates what `cpy` is doing under the hood.
-const isEmptyDir = async function({ srcGlob, cwd, isDir }) {
+const isEmptyDir = async function ({ srcGlob, cwd, isDir }) {
   if (!isDir) {
     return false
   }
@@ -36,7 +36,7 @@ const isEmptyDir = async function({ srcGlob, cwd, isDir }) {
 }
 
 // Get globbing pattern with files to move/copy
-const getSrcGlob = async function(src) {
+const getSrcGlob = async function (src) {
   const stat = await getStat(src)
 
   if (stat === undefined) {
@@ -54,7 +54,7 @@ const getSrcGlob = async function(src) {
   return { srcGlob: srcBasename, cwd, isDir }
 }
 
-const getStat = async function(src) {
+const getStat = async function (src) {
   try {
     return await pStat(src)
   } catch (error) {}

--- a/packages/cache-utils/src/hash.js
+++ b/packages/cache-utils/src/hash.js
@@ -7,7 +7,7 @@ const locatePath = require('locate-path')
 // Caching a big directory like `node_modules` is slow. However those can
 // sometime be represented by a digest file such as `package-lock.json`. If this
 // has not changed, we don't need to save cache again.
-const getHash = async function(digests, move) {
+const getHash = async function (digests, move) {
   // Moving files is faster than computing hashes
   if (move || digests.length === 0) {
     return
@@ -23,7 +23,7 @@ const getHash = async function(digests, move) {
 }
 
 // Hash a file's contents
-const hashFile = async function(path) {
+const hashFile = async function (path) {
   const contentStream = createReadStream(path, 'utf8')
   const hashStream = createHash(HASH_ALGO, { encoding: 'hex' })
   contentStream.pipe(hashStream)

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -7,7 +7,7 @@ const { isManifest } = require('./manifest')
 const { getBases } = require('./path')
 
 // List all cached files/directories, at the top-level
-const list = async function({ cacheDir, cwd: cwdOpt, mode, depth = DEFAULT_DEPTH } = {}) {
+const list = async function ({ cacheDir, cwd: cwdOpt, mode, depth = DEFAULT_DEPTH } = {}) {
   const bases = await getBases(cwdOpt)
   const cacheDirA = await getCacheDir({ cacheDir, mode })
   const files = await Promise.all(bases.map(({ name, base }) => listBase({ name, base, cacheDir: cacheDirA, depth })))
@@ -18,13 +18,13 @@ const list = async function({ cacheDir, cwd: cwdOpt, mode, depth = DEFAULT_DEPTH
 const DEFAULT_DEPTH = 1
 
 // TODO: the returned paths are missing the Windows drive
-const listBase = async function({ name, base, cacheDir, depth }) {
+const listBase = async function ({ name, base, cacheDir, depth }) {
   const files = await readdirp.promise(`${cacheDir}/${name}`, { fileFilter, depth, type: 'files_directories' })
   const filesA = files.map(({ path }) => join(base, path))
   return filesA
 }
 
-const fileFilter = function({ basename }) {
+const fileFilter = function ({ basename }) {
   return !isManifest(basename)
 }
 

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -9,7 +9,7 @@ const { getManifestInfo, writeManifest, removeManifest, isExpired } = require('.
 const { parsePath } = require('./path')
 
 // Cache a file
-const saveOne = async function(
+const saveOne = async function (
   path,
   { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [], cacheDir, cwd: cwdOpt, mode } = {},
 ) {
@@ -32,7 +32,7 @@ const saveOne = async function(
 }
 
 // Restore a cached file
-const restoreOne = async function(path, { move = DEFAULT_MOVE, cacheDir, cwd: cwdOpt, mode } = {}) {
+const restoreOne = async function (path, { move = DEFAULT_MOVE, cacheDir, cwd: cwdOpt, mode } = {}) {
   const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   if (!(await hasFiles(cachePath))) {
@@ -50,7 +50,7 @@ const restoreOne = async function(path, { move = DEFAULT_MOVE, cacheDir, cwd: cw
 }
 
 // Remove the cache of a file
-const removeOne = async function(path, { cacheDir, cwd: cwdOpt, mode } = {}) {
+const removeOne = async function (path, { cacheDir, cwd: cwdOpt, mode } = {}) {
   const { cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   if (!(await hasFiles(cachePath))) {
@@ -64,7 +64,7 @@ const removeOne = async function(path, { cacheDir, cwd: cwdOpt, mode } = {}) {
 }
 
 // Check if a file is cached
-const hasOne = async function(path, { cacheDir, cwd: cwdOpt, mode } = {}) {
+const hasOne = async function (path, { cacheDir, cwd: cwdOpt, mode } = {}) {
   const { cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
 
   return (await hasFiles(cachePath)) && !(await isExpired(cachePath))
@@ -75,12 +75,12 @@ const DEFAULT_TTL = undefined
 
 // Allow each of the main functions to take either a single path or an array of
 // paths as arguments
-const allowMany = async function(func, paths, ...args) {
+const allowMany = async function (func, paths, ...args) {
   if (!Array.isArray(paths)) {
     return func(paths, ...args)
   }
 
-  const results = await Promise.all(paths.map(path => func(path, ...args)))
+  const results = await Promise.all(paths.map((path) => func(path, ...args)))
   return results.some(Boolean)
 }
 
@@ -90,14 +90,14 @@ const remove = allowMany.bind(null, removeOne)
 const has = allowMany.bind(null, hasOne)
 
 // Change `opts` default values
-const bindOpts = function(opts) {
+const bindOpts = function (opts) {
   return {
     save: (paths, optsA) => save(paths, { ...opts, ...optsA }),
     restore: (paths, optsA) => restore(paths, { ...opts, ...optsA }),
     remove: (paths, optsA) => remove(paths, { ...opts, ...optsA }),
     has: (paths, optsA) => has(paths, { ...opts, ...optsA }),
-    list: optsA => list({ ...opts, ...optsA }),
-    getCacheDir: optsA => getCacheDir({ ...opts, ...optsA }),
+    list: (optsA) => list({ ...opts, ...optsA }),
+    getCacheDir: (optsA) => getCacheDir({ ...opts, ...optsA }),
   }
 }
 

--- a/packages/cache-utils/src/manifest.js
+++ b/packages/cache-utils/src/manifest.js
@@ -14,7 +14,7 @@ const pReadFile = promisify(readFile)
 
 // Retrieve cache manifest of a file to cache, which contains the file/directory
 // contents hash and the `expires` date.
-const getManifestInfo = async function({ cachePath, move, ttl, digests }) {
+const getManifestInfo = async function ({ cachePath, move, ttl, digests }) {
   const manifestPath = getManifestPath(cachePath)
   const expires = getExpires(ttl)
   const hash = await getHash(digests, move)
@@ -25,7 +25,7 @@ const getManifestInfo = async function({ cachePath, move, ttl, digests }) {
 }
 
 // Whether the cache manifest has changed
-const isIdentical = async function({ hash, manifestPath, manifestString }) {
+const isIdentical = async function ({ hash, manifestPath, manifestString }) {
   if (hash === undefined || !(await pathExists(manifestPath))) {
     return false
   }
@@ -35,30 +35,30 @@ const isIdentical = async function({ hash, manifestPath, manifestString }) {
 }
 
 // Persist the cache manifest to filesystem
-const writeManifest = async function({ manifestPath, manifestString }) {
+const writeManifest = async function ({ manifestPath, manifestString }) {
   await makeDir(dirname(manifestPath))
   await pWriteFile(manifestPath, manifestString)
 }
 
 // Remove the cache manifest from filesystem
-const removeManifest = async function(cachePath) {
+const removeManifest = async function (cachePath) {
   const manifestPath = getManifestPath(cachePath)
   await del(manifestPath, { force: true })
 }
 
 // Retrieve the cache manifest filepath
-const getManifestPath = function(cachePath) {
+const getManifestPath = function (cachePath) {
   return `${cachePath}${CACHE_EXTENSION}`
 }
 
-const isManifest = function(filePath) {
+const isManifest = function (filePath) {
   return filePath.endsWith(CACHE_EXTENSION)
 }
 
 const CACHE_EXTENSION = '.netlify.cache.json'
 
 // Check whether a file/directory is expired by checking its cache manifest
-const isExpired = async function(cachePath) {
+const isExpired = async function (cachePath) {
   const manifestPath = getManifestPath(cachePath)
   if (!(await pathExists(manifestPath))) {
     return false
@@ -68,7 +68,7 @@ const isExpired = async function(cachePath) {
   return checkExpires(expires)
 }
 
-const readManifest = async function(cachePath) {
+const readManifest = async function (cachePath) {
   const manifestPath = getManifestPath(cachePath)
   const manifestString = await pReadFile(manifestPath, 'utf8')
   const manifest = JSON.parse(manifestString)

--- a/packages/cache-utils/src/path.js
+++ b/packages/cache-utils/src/path.js
@@ -5,21 +5,21 @@ const { getCacheDir } = require('./dir')
 const { safeGetCwd } = require('./utils/cwd')
 
 // Find the paths of the file before/after caching
-const parsePath = async function({ path, cacheDir, cwdOpt, mode }) {
+const parsePath = async function ({ path, cacheDir, cwdOpt, mode }) {
   const srcPath = await getSrcPath(path, cwdOpt)
   const cachePath = await getCachePath({ srcPath, cacheDir, cwdOpt, mode })
   return { srcPath, cachePath }
 }
 
 // Retrieve absolute path to the local file to cache/restore
-const getSrcPath = async function(path, cwdOpt) {
+const getSrcPath = async function (path, cwdOpt) {
   const cwd = await safeGetCwd(cwdOpt)
   const srcPath = resolvePath(path, cwd)
   checkSrcPath(srcPath, cwd)
   return srcPath
 }
 
-const resolvePath = function(path, cwd) {
+const resolvePath = function (path, cwd) {
   if (isAbsolute(path)) {
     return resolve(path)
   }
@@ -39,18 +39,18 @@ const resolvePath = function(path, cwd) {
 //  - It undoes any build operations inside the repository that might have
 //    happened before this plugin starts restoring the cache, leading to
 //    conflicts with other plugins, Netlify Build or the buildbot.
-const checkSrcPath = function(srcPath, cwd) {
+const checkSrcPath = function (srcPath, cwd) {
   if (cwd !== '' && isParentPath(srcPath, cwd)) {
     throw new Error(`Cannot cache ${srcPath} because it is the current directory (${cwd}) or a parent directory`)
   }
 }
 
 // Note: srcPath and cwd are already normalized and absolute
-const isParentPath = function(srcPath, cwd) {
+const isParentPath = function (srcPath, cwd) {
   return `${cwd}${sep}`.startsWith(`${srcPath}${sep}`)
 }
 
-const getCachePath = async function({ srcPath, cacheDir, cwdOpt, mode }) {
+const getCachePath = async function ({ srcPath, cacheDir, cwdOpt, mode }) {
   const cacheDirA = await getCacheDir({ cacheDir, mode })
   const { name, relPath } = await findBase(srcPath, cwdOpt)
   const cachePath = join(cacheDirA, name, relPath)
@@ -60,7 +60,7 @@ const getCachePath = async function({ srcPath, cacheDir, cwdOpt, mode }) {
 // The cached path is the path relative to the base which can be either the
 // current directory, the home directory or the root directory. Each is tried
 // in order.
-const findBase = async function(srcPath, cwdOpt) {
+const findBase = async function (srcPath, cwdOpt) {
   const bases = await getBases(cwdOpt)
   const srcPathA = normalizeWindows(srcPath)
   return bases.map(({ name, base }) => parseBase(name, base, srcPathA)).find(Boolean)
@@ -76,14 +76,14 @@ const findBase = async function(srcPath, cwdOpt) {
 // This also means `cache.list()` always assumes the source files are on the
 // current drive.
 // TODO: fix it.
-const normalizeWindows = function(srcPath) {
+const normalizeWindows = function (srcPath) {
   return srcPath.replace(WINDOWS_DRIVE_REGEX, '\\')
 }
 
 const WINDOWS_DRIVE_REGEX = /^[a-zA-Z]:\\/
 
 // This logic works when `base` and `path` are on different Windows drives
-const parseBase = function(name, base, srcPath) {
+const parseBase = function (name, base, srcPath) {
   if (srcPath === base || !srcPath.startsWith(base)) {
     return
   }
@@ -92,12 +92,12 @@ const parseBase = function(name, base, srcPath) {
   return { name, relPath }
 }
 
-const getBases = async function(cwdOpt) {
+const getBases = async function (cwdOpt) {
   const cwdBase = await getCwdBase(cwdOpt)
   return [...cwdBase, { name: 'home', base: homedir() }, { name: 'root', base: sep }]
 }
 
-const getCwdBase = async function(cwdOpt) {
+const getCwdBase = async function (cwdOpt) {
   const cwd = await safeGetCwd(cwdOpt)
   if (cwd === '') {
     return []

--- a/packages/cache-utils/src/utils/cwd.js
+++ b/packages/cache-utils/src/utils/cwd.js
@@ -4,7 +4,7 @@ const process = require('process')
 const pathExists = require('path-exists')
 
 // Like `process.cwd()` but safer when current directory is wrong
-const safeGetCwd = async function(cwdOpt) {
+const safeGetCwd = async function (cwdOpt) {
   try {
     const cwd = getCwdValue(cwdOpt)
 
@@ -18,7 +18,7 @@ const safeGetCwd = async function(cwdOpt) {
   }
 }
 
-const getCwdValue = function(cwdOpt = process.cwd()) {
+const getCwdValue = function (cwdOpt = process.cwd()) {
   return normalize(cwdOpt)
 }
 

--- a/packages/cache-utils/tests/digests.js
+++ b/packages/cache-utils/tests/digests.js
@@ -4,7 +4,7 @@ const cacheUtils = require('..')
 
 const { pWriteFile, pReadFile, createTmpDir, removeFiles } = require('./helpers/main')
 
-test('Should allow caching according to a digest file', async t => {
+test('Should allow caching according to a digest file', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   try {
     const srcFile = `${srcDir}/test`
@@ -21,7 +21,7 @@ test('Should allow caching according to a digest file', async t => {
   }
 })
 
-test('Should allow caching according to several potential digests files', async t => {
+test('Should allow caching according to several potential digests files', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   try {
     const srcFile = `${srcDir}/test`
@@ -39,7 +39,7 @@ test('Should allow caching according to several potential digests files', async 
   }
 })
 
-test('Should ignore non-existing digests files', async t => {
+test('Should ignore non-existing digests files', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   try {
     const srcFile = `${srcDir}/test`

--- a/packages/cache-utils/tests/dir.js
+++ b/packages/cache-utils/tests/dir.js
@@ -7,7 +7,7 @@ const cacheUtils = require('..')
 
 const { pWriteFile, createTmpDir, removeFiles } = require('./helpers/main')
 
-test('Should allow not changing the cache directory', async t => {
+test('Should allow not changing the cache directory', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   const currentDir = getCwd()
   chdir(srcDir)
@@ -24,7 +24,7 @@ test('Should allow not changing the cache directory', async t => {
   }
 })
 
-test('Should allow not changing the cache directory in CI', async t => {
+test('Should allow not changing the cache directory in CI', async (t) => {
   const cacheDir = await cacheUtils.getCacheDir({ mode: 'buildbot', isTest: true })
   t.true(await pathExists(cacheDir))
 })

--- a/packages/cache-utils/tests/has.js
+++ b/packages/cache-utils/tests/has.js
@@ -4,7 +4,7 @@ const cacheUtils = require('..')
 
 const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
-test('Should allow checking if one file is cached', async t => {
+test('Should allow checking if one file is cached', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.false(await cacheUtils.has(srcFile, { cacheDir }))
@@ -15,7 +15,7 @@ test('Should allow checking if one file is cached', async t => {
   }
 })
 
-test('Should allow checking if several files are cached', async t => {
+test('Should allow checking if several files are cached', async (t) => {
   const [cacheDir, [srcFile, srcDir], [otherSrcFile, otherSrcDir]] = await Promise.all([
     createTmpDir(),
     createTmpFile(),
@@ -30,6 +30,6 @@ test('Should allow checking if several files are cached', async t => {
   }
 })
 
-test('Should allow checking if one file is cached without an options object', async t => {
+test('Should allow checking if one file is cached without an options object', async (t) => {
   t.is(typeof (await cacheUtils.has('doesNotExist')), 'boolean')
 })

--- a/packages/cache-utils/tests/helpers/main.js
+++ b/packages/cache-utils/tests/helpers/main.js
@@ -9,12 +9,12 @@ const pSetTimeout = promisify(setTimeout)
 const pWriteFile = promisify(writeFile)
 const pReadFile = promisify(readFile)
 
-const createTmpDir = async function(opts) {
+const createTmpDir = async function (opts) {
   const { path } = await getTmpDir({ ...opts, prefix: PREFIX })
   return path
 }
 
-const createTmpFile = async function(opts) {
+const createTmpFile = async function (opts) {
   const tmpDir = await createTmpDir(opts)
   const filename = basename(await tmpName())
   const tmpFile = join(tmpDir, filename)
@@ -24,7 +24,7 @@ const createTmpFile = async function(opts) {
 
 const PREFIX = 'test-cache-utils-'
 
-const removeFiles = function(paths) {
+const removeFiles = function (paths) {
   return del(paths, { force: true })
 }
 

--- a/packages/cache-utils/tests/list.js
+++ b/packages/cache-utils/tests/list.js
@@ -6,39 +6,39 @@ const cacheUtils = require('..')
 
 const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
-test('Should allow listing cached files', async t => {
+test('Should allow listing cached files', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.deepEqual(await cacheUtils.list({ cacheDir }), [])
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     const files = await cacheUtils.list({ cacheDir })
     t.is(files.length, 2)
-    t.true(files.every(file => srcFile.replace(/^[a-zA-Z]:\\/, '\\').startsWith(file)))
+    t.true(files.every((file) => srcFile.replace(/^[a-zA-Z]:\\/, '\\').startsWith(file)))
   } finally {
     await removeFiles([cacheDir, srcDir])
   }
 })
 
-test('Should allow changing the listing depth', async t => {
+test('Should allow changing the listing depth', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.deepEqual(await cacheUtils.list({ cacheDir }), [])
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
     const files = await cacheUtils.list({ cacheDir, depth: 0 })
     t.is(files.length, 1)
-    t.true(files.every(file => srcFile.replace(/^[a-zA-Z]:\\/, '\\').startsWith(file)))
+    t.true(files.every((file) => srcFile.replace(/^[a-zA-Z]:\\/, '\\').startsWith(file)))
   } finally {
     await removeFiles([cacheDir, srcDir])
   }
 })
 
-test('Should allow listing cached files without an options object', async t => {
+test('Should allow listing cached files without an options object', async (t) => {
   t.true(Array.isArray(await cacheUtils.list()))
 })
 
 // Windows does not allow deleting directory uses as current directory
 if (process.platform !== 'win32') {
-  test('Should work when cwd does not exist', async t => {
+  test('Should work when cwd does not exist', async (t) => {
     const tmpDir = await createTmpDir()
     await removeFiles(tmpDir)
     t.true(Array.isArray(await cacheUtils.list({ cwd: tmpDir })))

--- a/packages/cache-utils/tests/move.js
+++ b/packages/cache-utils/tests/move.js
@@ -5,7 +5,7 @@ const cacheUtils = require('..')
 
 const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
-test('Should allow moving files instead of copying them', async t => {
+test('Should allow moving files instead of copying them', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, move: true }))

--- a/packages/cache-utils/tests/path.js
+++ b/packages/cache-utils/tests/path.js
@@ -8,7 +8,7 @@ const cacheUtils = require('..')
 
 const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
-test('Should allow caching files in home directory', async t => {
+test('Should allow caching files in home directory', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile({ tmpdir: homedir() })])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
@@ -20,23 +20,23 @@ test('Should allow caching files in home directory', async t => {
   }
 })
 
-test('Should not allow caching the current directory', async t => {
+test('Should not allow caching the current directory', async (t) => {
   await t.throwsAsync(cacheUtils.save('.'))
 })
 
-test('Should not allow caching a direct parent directory', async t => {
+test('Should not allow caching a direct parent directory', async (t) => {
   await t.throwsAsync(cacheUtils.save('..'))
 })
 
 // Windows does not allow deleting directory uses as current directory
 if (platform !== 'win32') {
-  test('Should not allow invalid cwd with relative paths', async t => {
+  test('Should not allow invalid cwd with relative paths', async (t) => {
     const tmpDir = await createTmpDir()
     await removeFiles(tmpDir)
     await t.throwsAsync(cacheUtils.save('test', { cwd: tmpDir }))
   })
 
-  test('Should allow invalid cwd with absolute paths', async t => {
+  test('Should allow invalid cwd with absolute paths', async (t) => {
     const [tmpDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
     await removeFiles(tmpDir)
     try {

--- a/packages/cache-utils/tests/remove.js
+++ b/packages/cache-utils/tests/remove.js
@@ -4,7 +4,7 @@ const cacheUtils = require('..')
 
 const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
-test('Should allow removing one cached file', async t => {
+test('Should allow removing one cached file', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
@@ -15,7 +15,7 @@ test('Should allow removing one cached file', async t => {
   }
 })
 
-test('Should allow removing several cached files', async t => {
+test('Should allow removing several cached files', async (t) => {
   const [cacheDir, [srcFile, srcDir], [otherSrcFile, otherSrcDir]] = await Promise.all([
     createTmpDir(),
     createTmpFile(),
@@ -30,6 +30,6 @@ test('Should allow removing several cached files', async t => {
   }
 })
 
-test('Should ignore when trying to remove non-cached files', async t => {
+test('Should ignore when trying to remove non-cached files', async (t) => {
   t.false(await cacheUtils.remove('nonExisting'))
 })

--- a/packages/cache-utils/tests/save_restore.js
+++ b/packages/cache-utils/tests/save_restore.js
@@ -6,11 +6,11 @@ const cacheUtils = require('..')
 
 const { pWriteFile, pReadFile, createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
-test('Should expose several methods', t => {
+test('Should expose several methods', (t) => {
   t.deepEqual(Object.keys(cacheUtils).sort(), ['bindOpts', 'getCacheDir', 'has', 'list', 'remove', 'restore', 'save'])
 })
 
-test('Should cache and restore one file', async t => {
+test('Should cache and restore one file', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir }))
@@ -22,7 +22,7 @@ test('Should cache and restore one file', async t => {
   }
 })
 
-test('Should cache and restore several files', async t => {
+test('Should cache and restore several files', async (t) => {
   const [cacheDir, [srcFile, srcDir], [otherSrcFile, otherSrcDir]] = await Promise.all([
     createTmpDir(),
     createTmpFile(),
@@ -38,7 +38,7 @@ test('Should cache and restore several files', async t => {
   }
 })
 
-test('Should cache and restore one directory', async t => {
+test('Should cache and restore one directory', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   try {
     const srcFile = `${srcDir}/test`
@@ -52,7 +52,7 @@ test('Should cache and restore one directory', async t => {
   }
 })
 
-test('Should keep file contents when caching files', async t => {
+test('Should keep file contents when caching files', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     await pWriteFile(srcFile, 'test')
@@ -66,7 +66,7 @@ test('Should keep file contents when caching files', async t => {
   }
 })
 
-test('Should overwrite files on restore', async t => {
+test('Should overwrite files on restore', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     await pWriteFile(srcFile, 'test')
@@ -80,15 +80,15 @@ test('Should overwrite files on restore', async t => {
   }
 })
 
-test('Should skip non-existing files on save', async t => {
+test('Should skip non-existing files on save', async (t) => {
   t.false(await cacheUtils.save('nonExisting'))
 })
 
-test('Should skip non-existing files on restore', async t => {
+test('Should skip non-existing files on restore', async (t) => {
   t.false(await cacheUtils.restore('nonExisting'))
 })
 
-test('Should skip empty directories on save', async t => {
+test('Should skip empty directories on save', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   try {
     t.false(await cacheUtils.save(srcDir, { cacheDir }))
@@ -97,7 +97,7 @@ test('Should skip empty directories on save', async t => {
   }
 })
 
-test('Should skip empty directories on restore', async t => {
+test('Should skip empty directories on restore', async (t) => {
   const cacheDir = await createTmpDir()
 
   try {
@@ -111,7 +111,7 @@ test('Should skip empty directories on restore', async t => {
   }
 })
 
-test('Should skip deep empty directories on save', async t => {
+test('Should skip deep empty directories on save', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   try {
     const srcSubDir = `${srcDir}/test`
@@ -123,7 +123,7 @@ test('Should skip deep empty directories on save', async t => {
   }
 })
 
-test('Should skip deep empty directories on restore', async t => {
+test('Should skip deep empty directories on restore', async (t) => {
   const cacheDir = await createTmpDir()
 
   try {

--- a/packages/cache-utils/tests/ttl.js
+++ b/packages/cache-utils/tests/ttl.js
@@ -5,7 +5,7 @@ const cacheUtils = require('..')
 const { pSetTimeout, createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
 
 // Relies on timing
-test.serial('Should allow a TTL on cached files', async t => {
+test.serial('Should allow a TTL on cached files', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, ttl: 1 }))
@@ -17,7 +17,7 @@ test.serial('Should allow a TTL on cached files', async t => {
   }
 })
 
-test.serial('Should skip TTL when the value is invalid', async t => {
+test.serial('Should skip TTL when the value is invalid', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, ttl: '1' }))
@@ -28,7 +28,7 @@ test.serial('Should skip TTL when the value is invalid', async t => {
   }
 })
 
-test.serial('Should skip TTL when the value is negative', async t => {
+test.serial('Should skip TTL when the value is negative', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
   try {
     t.true(await cacheUtils.save(srcFile, { cacheDir, ttl: -1 }))

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -24,7 +24,7 @@ _Return value_: `Promise<object>`
 ```js
 const getNetlifyConfig = require('@netlify/config')
 
-const exampleFunction = async function() {
+const exampleFunction = async function () {
   const { config, configPath, buildDir, context, branch, token, siteInfo } = await getNetlifyConfig(options)
   /*
   {

--- a/packages/config/src/api/build_settings.js
+++ b/packages/config/src/api/build_settings.js
@@ -4,7 +4,11 @@ const { removeFalsy } = require('../utils/remove_falsy')
 // production. In local builds, we retrieve them with `getSite` (`siteInfo`)
 // instead.
 // This also includes UI-installed plugins.
-const addBuildSettings = function({ defaultConfig, baseRelDir, siteInfo: { build_settings: buildSettings, plugins } }) {
+const addBuildSettings = function ({
+  defaultConfig,
+  baseRelDir,
+  siteInfo: { build_settings: buildSettings, plugins },
+}) {
   if (buildSettings === undefined) {
     return { defaultConfig, baseRelDir }
   }
@@ -15,7 +19,7 @@ const addBuildSettings = function({ defaultConfig, baseRelDir, siteInfo: { build
 }
 
 // From the `getSite` API response to the corresponding configuration properties
-const getDefaultConfig = function(
+const getDefaultConfig = function (
   uiPlugins = [],
   { cmd: command, dir: publish, functions_dir: functions, base, env: environment },
   { build, plugins = [], ...defaultConfig },
@@ -27,11 +31,11 @@ const getDefaultConfig = function(
 }
 
 // Make sure we know which fields we are picking from the API
-const normalizeUiPlugin = function({ package: packageName, inputs }) {
+const normalizeUiPlugin = function ({ package: packageName, inputs }) {
   return { package: packageName, inputs }
 }
 
-const getBaseRelDir = function({ base_rel_dir: siteBaseRelDir }, baseRelDir = siteBaseRelDir) {
+const getBaseRelDir = function ({ base_rel_dir: siteBaseRelDir }, baseRelDir = siteBaseRelDir) {
   return Boolean(baseRelDir)
 }
 

--- a/packages/config/src/api/client.js
+++ b/packages/config/src/api/client.js
@@ -3,7 +3,7 @@ const NetlifyAPI = require('netlify')
 const { removeFalsy } = require('../utils/remove_falsy')
 
 // Retrieve Netlify API client, if an access token was passed
-const getApiClient = function({ token, testOpts: { scheme, host } = {} }) {
+const getApiClient = function ({ token, testOpts: { scheme, host } = {} }) {
   if (!token) {
     return
   }

--- a/packages/config/src/api/site_info.js
+++ b/packages/config/src/api/site_info.js
@@ -3,7 +3,7 @@
 // This is not used in production builds since the buildbot passes this
 // information instead.
 // Requires knowing the `siteId` and having the access `token`.
-const getSiteInfo = async function(api, siteId, mode) {
+const getSiteInfo = async function (api, siteId, mode) {
   if (api === undefined || siteId === undefined || mode === 'buildbot') {
     return { id: siteId }
   }
@@ -12,7 +12,7 @@ const getSiteInfo = async function(api, siteId, mode) {
   return { ...siteInfo, id: siteId }
 }
 
-const getSite = async function(siteId, api) {
+const getSite = async function (siteId, api) {
   try {
     return await api.getSite({ site_id: siteId })
     // Silently ignore errors. For example the network connection might be down,

--- a/packages/config/src/bin/flags.js
+++ b/packages/config/src/bin/flags.js
@@ -2,11 +2,8 @@ const filterObj = require('filter-obj')
 const yargs = require('yargs')
 
 // Parse CLI flags
-const parseFlags = function() {
-  const flags = yargs
-    .options(FLAGS)
-    .usage(USAGE)
-    .parse()
+const parseFlags = function () {
+  const flags = yargs.options(FLAGS).usage(USAGE).parse()
   const flagsA = filterObj(flags, isUserFlag)
   return flagsA
 }
@@ -111,7 +108,7 @@ The result is printed as a JSON object on stdout with the following properties:
   - branch     {string}  Repository branch`
 
 // Remove `yargs`-specific options, shortcuts, dash-cased and aliases
-const isUserFlag = function(key, value) {
+const isUserFlag = function (key, value) {
   return value !== undefined && !INTERNAL_KEYS.has(key) && key.length !== 1 && !key.includes('-')
 }
 

--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -12,7 +12,7 @@ const resolveConfig = require('../main')
 const { parseFlags } = require('./flags')
 
 // CLI entry point
-const runCli = async function() {
+const runCli = async function () {
   try {
     const { stable, ...flags } = parseFlags()
     const result = await resolveConfig(flags)
@@ -23,7 +23,7 @@ const runCli = async function() {
 }
 
 // The result is printed as JSON on stdout on success (exit code 0)
-const handleCliSuccess = function(result, stable) {
+const handleCliSuccess = function (result, stable) {
   const resultA = serializeApi(result)
   const resultB = omit(resultA, SECRET_PROPERTIES)
   const stringifyFunc = stable ? stableStringify : JSON.stringify
@@ -34,7 +34,7 @@ const handleCliSuccess = function(result, stable) {
 
 // `api` is not JSON-serializable, so we remove it
 // We still indicate it as a boolean
-const serializeApi = function({ api, ...result }) {
+const serializeApi = function ({ api, ...result }) {
   if (api === undefined) {
     return result
   }
@@ -44,7 +44,7 @@ const serializeApi = function({ api, ...result }) {
 
 const SECRET_PROPERTIES = ['token']
 
-const handleCliError = function(error) {
+const handleCliError = function (error) {
   // Errors caused by users do not show stack traces and have exit code 1
   if (isUserError(error)) {
     console.error(error.message)

--- a/packages/config/src/case.js
+++ b/packages/config/src/case.js
@@ -1,12 +1,12 @@
 const { removeFalsy } = require('./utils/remove_falsy')
 
 // Some properties can be optionally capitalized. We normalize them to lowercase
-const normalizeConfigCase = function({ Build, build = Build, ...config }) {
+const normalizeConfigCase = function ({ Build, build = Build, ...config }) {
   const buildA = normalizeBuildCase(build)
   return { ...config, build: buildA }
 }
 
-const normalizeBuildCase = function({
+const normalizeBuildCase = function ({
   Base,
   base = Base,
   Command,

--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -7,13 +7,13 @@ const { deepMerge } = require('./utils/merge')
 // Merge `config.context.{CONTEXT|BRANCH}.*` to `config.build.*`
 // CONTEXT is the `--context` CLI flag.
 // BRANCH is the `--branch` CLI flag.
-const mergeContext = function({ context: contextProps, ...config }, context, branch) {
+const mergeContext = function ({ context: contextProps, ...config }, context, branch) {
   if (!isPlainObj(contextProps)) {
     return config
   }
 
   const allContextProps = [context, branch]
-    .map(key => contextProps[key])
+    .map((key) => contextProps[key])
     .filter(Boolean)
     .map(normalizeBuildCase)
     .map(addCommandConfigOrigin)

--- a/packages/config/src/default.js
+++ b/packages/config/src/default.js
@@ -4,7 +4,7 @@ const { logDefaultConfig } = require('./log/main')
 
 // Retrieve default configuration file. It has less priority and it also does
 // not get normalized, merged with contexts, etc.
-const parseDefaultConfig = function({ defaultConfig, base, baseRelDir, siteInfo, logs, debug }) {
+const parseDefaultConfig = function ({ defaultConfig, base, baseRelDir, siteInfo, logs, debug }) {
   const defaultConfigA = getConfig(defaultConfig, 'default')
   const defaultConfigB = addDefaultConfigBase(defaultConfigA, base)
   const { defaultConfig: defaultConfigC, baseRelDir: baseRelDirA = DEFAULT_BASE_REL_DIR } = addBuildSettings({
@@ -18,7 +18,7 @@ const parseDefaultConfig = function({ defaultConfig, base, baseRelDir, siteInfo,
 
 // Load a configuration file passed as a JSON object.
 // The logic is much simpler: it does not normalize nor validate it.
-const getConfig = function(config, name) {
+const getConfig = function (config, name) {
   if (config === undefined) {
     return {}
   }
@@ -32,7 +32,7 @@ const getConfig = function(config, name) {
 
 // When the `base` was overridden, add it to `defaultConfig` so it behaves
 // as if it had been specified in the UI settings
-const addDefaultConfigBase = function(defaultConfig, base) {
+const addDefaultConfigBase = function (defaultConfig, base) {
   if (base === undefined) {
     return defaultConfig
   }

--- a/packages/config/src/error.js
+++ b/packages/config/src/error.js
@@ -1,13 +1,13 @@
 // We distinguish between errors thrown intentionally and uncaught exceptions
 // (such as bugs) with a `type` property.
-const throwError = function(messageOrError, error) {
+const throwError = function (messageOrError, error) {
   const errorA = getError(messageOrError, error)
   errorA.type = USER_ERROR_TYPE
   throw errorA
 }
 
 // Can pass either `message`, `error` or `message, error`
-const getError = function(messageOrError, error) {
+const getError = function (messageOrError, error) {
   if (messageOrError instanceof Error) {
     return messageOrError
   }
@@ -21,7 +21,7 @@ const getError = function(messageOrError, error) {
 }
 
 // Check `error.type`
-const isUserError = function(error) {
+const isUserError = function (error) {
   return error instanceof Error && error.type === USER_ERROR_TYPE
 }
 

--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -6,7 +6,7 @@ const { throwError } = require('./error')
 
 // Make configuration paths relative to `buildDir` and converts them to
 // absolute paths
-const handleFiles = async function({ config: { build, ...config }, repositoryRoot, baseRelDir }) {
+const handleFiles = async function ({ config: { build, ...config }, repositoryRoot, baseRelDir }) {
   const buildA = resolvePaths(build, REPOSITORY_RELATIVE_PROPS, repositoryRoot)
   const buildDir = await getBuildDir(repositoryRoot, buildA)
   const baseRel = baseRelDir ? buildDir : repositoryRoot
@@ -20,16 +20,16 @@ const handleFiles = async function({ config: { build, ...config }, repositoryRoo
 const REPOSITORY_RELATIVE_PROPS = ['base']
 const BUILD_DIR_RELATIVE_PROPS = ['publish', 'functions', 'edge_handlers']
 
-const resolvePaths = function(build, propNames, baseRel) {
+const resolvePaths = function (build, propNames, baseRel) {
   return propNames.reduce((buildA, propName) => resolvePathProp(buildA, propName, baseRel), build)
 }
 
-const resolvePathProp = function(build, propName, baseRel) {
+const resolvePathProp = function (build, propName, baseRel) {
   const path = resolvePath(baseRel, build[propName])
   return path === undefined ? build : { ...build, [propName]: path }
 }
 
-const resolvePath = function(baseRel, path) {
+const resolvePath = function (baseRel, path) {
   if (path === undefined) {
     return
   }
@@ -48,7 +48,7 @@ const LEADING_SLASH_REGEXP = /^\/+/
 //  - `build.base`
 //  - `--repositoryRoot`
 //  - the current directory (default value of `--repositoryRoot`)
-const getBuildDir = async function(repositoryRoot, { base = repositoryRoot }) {
+const getBuildDir = async function (repositoryRoot, { base = repositoryRoot }) {
   const buildDir = resolve(repositoryRoot, base)
   await checkBuildDir(buildDir, repositoryRoot)
   return buildDir
@@ -58,7 +58,7 @@ const getBuildDir = async function(repositoryRoot, { base = repositoryRoot }) {
 // build plugins. Therefore it must exist.
 // We already check `repositoryRoot` earlier in the code, so only need to check
 // `buildDir` when it is the base directory instead.
-const checkBuildDir = async function(buildDir, repositoryRoot) {
+const checkBuildDir = async function (buildDir, repositoryRoot) {
   if (buildDir === repositoryRoot || (await isDirectory(buildDir))) {
     return
   }

--- a/packages/config/src/inline_config.js
+++ b/packages/config/src/inline_config.js
@@ -2,7 +2,7 @@ const { logInlineConfig } = require('./log/main')
 const { removeFalsy } = require('./utils/remove_falsy')
 
 // Retrieve the `--inlineConfig` CLI flag
-const getInlineConfig = function({ inlineConfig, logs, debug }) {
+const getInlineConfig = function ({ inlineConfig, logs, debug }) {
   if (inlineConfig === undefined) {
     return {}
   }
@@ -13,7 +13,7 @@ const getInlineConfig = function({ inlineConfig, logs, debug }) {
 }
 
 // Remove empty values from `--inlineConfig`
-const removeFalsyInlineConfig = function({ build = {}, ...inlineConfig }) {
+const removeFalsyInlineConfig = function ({ build = {}, ...inlineConfig }) {
   return removeFalsy({ ...inlineConfig, build: removeFalsy(build) })
 }
 

--- a/packages/config/src/log/cleanup.js
+++ b/packages/config/src/log/cleanup.js
@@ -5,7 +5,7 @@ const { removeFalsy } = require('../utils/remove_falsy')
 const { removeEmptyObject, removeEmptyArray } = require('./remove')
 
 // Make sure we are not printing secret values. Use an allow list.
-const cleanupConfig = function({
+const cleanupConfig = function ({
   build: {
     base,
     command,
@@ -39,8 +39,8 @@ const cleanupConfig = function({
   return netlifyConfig
 }
 
-const cleanupEnvironment = function(environment) {
-  return Object.keys(environment).filter(key => !BUILDBOT_ENVIRONMENT.has(key))
+const cleanupEnvironment = function (environment) {
+  return Object.keys(environment).filter((key) => !BUILDBOT_ENVIRONMENT.has(key))
 }
 
 // Added by the buildbot. We only want to print environment variables specified
@@ -57,19 +57,19 @@ const BUILDBOT_ENVIRONMENT = new Set([
   'URL',
 ])
 
-const cleanupPlugin = function({ package: packageName, origin, inputs = {} }) {
+const cleanupPlugin = function ({ package: packageName, origin, inputs = {} }) {
   const inputsA = filterObj(inputs, isPublicInput)
   return { package: packageName, origin, inputs: inputsA }
 }
 
-const isPublicInput = function(key, input) {
+const isPublicInput = function (key, input) {
   return typeof input === 'boolean'
 }
 
 // The resolved configuration gets assigned some default values (empty objects and arrays)
 // to make it more convenient to use without checking for `undefined`.
 // However those empty values are not useful to users, so we don't log them.
-const simplifyConfig = function({ build: { environment, ...build }, plugins, ...netlifyConfig }) {
+const simplifyConfig = function ({ build: { environment, ...build }, plugins, ...netlifyConfig }) {
   const buildA = {
     ...build,
     ...removeEmptyArray(environment, 'environment'),

--- a/packages/config/src/log/logger.js
+++ b/packages/config/src/log/logger.js
@@ -5,7 +5,7 @@ const { THEME } = require('./theme')
 
 // When the `buffer` option is true, we return logs instead of printing them
 // on the console. The logs are accumulated in a `logs` array variable.
-const getBufferLogs = function({ buffer }) {
+const getBufferLogs = function ({ buffer }) {
   if (!buffer) {
     return
   }
@@ -15,7 +15,7 @@ const getBufferLogs = function({ buffer }) {
 
 // This should be used instead of `console.log()`
 // Printed on stderr because stdout is reserved for the JSON output
-const log = function(logs, string) {
+const log = function (logs, string) {
   const stringA = String(string).replace(EMPTY_LINES_REGEXP, EMPTY_LINE)
 
   if (logs !== undefined) {
@@ -33,12 +33,12 @@ const log = function(logs, string) {
 const EMPTY_LINES_REGEXP = /^\s*$/gm
 const EMPTY_LINE = '\u{200B}'
 
-const logObject = function(logs, object) {
+const logObject = function (logs, object) {
   const string = serializeObject(object)
   log(logs, string)
 }
 
-const logSubHeader = function(logs, string) {
+const logSubHeader = function (logs, string) {
   const stringA = `\n${THEME.subHeader(`${pointer} ${string}`)}`
   log(logs, stringA)
 }

--- a/packages/config/src/log/main.js
+++ b/packages/config/src/log/main.js
@@ -3,7 +3,7 @@ const { logObject, logSubHeader } = require('./logger')
 const { cleanupConfigOpts } = require('./options')
 
 // Log options in debug mode.
-const logOpts = function(opts, { logs, debug, cachedConfig }) {
+const logOpts = function (opts, { logs, debug, cachedConfig }) {
   // In production, print those in the first call to `@netlify/config`, not the
   // second one done inside `@netlify/build`
   if (!debug || cachedConfig !== undefined) {
@@ -15,7 +15,7 @@ const logOpts = function(opts, { logs, debug, cachedConfig }) {
 }
 
 // Log `defaultConfig` option in debug mode
-const logDefaultConfig = function(defaultConfig, { logs, debug, baseRelDir }) {
+const logDefaultConfig = function (defaultConfig, { logs, debug, baseRelDir }) {
   if (!debug || defaultConfig === undefined) {
     return
   }
@@ -25,7 +25,7 @@ const logDefaultConfig = function(defaultConfig, { logs, debug, baseRelDir }) {
 }
 
 // Log `inlineConfig` option in debug mode
-const logInlineConfig = function(initialConfig, { logs, debug }) {
+const logInlineConfig = function (initialConfig, { logs, debug }) {
   if (!debug) {
     return
   }
@@ -35,7 +35,7 @@ const logInlineConfig = function(initialConfig, { logs, debug }) {
 }
 
 // Log return value of `@netlify/config` in debug mode
-const logResult = function({ configPath, buildDir, config, context, branch }, { logs, debug }) {
+const logResult = function ({ configPath, buildDir, config, context, branch }, { logs, debug }) {
   if (!debug) {
     return
   }

--- a/packages/config/src/log/options.js
+++ b/packages/config/src/log/options.js
@@ -3,7 +3,7 @@ const { removeFalsy } = require('../utils/remove_falsy')
 const { removeEmptyArray } = require('./remove')
 
 // Use an allowlist to prevent printing confidential values.
-const cleanupConfigOpts = function({
+const cleanupConfigOpts = function ({
   config,
   cwd,
   context,

--- a/packages/config/src/log/remove.js
+++ b/packages/config/src/log/remove.js
@@ -1,11 +1,11 @@
 const { removeFalsy } = require('../utils/remove_falsy')
 
-const removeEmptyObject = function(object, propName) {
+const removeEmptyObject = function (object, propName) {
   const objectA = removeFalsy(object)
   return Object.keys(objectA).length === 0 ? {} : { [propName]: objectA }
 }
 
-const removeEmptyArray = function(array, propName) {
+const removeEmptyArray = function (array, propName) {
   return array.length === 0 ? {} : { [propName]: array }
 }
 

--- a/packages/config/src/log/serialize.js
+++ b/packages/config/src/log/serialize.js
@@ -1,6 +1,6 @@
 const { dump } = require('js-yaml')
 
-const serializeObject = function(object) {
+const serializeObject = function (object) {
   return dump(object, { noRefs: true, sortKeys: true, lineWidth: Infinity }).trimRight()
 }
 

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -25,7 +25,7 @@ const {
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
-const resolveConfig = async function(opts) {
+const resolveConfig = async function (opts) {
   const { cachedConfig, token, ...optsA } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
   const api = getApiClient({ ...optsA, token })
@@ -91,7 +91,7 @@ const resolveConfig = async function(opts) {
 // Try to load the configuration file in two passes.
 // The first pass uses the `defaultConfig`'s `build.base` (if defined).
 // The second pass uses the `build.base` from the first pass (if defined).
-const loadConfig = async function({
+const loadConfig = async function ({
   configOpt,
   cwd,
   context,
@@ -146,7 +146,7 @@ const loadConfig = async function({
 }
 
 // Load configuration file and normalize it, merge contexts, etc.
-const getFullConfig = async function({
+const getFullConfig = async function ({
   configOpt,
   cwd,
   context,
@@ -169,7 +169,7 @@ const getFullConfig = async function({
   }
 }
 
-const mergeAndNormalizeConfig = function({ config, defaultConfig, inlineConfig, context, branch }) {
+const mergeAndNormalizeConfig = function ({ config, defaultConfig, inlineConfig, context, branch }) {
   validatePreCaseNormalize(config)
   const configA = normalizeConfigCase(config)
 

--- a/packages/config/src/merge.js
+++ b/packages/config/src/merge.js
@@ -5,7 +5,7 @@ const { deepMerge } = require('./utils/merge')
 // Merge `--defaultConfig` which is used to retrieve UI build settings and
 // UI-installed plugins.
 // Also merge `inlineConfig` which is used for Netlify CLI flags.
-const mergeConfigs = function(
+const mergeConfigs = function (
   { plugins: defaultPlugins = [], ...defaultConfig },
   { plugins = [], ...config },
   { plugins: inlinePlugins = [], ...inlineConfig },
@@ -20,7 +20,7 @@ const mergeConfigs = function(
 // concatenation instead of override.
 // Also, we add the `origin` field of plugins: installed through `ui` or through
 // `config` (`netlify.toml`)
-const mergePlugins = function(defaultPlugins, plugins, inlinePlugins) {
+const mergePlugins = function (defaultPlugins, plugins, inlinePlugins) {
   const [defaultPluginsA, pluginsA, inlinePluginsA] = addPluginsOrigins(defaultPlugins, plugins, inlinePlugins)
   const pluginsB = [...defaultPluginsA, ...pluginsA, ...inlinePluginsA].filter(isNotOverridenPlugin)
   return pluginsB
@@ -28,8 +28,8 @@ const mergePlugins = function(defaultPlugins, plugins, inlinePlugins) {
 
 // When a plugin is specified both in the UI and netlify.toml, we only keep
 // the netlify.toml one.
-const isNotOverridenPlugin = function(plugin, index, plugins) {
-  const overridingPlugin = plugins.slice(index + 1).find(pluginA => plugin.package === pluginA.package)
+const isNotOverridenPlugin = function (plugin, index, plugins) {
+  const overridingPlugin = plugins.slice(index + 1).find((pluginA) => plugin.package === pluginA.package)
 
   if (overridingPlugin !== undefined && overridingPlugin.origin === 'config' && plugin.origin === 'config') {
     throwError(`Plugin "${plugin.package}" must not be specified twice in netlify.toml`)

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -2,7 +2,7 @@ const { deepMerge } = require('./utils/merge')
 const { removeFalsy } = require('./utils/remove_falsy')
 
 // Normalize configuration object
-const normalizeConfig = function(config) {
+const normalizeConfig = function (config) {
   const { build, plugins, ...configA } = deepMerge(DEFAULT_CONFIG, config)
   const pluginsA = plugins.map(normalizePlugin)
   return { ...configA, build, plugins: pluginsA }
@@ -13,7 +13,7 @@ const DEFAULT_CONFIG = {
   plugins: [],
 }
 
-const normalizePlugin = function({ package: packageName, inputs = {}, origin, ...plugin }) {
+const normalizePlugin = function ({ package: packageName, inputs = {}, origin, ...plugin }) {
   return removeFalsy({ ...plugin, package: packageName, inputs, origin })
 }
 

--- a/packages/config/src/options/base.js
+++ b/packages/config/src/options/base.js
@@ -11,7 +11,7 @@ const pRealpath = promisify(realpath)
 // `cwd` that has a `.netlify` or `netlify.toml`. This allows Netlify CLI users
 // to `cd` into monorepo directories to change their base and build directories.
 // Do all checks in parallel for speed
-const getBaseOverride = async function({ repositoryRoot, cwd }) {
+const getBaseOverride = async function ({ repositoryRoot, cwd }) {
   // Performance optimization
   if (repositoryRoot === cwd) {
     return {}
@@ -34,15 +34,15 @@ const getBaseOverride = async function({ repositoryRoot, cwd }) {
 }
 
 // Returns list of files to check for the existence of a `base`
-const getBasePaths = function(repositoryRoot, cwd) {
+const getBasePaths = function (repositoryRoot, cwd) {
   const subdirs = getSubdirs(repositoryRoot, cwd)
-  const basePaths = subdirs.flatMap(subdir => BASE_FILENAMES.map(filename => `${subdir}/${filename}`))
+  const basePaths = subdirs.flatMap((subdir) => BASE_FILENAMES.map((filename) => `${subdir}/${filename}`))
   return basePaths
 }
 
 // Retrieves list of directories between `repositoryRoot` and `cwd`, including
 // `cwd` but excluding `repositoryRoot`
-const getSubdirs = function(repositoryRoot, dir, subdirs = []) {
+const getSubdirs = function (repositoryRoot, dir, subdirs = []) {
   if (!dir.startsWith(`${repositoryRoot}${sep}`)) {
     return subdirs
   }
@@ -54,13 +54,13 @@ const BASE_FILENAMES = ['.netlify', 'netlify.toml']
 
 // Returns the first path that exists.
 // Like `locate-path` library but works with mixed files/directories
-const locatePath = async function(paths) {
+const locatePath = async function (paths) {
   const results = await Promise.all(paths.map(returnIfExists))
   const path = results.find(Boolean)
   return path
 }
 
-const returnIfExists = async function(path) {
+const returnIfExists = async function (path) {
   if (!(await pathExists(path))) {
     return
   }

--- a/packages/config/src/options/branch.js
+++ b/packages/config/src/options/branch.js
@@ -5,7 +5,7 @@ const execa = require('execa')
 //   - `BRANCH` environment variable
 //   - Running `git`
 //   - 'master' (fallback)
-const getBranch = async function({ branch, repositoryRoot }) {
+const getBranch = async function ({ branch, repositoryRoot }) {
   if (branch) {
     return branch
   }
@@ -18,7 +18,7 @@ const getBranch = async function({ branch, repositoryRoot }) {
   return FALLBACK_BRANCH
 }
 
-const getGitBranch = async function(repositoryRoot) {
+const getGitBranch = async function (repositoryRoot) {
   try {
     const { stdout } = await execa.command('git rev-parse --abbrev-ref HEAD', { cwd: repositoryRoot })
     return stdout

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -12,7 +12,7 @@ const { getBranch } = require('./branch')
 const { getRepositoryRoot } = require('./repository_root')
 
 // Assign default options
-const addDefaultOpts = function(opts = {}) {
+const addDefaultOpts = function (opts = {}) {
   const rawOpts = removeFalsy(opts)
   const defaultOpts = getDefaultOpts(rawOpts)
   const mergedOpts = { ...defaultOpts, ...rawOpts }
@@ -26,7 +26,7 @@ const addDefaultOpts = function(opts = {}) {
   return normalizedOptsA
 }
 
-const getDefaultOpts = function({ env: envOpt = {}, cwd: cwdOpt, defaultConfig }) {
+const getDefaultOpts = function ({ env: envOpt = {}, cwd: cwdOpt, defaultConfig }) {
   const combinedEnv = { ...process.env, ...envOpt }
   return {
     ...getDefaultCwd(cwdOpt),
@@ -43,7 +43,7 @@ const getDefaultOpts = function({ env: envOpt = {}, cwd: cwdOpt, defaultConfig }
 
 // --debug can be set using an environment variable `NETLIFY_BUILD_DEBUG` either
 // locally or in the UI build settings
-const getDefaultDebug = function(combinedEnv, defaultConfig) {
+const getDefaultDebug = function (combinedEnv, defaultConfig) {
   if (combinedEnv.NETLIFY_BUILD_DEBUG) {
     return true
   }
@@ -57,7 +57,7 @@ const getDefaultDebug = function(combinedEnv, defaultConfig) {
 }
 
 // `process.cwd()` can throw, so only call it when needed
-const getDefaultCwd = function(cwdOpt) {
+const getDefaultCwd = function (cwdOpt) {
   if (cwdOpt !== undefined) {
     return {}
   }
@@ -67,7 +67,7 @@ const getDefaultCwd = function(cwdOpt) {
 }
 
 // Normalize options
-const normalizeOpts = async function(opts) {
+const normalizeOpts = async function (opts) {
   const repositoryRoot = await getRepositoryRoot(opts)
   const optsA = { ...opts, repositoryRoot }
 
@@ -83,13 +83,13 @@ const normalizeOpts = async function(opts) {
 }
 
 // Verify that options point to existing directories
-const checkDirs = async function(opts) {
-  await Promise.all(DIR_OPTIONS.map(optName => checkDir(opts, optName)))
+const checkDirs = async function (opts) {
+  await Promise.all(DIR_OPTIONS.map((optName) => checkDir(opts, optName)))
 }
 
 const DIR_OPTIONS = ['cwd', 'repositoryRoot']
 
-const checkDir = async function(opts, optName) {
+const checkDir = async function (opts, optName) {
   const path = opts[optName]
   if (!(await isDirectory(path))) {
     throwError(`Option '${optName}' points to a non-existing directory: ${path}`)

--- a/packages/config/src/options/repository_root.js
+++ b/packages/config/src/options/repository_root.js
@@ -6,7 +6,7 @@ const findUp = require('find-up')
 //  - `repositoryRoot` option
 //  - find a `.git` directory up from `cwd`
 //  - `cwd` (fallback)
-const getRepositoryRoot = async function({ repositoryRoot, cwd }) {
+const getRepositoryRoot = async function ({ repositoryRoot, cwd }) {
   if (repositoryRoot !== undefined) {
     return repositoryRoot
   }

--- a/packages/config/src/origin.js
+++ b/packages/config/src/origin.js
@@ -5,7 +5,7 @@ const CONFIG_ORIGIN = 'config'
 // Add `build.commandOrigin`. This shows whether `build.command` came from the
 // `ui` or from the `config`.
 // This also removes empty build commands.
-const addBuildCommandOrigins = function(defaultConfig, config, inlineConfig) {
+const addBuildCommandOrigins = function (defaultConfig, config, inlineConfig) {
   return [
     addBuildCommandUiOrigin(defaultConfig),
     addBuildCommandConfigOrigin(config),
@@ -13,7 +13,7 @@ const addBuildCommandOrigins = function(defaultConfig, config, inlineConfig) {
   ]
 }
 
-const addBuildCommandOrigin = function(commandOrigin, { build = {}, ...config }) {
+const addBuildCommandOrigin = function (commandOrigin, { build = {}, ...config }) {
   const buildA = addCommandOrigin(commandOrigin, build)
   return { ...config, build: buildA }
 }
@@ -21,7 +21,7 @@ const addBuildCommandOrigin = function(commandOrigin, { build = {}, ...config })
 const addBuildCommandUiOrigin = addBuildCommandOrigin.bind(null, UI_ORIGIN)
 const addBuildCommandConfigOrigin = addBuildCommandOrigin.bind(null, CONFIG_ORIGIN)
 
-const addCommandOrigin = function(commandOrigin, { command, ...build }) {
+const addCommandOrigin = function (commandOrigin, { command, ...build }) {
   if (command === undefined || (typeof command === 'string' && command.trim() === '')) {
     return build
   }
@@ -32,7 +32,7 @@ const addCommandOrigin = function(commandOrigin, { command, ...build }) {
 const addCommandConfigOrigin = addCommandOrigin.bind(null, CONFIG_ORIGIN)
 
 // Add `plugins[*].origin`. This is like `build.commandOrigin` but for plugins.
-const addPluginsOrigins = function(defaultPlugins, plugins, inlinePlugins) {
+const addPluginsOrigins = function (defaultPlugins, plugins, inlinePlugins) {
   return [
     defaultPlugins.map(addPluginUiOrigin),
     plugins.map(addPluginConfigOrigin),
@@ -40,7 +40,7 @@ const addPluginsOrigins = function(defaultPlugins, plugins, inlinePlugins) {
   ]
 }
 
-const addPluginOrigin = function(origin, plugin) {
+const addPluginOrigin = function (origin, plugin) {
   return { ...plugin, origin }
 }
 

--- a/packages/config/src/parse.js
+++ b/packages/config/src/parse.js
@@ -9,7 +9,7 @@ const { throwError } = require('./error')
 const pReadFile = promisify(readFile)
 
 // Load the configuration file and parse it (TOML)
-const parseConfig = async function(configPath) {
+const parseConfig = async function (configPath) {
   if (configPath === undefined) {
     return {}
   }
@@ -28,7 +28,7 @@ const parseConfig = async function(configPath) {
 }
 
 // Reach the configuration file's raw content
-const readConfig = async function(configPath) {
+const readConfig = async function (configPath) {
   try {
     return await pReadFile(configPath, 'utf8')
   } catch (error) {
@@ -36,7 +36,7 @@ const readConfig = async function(configPath) {
   }
 }
 
-const parseToml = function(configString) {
+const parseToml = function (configString) {
   const config = loadToml(configString)
   // `toml.parse()` returns a object with `null` prototype deeply, which can
   // sometimes create problems with some utilities. We convert it.

--- a/packages/config/src/path.js
+++ b/packages/config/src/path.js
@@ -11,7 +11,7 @@ const { resolvePath } = require('./files')
 //  - a `netlify.*` file in the `repositoryRoot/{base}`
 //  - a `netlify.*` file in the `repositoryRoot`
 //  - a `netlify.*` file in the current directory or any parent
-const getConfigPath = async function({ configOpt, cwd, repositoryRoot, base }) {
+const getConfigPath = async function ({ configOpt, cwd, repositoryRoot, base }) {
   const configPath = await pLocate(
     [
       searchConfigOpt(cwd, configOpt),
@@ -25,7 +25,7 @@ const getConfigPath = async function({ configOpt, cwd, repositoryRoot, base }) {
 }
 
 // --config CLI flag
-const searchConfigOpt = function(cwd, configOpt) {
+const searchConfigOpt = function (cwd, configOpt) {
   if (configOpt === undefined) {
     return
   }
@@ -34,7 +34,7 @@ const searchConfigOpt = function(cwd, configOpt) {
 }
 
 // Look for `repositoryRoot/{base}/netlify.*`
-const searchBaseConfigFile = function(repositoryRoot, base) {
+const searchBaseConfigFile = function (repositoryRoot, base) {
   if (base === undefined) {
     return
   }
@@ -44,7 +44,7 @@ const searchBaseConfigFile = function(repositoryRoot, base) {
 }
 
 // Look for several file extensions for `netlify.*`
-const searchConfigFile = async function(cwd) {
+const searchConfigFile = async function (cwd) {
   const path = resolve(cwd, FILENAME)
   if (!(await pathExists(path))) {
     return

--- a/packages/config/src/utils/merge.js
+++ b/packages/config/src/utils/merge.js
@@ -2,14 +2,14 @@ const deepmerge = require('deepmerge')
 const isPlainObj = require('is-plain-obj')
 
 // Deep merge utility for configuration objects
-const deepMerge = function(...values) {
+const deepMerge = function (...values) {
   const objects = values.filter(isPlainObj)
   return deepmerge.all(objects, { arrayMerge })
 }
 
 // By default `deepmerge` concatenates arrays. We use the `arrayMerge` option
 // to remove this behavior.
-const arrayMerge = function(arrayA, arrayB) {
+const arrayMerge = function (arrayA, arrayB) {
   return arrayB
 }
 

--- a/packages/config/src/utils/remove_falsy.js
+++ b/packages/config/src/utils/remove_falsy.js
@@ -1,11 +1,11 @@
 const filterObj = require('filter-obj')
 
 // Remove falsy values from object
-const removeFalsy = function(obj) {
+const removeFalsy = function (obj) {
   return filterObj(obj, isDefined)
 }
 
-const isDefined = function(key, value) {
+const isDefined = function (key, value) {
   return value !== undefined && value !== null && value !== ''
 }
 

--- a/packages/config/src/utils/toml.js
+++ b/packages/config/src/utils/toml.js
@@ -1,7 +1,7 @@
 const tomlify = require('tomlify-j0.4')
 
 // Serialize JavaScript object to TOML
-const serializeToml = function(object) {
+const serializeToml = function (object) {
   return tomlify.toToml(object, { space: 2 })
 }
 

--- a/packages/config/src/validate/example.js
+++ b/packages/config/src/validate/example.js
@@ -4,7 +4,7 @@ const { THEME } = require('../log/theme')
 const { serializeToml } = require('../utils/toml.js')
 
 // Print invalid value and example netlify.toml
-const getExample = function({ value, key, prevPath, example }) {
+const getExample = function ({ value, key, prevPath, example }) {
   const exampleA = typeof example === 'function' ? example(value, key, prevPath) : example
   return `
 ${THEME.errorSubHeader('Invalid syntax')}
@@ -16,18 +16,15 @@ ${THEME.subHeader('Valid syntax')}
 ${indentString(serializeToml(exampleA), 2)}`
 }
 
-const getInvalidValue = function(value, prevPath) {
+const getInvalidValue = function (value, prevPath) {
   // slice() is temporary, so it does not mutate
   // eslint-disable-next-line fp/no-mutating-methods
-  const invalidValue = prevPath
-    .slice()
-    .reverse()
-    .reduce(setInvalidValuePart, value)
+  const invalidValue = prevPath.slice().reverse().reduce(setInvalidValuePart, value)
   const invalidValueA = serializeToml(invalidValue)
   return invalidValueA
 }
 
-const setInvalidValuePart = function(value, part) {
+const setInvalidValuePart = function (value, part) {
   if (Number.isInteger(part)) {
     return [value]
   }

--- a/packages/config/src/validate/helpers.js
+++ b/packages/config/src/validate/helpers.js
@@ -1,25 +1,25 @@
 const { normalize } = require('path')
 
-const isString = function(value) {
+const isString = function (value) {
   return typeof value === 'string'
 }
 
 // Check an object valid properties, including legacy ones
-const validProperties = function(propNames, legacyPropNames) {
+const validProperties = function (propNames, legacyPropNames) {
   return {
-    check: value => checkValidProperty(value, [...propNames, ...legacyPropNames]),
+    check: (value) => checkValidProperty(value, [...propNames, ...legacyPropNames]),
     message: `has unknown properties. Valid properties are:
-${propNames.map(propName => `  - ${propName}`).join('\n')}`,
+${propNames.map((propName) => `  - ${propName}`).join('\n')}`,
   }
 }
 
-const checkValidProperty = function(value, propNames) {
-  return Object.keys(value).every(propName => propNames.includes(propName))
+const checkValidProperty = function (value, propNames) {
+  return Object.keys(value).every((propName) => propNames.includes(propName))
 }
 
 // Ensure paths specified by users in the configuration file are not targetting
 // files outside the repository root directory.
-const isInsideRoot = function(path) {
+const isInsideRoot = function (path) {
   return !normalize(path).startsWith('..')
 }
 
@@ -29,7 +29,7 @@ const insideRootCheck = {
 }
 
 // Used in examples to show how to fix the above check
-const removeParentDots = function(path) {
+const removeParentDots = function (path) {
   return normalize(path).replace(PARENT_DOTS_REGEXP, '')
 }
 

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -11,33 +11,33 @@ const {
 } = require('./validations')
 
 // Validate the configuration file, before case normalization.
-const validatePreCaseNormalize = function(config) {
+const validatePreCaseNormalize = function (config) {
   validateConfig(config, PRE_CASE_NORMALIZE_VALIDATIONS)
 }
 
 // Validate the configuration file, before `defaultConfig` merge.
-const validatePreMergeConfig = function(defaultConfig, config, inlineConfig) {
+const validatePreMergeConfig = function (defaultConfig, config, inlineConfig) {
   validateConfig(defaultConfig, PRE_MERGE_VALIDATIONS)
   validateConfig(config, PRE_MERGE_VALIDATIONS)
   validateConfig(inlineConfig, PRE_MERGE_VALIDATIONS)
 }
 
 // Validate the configuration file, before context merge.
-const validatePreContextConfig = function(config) {
+const validatePreContextConfig = function (config) {
   validateConfig(config, PRE_CONTEXT_VALIDATIONS)
 }
 
 // Validate the configuration file, before normalization.
-const validatePreNormalizeConfig = function(config) {
+const validatePreNormalizeConfig = function (config) {
   validateConfig(config, PRE_NORMALIZE_VALIDATIONS)
 }
 
 // Validate the configuration file, after normalization.
-const validatePostNormalizeConfig = function(config) {
+const validatePostNormalizeConfig = function (config) {
   validateConfig(config, POST_NORMALIZE_VALIDATIONS)
 }
 
-const validateConfig = function(config, validations) {
+const validateConfig = function (config, validations) {
   try {
     validations.forEach(({ property, ...validation }) => {
       validateProperty(config, { ...validation, nextPath: property.split('.') })
@@ -48,7 +48,7 @@ const validateConfig = function(config, validations) {
 }
 
 // Validate a single property in the configuration file.
-const validateProperty = function(
+const validateProperty = function (
   parent,
   {
     nextPath: [propName, nextPropName, ...nextPath],
@@ -83,13 +83,13 @@ const validateProperty = function(
   reportError({ prevPath, propPath, message, example, value, key })
 }
 
-const reportError = function({ prevPath, propPath, message, example, value, key }) {
+const reportError = function ({ prevPath, propPath, message, example, value, key }) {
   throwError(`${THEME.highlightWords('Configuration property')} ${propPath} ${message}
 ${getExample({ value, key, prevPath, example })}`)
 }
 
 // Recurse over children (each part of the `property` array).
-const validateChild = function({ value, nextPropName, prevPath, nextPath, propPath, ...rest }) {
+const validateChild = function ({ value, nextPropName, prevPath, nextPath, propPath, ...rest }) {
   if (value === undefined) {
     return
   }
@@ -104,13 +104,13 @@ const validateChild = function({ value, nextPropName, prevPath, nextPath, propPa
     })
   }
 
-  return Object.keys(value).forEach(childProp =>
+  return Object.keys(value).forEach((childProp) =>
     validateChildProp({ childProp, value, nextPath, propPath, prevPath, ...rest }),
   )
 }
 
 // Can use * to recurse over array|object elements.
-const validateChildProp = function({ childProp, value, nextPath, propPath, prevPath, ...rest }) {
+const validateChildProp = function ({ childProp, value, nextPath, propPath, prevPath, ...rest }) {
   if (Array.isArray(value)) {
     const key = Number(childProp)
     return validateProperty(value, {

--- a/packages/config/src/validate/validations.js
+++ b/packages/config/src/validate/validations.js
@@ -28,7 +28,7 @@ const PRE_CASE_NORMALIZE_VALIDATIONS = [
 const PRE_MERGE_VALIDATIONS = [
   {
     property: 'plugins',
-    check: value => Array.isArray(value) && value.every(isPlainObj),
+    check: (value) => Array.isArray(value) && value.every(isPlainObj),
     message: 'must be an array of objects.',
     example: () => ({ plugins: [{ package: 'netlify-plugin-one' }, { package: 'netlify-plugin-two' }] }),
   },
@@ -70,7 +70,7 @@ const POST_NORMALIZE_VALIDATIONS = [
 
   {
     property: 'plugins.*',
-    check: plugin => plugin.package !== undefined,
+    check: (plugin) => plugin.package !== undefined,
     message: '"package" property is required.',
     example: () => ({ plugins: [{ package: 'netlify-plugin-one' }] }),
   },
@@ -87,7 +87,7 @@ const POST_NORMALIZE_VALIDATIONS = [
   // We ensure @scope/plugin still work.
   {
     property: 'plugins.*.package',
-    check: packageName =>
+    check: (packageName) =>
       packageName.startsWith('.') ||
       packageName.startsWith('/') ||
       validateNpmPackageName(packageName).validForOldPackages,
@@ -110,7 +110,7 @@ const POST_NORMALIZE_VALIDATIONS = [
   {
     property: 'build.base',
     ...insideRootCheck,
-    example: base => ({ build: { base: removeParentDots(base) } }),
+    example: (base) => ({ build: { base: removeParentDots(base) } }),
   },
   {
     property: 'build.publish',
@@ -121,7 +121,7 @@ const POST_NORMALIZE_VALIDATIONS = [
   {
     property: 'build.publish',
     ...insideRootCheck,
-    example: publish => ({ build: { publish: removeParentDots(publish) } }),
+    example: (publish) => ({ build: { publish: removeParentDots(publish) } }),
   },
   {
     property: 'build.functions',
@@ -132,7 +132,7 @@ const POST_NORMALIZE_VALIDATIONS = [
   {
     property: 'build.functions',
     ...insideRootCheck,
-    example: functions => ({ build: { functions: removeParentDots(functions) } }),
+    example: (functions) => ({ build: { functions: removeParentDots(functions) } }),
   },
   {
     property: 'build.edge_handlers',
@@ -143,7 +143,7 @@ const POST_NORMALIZE_VALIDATIONS = [
   {
     property: 'build.edge_handlers',
     ...insideRootCheck,
-    example: edgeHandlers => ({ build: { edge_handlers: removeParentDots(edgeHandlers) } }),
+    example: (edgeHandlers) => ({ build: { edge_handlers: removeParentDots(edgeHandlers) } }),
   },
 ]
 

--- a/packages/config/tests/api/tests.js
+++ b/packages/config/tests/api/tests.js
@@ -2,23 +2,23 @@ const test = require('ava')
 
 const { runFixture, FIXTURES_DIR, startServer } = require('../helpers/main')
 
-test('--token', async t => {
+test('--token', async (t) => {
   await runFixture(t, 'empty', { flags: { token: 'test' } })
 })
 
-test('--token in CLI', async t => {
+test('--token in CLI', async (t) => {
   await runFixture(t, 'empty', { flags: { token: 'test' }, useBinary: true })
 })
 
-test('NETLIFY_AUTH_TOKEN environment variable', async t => {
+test('NETLIFY_AUTH_TOKEN environment variable', async (t) => {
   await runFixture(t, 'empty', { env: { NETLIFY_AUTH_TOKEN: 'test' } })
 })
 
-test('--site-id', async t => {
+test('--site-id', async (t) => {
   await runFixture(t, 'empty', { flags: { siteId: 'test' } })
 })
 
-test('NETLIFY_SITE_ID environment variable', async t => {
+test('NETLIFY_SITE_ID environment variable', async (t) => {
   await runFixture(t, 'empty', { env: { NETLIFY_SITE_ID: 'test' } })
 })
 
@@ -26,31 +26,31 @@ const SITE_INFO_PATH = '/api/v1/sites/test'
 const SITE_INFO_DATA = { url: 'test', build_settings: { repo_url: 'test' } }
 const SITE_INFO_ERROR = { error: 'invalid' }
 
-test('Environment variable siteInfo success', async t => {
+test('Environment variable siteInfo success', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Environment variable siteInfo API error', async t => {
+test('Environment variable siteInfo API error', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_ERROR, { status: 400 })
   await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Environment variable siteInfo no token', async t => {
+test('Environment variable siteInfo no token', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', { flags: { siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Environment variable siteInfo no siteId', async t => {
+test('Environment variable siteInfo no siteId', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Environment variable siteInfo CI', async t => {
+test('Environment variable siteInfo CI', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
   await runFixture(t, 'empty', {
     flags: { token: 'test', siteId: 'test', mode: 'buildbot', testOpts: { scheme, host } },
@@ -63,7 +63,7 @@ const SITE_INFO_BUILD_SETTINGS_NULL = {
   build_settings: { cmd: null, dir: null, functions_dir: null, base: null, env: null, base_rel_dir: null },
 }
 
-test('Build settings can be null', async t => {
+test('Build settings can be null', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS_NULL)
   await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
@@ -82,13 +82,13 @@ const SITE_INFO_BUILD_SETTINGS = {
   plugins: [{ package: 'netlify-plugin-test', version: '1.0.0', inputs: { test: true } }],
 }
 
-test('Use build settings if a siteId and token are provided', async t => {
+test('Use build settings if a siteId and token are provided', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Build settings have low merging priority', async t => {
+test('Build settings have low merging priority', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'build_settings', {
     flags: { token: 'test', siteId: 'test', baseRelDir: true, testOpts: { scheme, host } },
@@ -96,25 +96,25 @@ test('Build settings have low merging priority', async t => {
   await stopServer()
 })
 
-test('Build settings are not used if getSite call fails', async t => {
+test('Build settings are not used if getSite call fails', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS, { status: 400 })
   await runFixture(t, 'base', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Build settings are not used without a token', async t => {
+test('Build settings are not used without a token', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', { flags: { siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Build settings are not used without a siteId', async t => {
+test('Build settings are not used without a siteId', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
-test('Build settings are not used in CI', async t => {
+test('Build settings are not used in CI', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
   await runFixture(t, 'base', {
     flags: { token: 'test', siteId: 'test', mode: 'buildbot', testOpts: { scheme, host } },
@@ -127,7 +127,7 @@ const SITE_INFO_BASE_REL_DIR = {
   build_settings: { base_rel_dir: false },
 }
 
-test('baseRelDir is true if build.base is overridden', async t => {
+test('baseRelDir is true if build.base is overridden', async (t) => {
   const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BASE_REL_DIR)
   try {
     await runFixture(t, 'build_base_override', {

--- a/packages/config/tests/base/tests.js
+++ b/packages/config/tests/base/tests.js
@@ -2,12 +2,12 @@ const test = require('ava')
 
 const { runFixture } = require('../helpers/main')
 
-test('Base from defaultConfig', async t => {
+test('Base from defaultConfig', async (t) => {
   const defaultConfig = JSON.stringify({ build: { base: 'base' } })
   await runFixture(t, 'default_config', { flags: { defaultConfig } })
 })
 
-test('Base from configuration file property', async t => {
+test('Base from configuration file property', async (t) => {
   const { returnValue } = await runFixture(t, 'prop_config')
   const {
     buildDir,
@@ -21,11 +21,11 @@ test('Base from configuration file property', async t => {
   t.true(publish.startsWith(buildDir))
 })
 
-test('Base logic is not recursive', async t => {
+test('Base logic is not recursive', async (t) => {
   await runFixture(t, 'recursive')
 })
 
-test('BaseRelDir feature flag', async t => {
+test('BaseRelDir feature flag', async (t) => {
   const { returnValue } = await runFixture(t, 'prop_config', { flags: { baseRelDir: false } })
   const {
     buildDir,
@@ -39,6 +39,6 @@ test('BaseRelDir feature flag', async t => {
   t.false(publish.startsWith(buildDir))
 })
 
-test('Base directory does not exist', async t => {
+test('Base directory does not exist', async (t) => {
   await runFixture(t, 'base_invalid')
 })

--- a/packages/config/tests/cli/tests.js
+++ b/packages/config/tests/cli/tests.js
@@ -9,37 +9,37 @@ const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
 const pWriteFile = promisify(writeFile)
 
-test('--help', async t => {
+test('--help', async (t) => {
   await runFixture(t, '', { flags: { help: true }, useBinary: true })
 })
 
-test('--version', async t => {
+test('--version', async (t) => {
   await runFixture(t, '', { flags: { version: true }, useBinary: true })
 })
 
-test('Success', async t => {
+test('Success', async (t) => {
   await runFixture(t, 'empty', { useBinary: true })
 })
 
-test('User error', async t => {
+test('User error', async (t) => {
   await runFixture(t, 'empty', { flags: { config: '/invalid' }, useBinary: true })
 })
 
-test('CLI flags', async t => {
+test('CLI flags', async (t) => {
   await runFixture(t, 'empty', { flags: { branch: 'test' }, useBinary: true })
 })
 
-test('Stabilitize output with the --stable flag', async t => {
+test('Stabilitize output with the --stable flag', async (t) => {
   await runFixture(t, 'empty', { flags: { stable: true }, useBinary: true })
 })
 
-test('Does not stabilitize output without the --stable flag', async t => {
+test('Does not stabilitize output without the --stable flag', async (t) => {
   await runFixture(t, 'empty', { flags: { stable: false }, useBinary: true })
 })
 
 // This test is too slow in local development
 if (isCI) {
-  test('Handles big outputs', async t => {
+  test('Handles big outputs', async (t) => {
     const bigNetlify = `${FIXTURES_DIR}/big/netlify.toml`
     await del(bigNetlify, { force: true })
     try {
@@ -54,7 +54,7 @@ if (isCI) {
     }
   })
 
-  const getBigNetlifyContent = function() {
+  const getBigNetlifyContent = function () {
     const envVars = Array.from({ length: BIG_NUMBER }, getEnvVar).join('\n')
     return `[build.environment]\n${envVars}`
   }
@@ -62,6 +62,6 @@ if (isCI) {
   const BIG_NUMBER = 1e4
 }
 
-const getEnvVar = function(value, index) {
+const getEnvVar = function (value, index) {
   return `TEST${index} = ${index}`
 }

--- a/packages/config/tests/context/tests.js
+++ b/packages/config/tests/context/tests.js
@@ -2,42 +2,42 @@ const test = require('ava')
 
 const { runFixture } = require('../helpers/main')
 
-test('Context with context CLI flag', async t => {
+test('Context with context CLI flag', async (t) => {
   await runFixture(t, 'context_flag', { flags: { context: 'testContext' } })
 })
 
-test('Context environment variable', async t => {
+test('Context environment variable', async (t) => {
   await runFixture(t, 'context_flag', { env: { CONTEXT: 'testContext' } })
 })
 
-test('Context default value', async t => {
+test('Context default value', async (t) => {
   await runFixture(t, 'context_default')
 })
 
-test('Context with branch CLI flag', async t => {
+test('Context with branch CLI flag', async (t) => {
   await runFixture(t, 'branch', { flags: { branch: 'testBranch' } })
 })
 
-test('Context with branch environment variable', async t => {
+test('Context with branch environment variable', async (t) => {
   await runFixture(t, 'branch', { env: { BRANCH: 'testBranch' }, flags: { branch: '' } })
 })
 
-test('Context with branch git', async t => {
+test('Context with branch git', async (t) => {
   await runFixture(t, 'branch', { copyRoot: { branch: 'testBranch' }, flags: { branch: '' } })
 })
 
-test('Context with branch fallback', async t => {
+test('Context with branch fallback', async (t) => {
   await runFixture(t, 'branch_fallback', { copyRoot: { git: false }, flags: { branch: '' } })
 })
 
-test('Context deep merge', async t => {
+test('Context deep merge', async (t) => {
   await runFixture(t, 'deep_merge')
 })
 
-test('Context array merge', async t => {
+test('Context array merge', async (t) => {
   await runFixture(t, 'array_merge')
 })
 
-test('Context merge priority', async t => {
+test('Context merge priority', async (t) => {
   await runFixture(t, 'priority_merge', { flags: { branch: 'testBranch' } })
 })

--- a/packages/config/tests/cwd/tests.js
+++ b/packages/config/tests/cwd/tests.js
@@ -5,44 +5,44 @@ const test = require('ava')
 
 const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
-test('--cwd with no config', async t => {
+test('--cwd with no config', async (t) => {
   await runFixture(t, '', { flags: { cwd: `${FIXTURES_DIR}/empty` } })
 })
 
-test('--cwd with a relative path config', async t => {
+test('--cwd with a relative path config', async (t) => {
   await runFixture(t, '', { flags: { cwd: `${relative(cwd(), FIXTURES_DIR)}`, config: 'empty/netlify.toml' } })
 })
 
-test('build.base current directory', async t => {
+test('build.base current directory', async (t) => {
   await runFixture(t, 'build_base_cwd')
 })
 
-test('build.base override', async t => {
+test('build.base override', async (t) => {
   await runFixture(t, 'build_base_override', { flags: { cwd: `${FIXTURES_DIR}/build_base_override/subdir` } })
 })
 
-test('--repository-root', async t => {
+test('--repository-root', async (t) => {
   await runFixture(t, '', { flags: { repositoryRoot: `${FIXTURES_DIR}/empty` } })
 })
 
-test('No .git', async t => {
+test('No .git', async (t) => {
   await runFixture(t, 'empty', { copyRoot: { cwd: true, git: false } })
 })
 
-test('--cwd non-existing', async t => {
+test('--cwd non-existing', async (t) => {
   await runFixture(t, '', { flags: { cwd: '/invalid', repositoryRoot: `${FIXTURES_DIR}/empty` } })
 })
 
-test('--cwd points to a non-directory file', async t => {
+test('--cwd points to a non-directory file', async (t) => {
   await runFixture(t, '', {
     flags: { cwd: `${FIXTURES_DIR}/empty/netlify.toml`, repositoryRoot: `${FIXTURES_DIR}/empty` },
   })
 })
 
-test('--repositoryRoot non-existing', async t => {
+test('--repositoryRoot non-existing', async (t) => {
   await runFixture(t, '', { flags: { repositoryRoot: '/invalid' } })
 })
 
-test('--repositoryRoot points to a non-directory file', async t => {
+test('--repositoryRoot points to a non-directory file', async (t) => {
   await runFixture(t, '', { flags: { repositoryRoot: `${FIXTURES_DIR}/empty/netlify.toml` } })
 })

--- a/packages/config/tests/helpers/main.js
+++ b/packages/config/tests/helpers/main.js
@@ -8,7 +8,7 @@ const { runFixtureCommon, FIXTURES_DIR, startServer } = require('../../../build/
 
 const ROOT_DIR = `${__dirname}/../..`
 
-const runFixture = async function(t, fixtureName, { flags = {}, env, ...opts } = {}) {
+const runFixture = async function (t, fixtureName, { flags = {}, env, ...opts } = {}) {
   const binaryPath = await BINARY_PATH
   const flagsA = { stable: true, buffer: true, branch: 'branch', ...flags }
   // Ensure local environment variables aren't used during development
@@ -17,7 +17,7 @@ const runFixture = async function(t, fixtureName, { flags = {}, env, ...opts } =
 }
 
 // In tests, make the return value stable so it can be snapshot
-const mainFunc = async function(flags) {
+const mainFunc = async function (flags) {
   const { logs: { stdout = [], stderr = [] } = {}, ...result } = await resolveConfig(flags)
   const resultA = serializeApi(result)
   const resultB = stableStringify(resultA, null, 2)
@@ -25,7 +25,7 @@ const mainFunc = async function(flags) {
   return resultC
 }
 
-const serializeApi = function({ api, ...result }) {
+const serializeApi = function ({ api, ...result }) {
   if (api === undefined) {
     return result
   }

--- a/packages/config/tests/load/tests.js
+++ b/packages/config/tests/load/tests.js
@@ -6,95 +6,95 @@ const test = require('ava')
 const resolveConfig = require('../..')
 const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
-test('Empty configuration', async t => {
+test('Empty configuration', async (t) => {
   await runFixture(t, 'empty')
 })
 
-test('No --config but none found', async t => {
+test('No --config but none found', async (t) => {
   await runFixture(t, 'none', { copyRoot: {} })
 })
 
-test('--config with an absolute path', async t => {
+test('--config with an absolute path', async (t) => {
   await runFixture(t, '', { flags: { config: `${FIXTURES_DIR}/empty/netlify.toml` } })
 })
 
-test('--config with a relative path', async t => {
+test('--config with a relative path', async (t) => {
   await runFixture(t, '', { flags: { config: `${relative(cwd(), FIXTURES_DIR)}/empty/netlify.toml` } })
 })
 
-test('--config with an invalid relative path', async t => {
+test('--config with an invalid relative path', async (t) => {
   await runFixture(t, '', { flags: { config: '/invalid' } })
 })
 
-test('--defaultConfig merge', async t => {
+test('--defaultConfig merge', async (t) => {
   const defaultConfig = JSON.stringify({ build: { publish: 'publish' } })
   await runFixture(t, 'default_merge', { flags: { defaultConfig } })
 })
 
-test('--defaultConfig priority', async t => {
+test('--defaultConfig priority', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: 'echo commandDefault' } })
   await runFixture(t, 'default_priority', { flags: { defaultConfig } })
 })
 
-test('--defaultConfig with an invalid relative path', async t => {
+test('--defaultConfig with an invalid relative path', async (t) => {
   await runFixture(t, '', { flags: { defaultConfig: '{{}' } })
 })
 
-test('--defaultConfig merges UI plugins with config plugins', async t => {
+test('--defaultConfig merges UI plugins with config plugins', async (t) => {
   const defaultConfig = JSON.stringify({ plugins: [{ package: 'one', inputs: { test: false, testThree: true } }] })
   await runFixture(t, 'plugins_merge', { flags: { defaultConfig } })
 })
 
-test('--inlineConfig CLI flag', async t => {
+test('--inlineConfig CLI flag', async (t) => {
   await runFixture(t, 'default_merge', { flags: { 'inlineConfig.build.publish': 'publish' }, useBinary: true })
 })
 
-test('--inlineConfig is merged', async t => {
+test('--inlineConfig is merged', async (t) => {
   const inlineConfig = { build: { publish: 'publish' } }
   await runFixture(t, 'default_merge', { flags: { inlineConfig } })
 })
 
-test('--inlineConfig is merged with priority', async t => {
+test('--inlineConfig is merged with priority', async (t) => {
   const inlineConfig = { build: { command: 'echo commandInline' } }
   await runFixture(t, 'default_priority', { flags: { inlineConfig } })
 })
 
-test('--inlineConfig falsy values are ignored', async t => {
+test('--inlineConfig falsy values are ignored', async (t) => {
   const inlineConfig = { build: { command: '', publish: undefined } }
   await runFixture(t, 'default_priority', { flags: { inlineConfig } })
 })
 
-test('--inlineConfig can override the "base"', async t => {
+test('--inlineConfig can override the "base"', async (t) => {
   const defaultConfig = JSON.stringify({ build: { base: 'defaultBase' } })
   const inlineConfig = { build: { base: 'base' } }
   await runFixture(t, 'merge_base', { flags: { defaultConfig, inlineConfig } })
 })
 
-test('--cachedConfig', async t => {
+test('--cachedConfig', async (t) => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false })
   await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue } })
 })
 
-test('--cachedConfig with an invalid path', async t => {
+test('--cachedConfig with an invalid path', async (t) => {
   await runFixture(t, '', { flags: { cachedConfig: '{{}' } })
 })
 
-test('--cachedConfig with a token', async t => {
+test('--cachedConfig with a token', async (t) => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false })
   await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue, token: 'test' } })
 })
 
-test('--cachedConfig with a siteId', async t => {
+test('--cachedConfig with a siteId', async (t) => {
   const { returnValue } = await runFixture(t, 'cached_config', { snapshot: false, flags: { siteId: 'test' } })
   await runFixture(t, 'cached_config', { flags: { cachedConfig: returnValue, siteId: 'test' } })
 })
 
-test('Programmatic', async t => {
+test('Programmatic', async (t) => {
   const { config } = await resolveConfig({ repositoryRoot: `${FIXTURES_DIR}/empty` })
   t.not(config.build.environment, undefined)
 })
 
-test('Programmatic no options', async t => {
+test('Programmatic no options', async (t) => {
   const { config } = await resolveConfig()
   t.not(config.build.environment, undefined)
 })

--- a/packages/config/tests/log/tests.js
+++ b/packages/config/tests/log/tests.js
@@ -3,35 +3,35 @@ const hasAnsi = require('has-ansi')
 
 const { runFixture } = require('../helpers/main')
 
-test('Prints some information in debug mode', async t => {
+test('Prints some information in debug mode', async (t) => {
   await runFixture(t, 'simple', { flags: { debug: true } })
 })
 
-test('Allow printing undefined in debug mode', async t => {
+test('Allow printing undefined in debug mode', async (t) => {
   await runFixture(t, 'empty', { flags: { debug: true } })
 })
 
-test('Allow printing plugins with no inputs in debug mode', async t => {
+test('Allow printing plugins with no inputs in debug mode', async (t) => {
   const defaultConfig = JSON.stringify({ plugins: [{ package: 'test' }] })
   await runFixture(t, 'empty', { flags: { debug: true, defaultConfig } })
 })
 
-test('Does not print confidential information in debug mode', async t => {
+test('Does not print confidential information in debug mode', async (t) => {
   const defaultConfig = JSON.stringify({ build: { environment: { SECRET: 'true' } } })
   const inlineConfig = { build: { environment: { SECRET_TWO: 'true' } } }
   await runFixture(t, 'simple', { flags: { debug: true, defaultConfig, inlineConfig }, env: { SECRET: 'true' } })
 })
 
-test('Debug mode can be enabled using the NETLIFY_BUILD_DEBUG environment variable', async t => {
+test('Debug mode can be enabled using the NETLIFY_BUILD_DEBUG environment variable', async (t) => {
   await runFixture(t, 'simple', { env: { NETLIFY_BUILD_DEBUG: 'true' } })
 })
 
-test('Debug mode can be enabled using the NETLIFY_BUILD_DEBUG environment UI setting', async t => {
+test('Debug mode can be enabled using the NETLIFY_BUILD_DEBUG environment UI setting', async (t) => {
   const defaultConfig = JSON.stringify({ build: { environment: { NETLIFY_BUILD_DEBUG: 'true' } } })
   await runFixture(t, 'simple', { flags: { defaultConfig } })
 })
 
-test('Prints colors', async t => {
+test('Prints colors', async (t) => {
   const { returnValue } = await runFixture(t, 'simple', {
     flags: { debug: true },
     env: { FORCE_COLOR: '1' },

--- a/packages/config/tests/normalize/tests.js
+++ b/packages/config/tests/normalize/tests.js
@@ -2,15 +2,15 @@ const test = require('ava')
 
 const { runFixture } = require('../helpers/main')
 
-test('build.command empty', async t => {
+test('build.command empty', async (t) => {
   await runFixture(t, 'command_empty')
 })
 
-test('Some properties can be capitalized', async t => {
+test('Some properties can be capitalized', async (t) => {
   await runFixture(t, 'props_case')
 })
 
-test('Some properties can be capitalized even when merged with defaultConfig', async t => {
+test('Some properties can be capitalized even when merged with defaultConfig', async (t) => {
   const defaultConfig = JSON.stringify({
     build: {
       base: 'baseDefault',
@@ -26,27 +26,27 @@ test('Some properties can be capitalized even when merged with defaultConfig', a
   await runFixture(t, 'props_case', { flags: { defaultConfig } })
 })
 
-test('Some properties can be capitalized even when merged with contexts', async t => {
+test('Some properties can be capitalized even when merged with contexts', async (t) => {
   await runFixture(t, 'props_case_context', { flags: { context: 'testContext', branch: 'testBranch' } })
 })
 
-test('Does not add build.commandOrigin config if there are none', async t => {
+test('Does not add build.commandOrigin config if there are none', async (t) => {
   await runFixture(t, 'empty')
 })
 
-test('Does not add build.commandOrigin config if command is empty', async t => {
+test('Does not add build.commandOrigin config if command is empty', async (t) => {
   await runFixture(t, 'command_empty')
 })
 
-test('Add build.commandOrigin config if it came from netlify.toml', async t => {
+test('Add build.commandOrigin config if it came from netlify.toml', async (t) => {
   await runFixture(t, 'command_origin_config')
 })
 
-test('Add build.commandOrigin config if it came from contexts', async t => {
+test('Add build.commandOrigin config if it came from contexts', async (t) => {
   await runFixture(t, 'command_origin_context')
 })
 
-test('Add build.commandOrigin ui if it came from defaultConfig', async t => {
+test('Add build.commandOrigin ui if it came from defaultConfig', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: 'test' } })
   await runFixture(t, 'empty', { flags: { defaultConfig } })
 })

--- a/packages/config/tests/parse/tests.js
+++ b/packages/config/tests/parse/tests.js
@@ -4,7 +4,7 @@ const test = require('ava')
 
 const { runFixture, FIXTURES_DIR } = require('../helpers/main')
 
-test('Configuration file - netlify.toml', async t => {
+test('Configuration file - netlify.toml', async (t) => {
   await runFixture(t, 'toml')
 })
 
@@ -12,11 +12,11 @@ test('Configuration file - netlify.toml', async t => {
 // Node 10 also changed errors there, so Node 8 shows different error messages.
 // TODO: remove once dropping support for Node 8
 if (platform !== 'win32' && !version.startsWith('v8.')) {
-  test('Configuration file - read permission error', async t => {
+  test('Configuration file - read permission error', async (t) => {
     await runFixture(t, '', { flags: { config: `${FIXTURES_DIR}/read_error/netlify.toml` } })
   })
 }
 
-test('Configuration file - parsing error', async t => {
+test('Configuration file - parsing error', async (t) => {
   await runFixture(t, 'parse_error')
 })

--- a/packages/config/tests/validate/tests.js
+++ b/packages/config/tests/validate/tests.js
@@ -2,116 +2,116 @@ const test = require('ava')
 
 const { runFixture } = require('../helpers/main')
 
-test('plugins: not array', async t => {
+test('plugins: not array', async (t) => {
   await runFixture(t, 'plugins_not_array')
 })
 
-test('plugins: not array of objects', async t => {
+test('plugins: not array of objects', async (t) => {
   await runFixture(t, 'plugins_not_objects')
 })
 
-test('plugins: do not allow duplicates', async t => {
+test('plugins: do not allow duplicates', async (t) => {
   await runFixture(t, 'plugins_duplicate')
 })
 
-test('plugins.any: unknown property', async t => {
+test('plugins.any: unknown property', async (t) => {
   await runFixture(t, 'plugins_unknown')
 })
 
-test('plugins.any.id backward compatibility', async t => {
+test('plugins.any.id backward compatibility', async (t) => {
   await runFixture(t, 'plugins_id_compat')
 })
 
-test('plugins.any.enabled removed', async t => {
+test('plugins.any.enabled removed', async (t) => {
   await runFixture(t, 'plugins_enabled')
 })
 
-test('plugins.any.package: required', async t => {
+test('plugins.any.package: required', async (t) => {
   await runFixture(t, 'plugins_package_required')
 })
 
-test('plugins.any.package: string', async t => {
+test('plugins.any.package: string', async (t) => {
   await runFixture(t, 'plugins_package_string')
 })
 
-test('plugins.any.package: should not include a version', async t => {
+test('plugins.any.package: should not include a version', async (t) => {
   await runFixture(t, 'plugins_package_version')
 })
 
-test('plugins.any.package: should not include a URI scheme', async t => {
+test('plugins.any.package: should not include a URI scheme', async (t) => {
   await runFixture(t, 'plugins_package_scheme')
 })
 
-test('plugins.any.inputs: object', async t => {
+test('plugins.any.inputs: object', async (t) => {
   await runFixture(t, 'plugins_inputs_object')
 })
 
-test('build: object', async t => {
+test('build: object', async (t) => {
   await runFixture(t, 'build_object')
 })
 
-test('build.publish: string', async t => {
+test('build.publish: string', async (t) => {
   await runFixture(t, 'build_publish_string')
 })
 
-test('build.publish: parent directory', async t => {
+test('build.publish: parent directory', async (t) => {
   await runFixture(t, 'build_publish_parent')
 })
 
-test('build.functions: string', async t => {
+test('build.functions: string', async (t) => {
   await runFixture(t, 'build_functions_string')
 })
 
-test('build.functions: parent directory', async t => {
+test('build.functions: parent directory', async (t) => {
   await runFixture(t, 'build_functions_parent')
 })
 
-test('build.edge_handlers: string', async t => {
+test('build.edge_handlers: string', async (t) => {
   await runFixture(t, 'build_edge_handlers_string')
 })
 
-test('build.edge_handlers: parent directory', async t => {
+test('build.edge_handlers: parent directory', async (t) => {
   await runFixture(t, 'build_edge_handlers_parent')
 })
 
-test('build.base: string', async t => {
+test('build.base: string', async (t) => {
   await runFixture(t, 'build_base_string')
 })
 
-test('build.base: parent directory', async t => {
+test('build.base: parent directory', async (t) => {
   await runFixture(t, 'build_base_parent')
 })
 
-test('build.command: string', async t => {
+test('build.command: string', async (t) => {
   await runFixture(t, 'build_command_string')
 })
 
-test('build.command: array', async t => {
+test('build.command: array', async (t) => {
   await runFixture(t, 'build_command_array')
 })
 
-test('build.context: property', async t => {
+test('build.context: property', async (t) => {
   await runFixture(t, 'build_context_property', { flags: { context: 'development' } })
 })
 
-test('build.context: nested property', async t => {
+test('build.context: nested property', async (t) => {
   await runFixture(t, 'build_context_nested_property', { flags: { context: 'development' } })
 })
 
-test('build.context: object', async t => {
+test('build.context: object', async (t) => {
   await runFixture(t, 'build_context_object')
 })
 
-test('build.context.CONTEXT: object', async t => {
+test('build.context.CONTEXT: object', async (t) => {
   await runFixture(t, 'build_context_nested_object')
 })
 
-test('Validates defaultConfig', async t => {
+test('Validates defaultConfig', async (t) => {
   const defaultConfig = JSON.stringify({ build: { command: false } })
   await runFixture(t, 'empty', { flags: { defaultConfig } })
 })
 
-test('Validates inlineConfig', async t => {
+test('Validates inlineConfig', async (t) => {
   const inlineConfig = { build: { command: false } }
   await runFixture(t, 'empty', { flags: { inlineConfig } })
 })

--- a/packages/functions-utils/src/main.js
+++ b/packages/functions-utils/src/main.js
@@ -10,7 +10,7 @@ const pStat = promisify(stat)
 
 // Add a Netlify Function file to the `functions` directory so it is processed
 // by `@netlify/plugin-functions-core`
-const add = async function(src, dist, { fail = defaultFail } = {}) {
+const add = async function (src, dist, { fail = defaultFail } = {}) {
   if (src === undefined) {
     return fail('No function source directory was specified')
   }
@@ -33,7 +33,7 @@ const add = async function(src, dist, { fail = defaultFail } = {}) {
   await cpy(srcGlob, dist, { cwd: dirname(src), parents: true, overwrite: false })
 }
 
-const getSrcGlob = async function(src, srcBasename) {
+const getSrcGlob = async function (src, srcBasename) {
   const stat = await pStat(src)
 
   if (stat.isDirectory()) {
@@ -43,7 +43,7 @@ const getSrcGlob = async function(src, srcBasename) {
   return srcBasename
 }
 
-const list = async function(functionsSrc, { fail = defaultFail } = {}) {
+const list = async function (functionsSrc, { fail = defaultFail } = {}) {
   if (functionsSrc === undefined) {
     return fail('No function directory was specified')
   }
@@ -55,7 +55,7 @@ const list = async function(functionsSrc, { fail = defaultFail } = {}) {
   }
 }
 
-const listAll = async function(functionsSrc, { fail = defaultFail } = {}) {
+const listAll = async function (functionsSrc, { fail = defaultFail } = {}) {
   if (functionsSrc === undefined) {
     return fail('No function directory was specified')
   }
@@ -67,7 +67,7 @@ const listAll = async function(functionsSrc, { fail = defaultFail } = {}) {
   }
 }
 
-const defaultFail = function(message) {
+const defaultFail = function (message) {
   throw new Error(message)
 }
 

--- a/packages/functions-utils/tests/helpers/main.js
+++ b/packages/functions-utils/tests/helpers/main.js
@@ -2,12 +2,12 @@ const del = require('del')
 const { tmpName, dir: tmpDir } = require('tmp-promise')
 
 // Retrieve name of a temporary directory
-const getDist = function() {
+const getDist = function () {
   return tmpName({ prefix: PREFIX })
 }
 
 // Create temporary directory
-const createDist = async function() {
+const createDist = async function () {
   const { path } = await tmpDir({ prefix: PREFIX })
   return path
 }
@@ -15,7 +15,7 @@ const createDist = async function() {
 const PREFIX = 'test-functions-utils-'
 
 // Remove temporary directory
-const removeDist = async function(dir) {
+const removeDist = async function (dir) {
   await del(dir, { force: true })
 }
 

--- a/packages/functions-utils/tests/main.js
+++ b/packages/functions-utils/tests/main.js
@@ -10,7 +10,7 @@ const { getDist, createDist, removeDist } = require('./helpers/main')
 
 const FIXTURES_DIR = `${__dirname}/fixtures`
 
-test('Should copy a source file to a dist directory', async t => {
+test('Should copy a source file to a dist directory', async (t) => {
   const dist = await getDist()
   try {
     await add(`${FIXTURES_DIR}/file/test.js`, dist)
@@ -20,7 +20,7 @@ test('Should copy a source file to a dist directory', async t => {
   }
 })
 
-test('Should copy a source directory to a dist directory', async t => {
+test('Should copy a source directory to a dist directory', async (t) => {
   const dist = await getDist()
   try {
     await add(`${FIXTURES_DIR}/directory/test`, dist)
@@ -30,7 +30,7 @@ test('Should copy a source directory to a dist directory', async t => {
   }
 })
 
-test('Should throw when source is undefined', async t => {
+test('Should throw when source is undefined', async (t) => {
   const dist = await getDist()
   try {
     await t.throwsAsync(add(undefined, dist))
@@ -39,7 +39,7 @@ test('Should throw when source is undefined', async t => {
   }
 })
 
-test('Should throw when source points to non-existing file', async t => {
+test('Should throw when source points to non-existing file', async (t) => {
   const dist = await getDist()
   try {
     await t.throwsAsync(add(`${FIXTURES_DIR}/file/doesNotExist.js`, dist))
@@ -48,11 +48,11 @@ test('Should throw when source points to non-existing file', async t => {
   }
 })
 
-test('Should throw when dist is undefined', async t => {
+test('Should throw when dist is undefined', async (t) => {
   await t.throwsAsync(add(`${FIXTURES_DIR}/file/test.js`))
 })
 
-test('Should copy a source file even if dist directory already exists', async t => {
+test('Should copy a source file even if dist directory already exists', async (t) => {
   const dist = await createDist()
   try {
     await add(`${FIXTURES_DIR}/file/test.js`, dist)
@@ -62,7 +62,7 @@ test('Should copy a source file even if dist directory already exists', async t 
   }
 })
 
-test('Should throw if dist file already exists', async t => {
+test('Should throw if dist file already exists', async (t) => {
   const dist = await getDist()
   try {
     await add(`${FIXTURES_DIR}/file/test.js`, dist)
@@ -72,20 +72,20 @@ test('Should throw if dist file already exists', async t => {
   }
 })
 
-test('Should allow "fail" option to customize failures', async t => {
+test('Should allow "fail" option to customize failures', async (t) => {
   const fail = spy()
   await add(undefined, undefined, { fail })
   t.true(fail.calledOnce)
   t.is(typeof fail.firstCall.firstArg, 'string')
 })
 
-const normalizeFiles = function(fixtureDir, { mainFile, runtime, extension, srcFile }) {
+const normalizeFiles = function (fixtureDir, { mainFile, runtime, extension, srcFile }) {
   const mainFileA = normalize(`${fixtureDir}/${mainFile}`)
   const srcFileA = srcFile === undefined ? {} : { srcFile: normalize(`${fixtureDir}/${srcFile}`) }
   return { mainFile: mainFileA, runtime, extension, ...srcFileA }
 }
 
-test('Can list function main files with list()', async t => {
+test('Can list function main files with list()', async (t) => {
   const fixtureDir = `${FIXTURES_DIR}/list`
   const functions = await list(fixtureDir)
   t.deepEqual(
@@ -100,7 +100,7 @@ test('Can list function main files with list()', async t => {
   )
 })
 
-test('Can list all function files with listAll()', async t => {
+test('Can list all function files with listAll()', async (t) => {
   const fixtureDir = `${FIXTURES_DIR}/list`
   const functions = await listAll(fixtureDir)
   t.deepEqual(

--- a/packages/git-utils/src/commits.js
+++ b/packages/git-utils/src/commits.js
@@ -2,7 +2,7 @@ const { git } = require('./exec')
 
 // Return information on each commit since the `base` commit, such as SHA,
 // parent commits, author, committer and commit message
-const getCommits = function(base, head, cwd) {
+const getCommits = function (base, head, cwd) {
   const stdout = git(['log', `--pretty=format:${JSON.stringify(FORMAT_JSON)}`, `${base}...${head}`], cwd)
   const commits = JSON.parse(`[${stdout.split('\n').join(',')}]`)
   return commits

--- a/packages/git-utils/src/diff.js
+++ b/packages/git-utils/src/diff.js
@@ -2,12 +2,9 @@ const { git } = require('./exec')
 
 // Return the list of modified|created|deleted files according to git, between
 // the `base` commit and the `HEAD`
-const getDiffFiles = function(base, head, cwd) {
+const getDiffFiles = function (base, head, cwd) {
   const stdout = git(['diff', '--name-status', '--no-renames', `${base}...${head}`], cwd)
-  const files = stdout
-    .split('\n')
-    .map(getDiffFile)
-    .filter(Boolean)
+  const files = stdout.split('\n').map(getDiffFile).filter(Boolean)
 
   const modifiedFiles = getFilesByType(files, 'M')
   const createdFiles = getFilesByType(files, 'A')
@@ -16,7 +13,7 @@ const getDiffFiles = function(base, head, cwd) {
 }
 
 // Parse each `git diff` line
-const getDiffFile = function(line) {
+const getDiffFile = function (line) {
   const result = DIFF_FILE_REGEXP.exec(line)
 
   // Happens for example when `base` is invalid
@@ -30,11 +27,11 @@ const getDiffFile = function(line) {
 
 const DIFF_FILE_REGEXP = /([ADM])\s+(.*)/
 
-const getFilesByType = function(files, type) {
-  return files.filter(file => file.type === type).map(getFilepath)
+const getFilesByType = function (files, type) {
+  return files.filter((file) => file.type === type).map(getFilepath)
 }
 
-const getFilepath = function({ filepath }) {
+const getFilepath = function ({ filepath }) {
   return filepath
 }
 

--- a/packages/git-utils/src/exec.js
+++ b/packages/git-utils/src/exec.js
@@ -5,7 +5,7 @@ const moize = require('moize').default
 const pathExists = require('path-exists')
 
 // Fires the `git` binary. Memoized.
-const mGit = function(args, cwd) {
+const mGit = function (args, cwd) {
   const cwdA = safeGetCwd(cwd)
   const { stdout } = execa.sync('git', args, { cwd: cwdA })
   return stdout
@@ -13,7 +13,7 @@ const mGit = function(args, cwd) {
 
 const git = moize(mGit, { isDeepEqual: true })
 
-const safeGetCwd = function(cwd) {
+const safeGetCwd = function (cwd) {
   const cwdA = getCwdValue(cwd)
 
   if (!pathExists.sync(cwdA)) {
@@ -23,7 +23,7 @@ const safeGetCwd = function(cwd) {
   return cwdA
 }
 
-const getCwdValue = function(cwd) {
+const getCwdValue = function (cwd) {
   if (cwd !== undefined) {
     return cwd
   }

--- a/packages/git-utils/src/main.js
+++ b/packages/git-utils/src/main.js
@@ -5,7 +5,7 @@ const { getBase, getHead } = require('./refs')
 const { getLinesOfCode } = require('./stats')
 
 // Main entry point to the git utilities
-const getGitUtils = function({ base, head, cwd } = {}) {
+const getGitUtils = function ({ base, head, cwd } = {}) {
   const headA = getHead(head)
   const baseA = getBase(base, headA, cwd)
   const { modifiedFiles, createdFiles, deletedFiles } = getDiffFiles(baseA, headA, cwd)

--- a/packages/git-utils/src/match.js
+++ b/packages/git-utils/src/match.js
@@ -3,7 +3,7 @@ const micromatch = require('micromatch')
 
 // Return functions that return modified|created|deleted files filtered by a
 // globbing pattern
-const fileMatch = function({ modifiedFiles, createdFiles, deletedFiles }, ...patterns) {
+const fileMatch = function ({ modifiedFiles, createdFiles, deletedFiles }, ...patterns) {
   const matchFiles = {
     modified: modifiedFiles,
     created: createdFiles,

--- a/packages/git-utils/src/refs.js
+++ b/packages/git-utils/src/refs.js
@@ -3,7 +3,7 @@ const { env } = require('process')
 const { git } = require('./exec')
 
 // Retrieve the `head` commit
-const getHead = function(head = 'HEAD', cwd) {
+const getHead = function (head = 'HEAD', cwd) {
   const result = checkRef(head, cwd)
   if (result.error !== undefined) {
     throwError('head', result)
@@ -12,13 +12,13 @@ const getHead = function(head = 'HEAD', cwd) {
 }
 
 // Retrieve the `base` commit
-const getBase = function(base, head, cwd) {
+const getBase = function (base, head, cwd) {
   const refs = getBaseRefs(base, head)
   const { ref } = findRef(refs, cwd)
   return ref
 }
 
-const getBaseRefs = function(base, head) {
+const getBaseRefs = function (base, head) {
   if (base !== undefined) {
     return [base]
   }
@@ -33,8 +33,8 @@ const getBaseRefs = function(base, head) {
 }
 
 // Use the first commit that exists
-const findRef = function(refs, cwd) {
-  const results = refs.map(ref => checkRef(ref, cwd))
+const findRef = function (refs, cwd) {
+  const results = refs.map((ref) => checkRef(ref, cwd))
   const result = results.find(refExists)
   if (result === undefined) {
     throwError('base', results[0])
@@ -43,7 +43,7 @@ const findRef = function(refs, cwd) {
 }
 
 // Check if a commit exists
-const checkRef = function(ref, cwd) {
+const checkRef = function (ref, cwd) {
   try {
     git(['rev-parse', ref], cwd)
     return { ref }
@@ -52,11 +52,11 @@ const checkRef = function(ref, cwd) {
   }
 }
 
-const refExists = function({ error }) {
+const refExists = function ({ error }) {
   return error === undefined
 }
 
-const throwError = function(name, { ref, error: { message, stderr } }) {
+const throwError = function (name, { ref, error: { message, stderr } }) {
   const messages = [message, stderr].filter(Boolean).join('\n')
   const messageA = `Invalid ${name} commit ${ref}\n${messages}`
   throw new Error(messageA)

--- a/packages/git-utils/src/stats.js
+++ b/packages/git-utils/src/stats.js
@@ -2,14 +2,14 @@ const { git } = require('./exec')
 
 // Returns the number of lines of code added, removed or modified since the
 // `base` commit
-const getLinesOfCode = function(base, head, cwd) {
+const getLinesOfCode = function (base, head, cwd) {
   const stdout = git(['diff', '--shortstat', `${base}...${head}`], cwd)
   const insertions = parseStdout(stdout, INSERTION_REGEXP)
   const deletions = parseStdout(stdout, DELETION_REGEXP)
   return insertions + deletions
 }
 
-const parseStdout = function(stdout, regexp) {
+const parseStdout = function (stdout, regexp) {
   const result = regexp.exec(stdout)
 
   if (result === null) {

--- a/packages/git-utils/tests/main.js
+++ b/packages/git-utils/tests/main.js
@@ -11,7 +11,7 @@ const HEAD = '152867c2'
 const UNKNOWN_COMMIT = 'aaaaaaaa'
 const DEFAULT_OPTS = { base: BASE, head: HEAD }
 
-test('Should define all its methods and properties', t => {
+test('Should define all its methods and properties', (t) => {
   const git = getGitUtils(DEFAULT_OPTS)
   t.deepEqual(Object.keys(git).sort(), [
     'commits',
@@ -23,17 +23,17 @@ test('Should define all its methods and properties', t => {
   ])
 })
 
-test('Should be callable with no options', t => {
+test('Should be callable with no options', (t) => {
   const { linesOfCode } = getGitUtils()
   t.true(Number.isInteger(linesOfCode))
 })
 
-test('Option "head" should have a default value', t => {
+test('Option "head" should have a default value', (t) => {
   const { linesOfCode } = getGitUtils({ base: BASE })
   t.true(Number.isInteger(linesOfCode))
 })
 
-test('Options "base" and "head" can be the same commit', t => {
+test('Options "base" and "head" can be the same commit', (t) => {
   const { linesOfCode, modifiedFiles, createdFiles, deletedFiles } = getGitUtils({ base: HEAD, head: HEAD })
   t.is(linesOfCode, 0)
   t.deepEqual(modifiedFiles, [])
@@ -41,15 +41,15 @@ test('Options "base" and "head" can be the same commit', t => {
   t.deepEqual(deletedFiles, [])
 })
 
-test('Should error when the option "base" points to an unknown commit', t => {
+test('Should error when the option "base" points to an unknown commit', (t) => {
   t.throws(() => getGitUtils({ base: UNKNOWN_COMMIT, head: HEAD }), { message: /Invalid base commit/ })
 })
 
-test('Should error when the option "head" points to an unknown commit', t => {
+test('Should error when the option "head" points to an unknown commit', (t) => {
   t.throws(() => getGitUtils({ base: BASE, head: UNKNOWN_COMMIT }), { message: /Invalid head commit/ })
 })
 
-test.serial('Should allow using the environment variable CACHED_COMMIT_REF', t => {
+test.serial('Should allow using the environment variable CACHED_COMMIT_REF', (t) => {
   try {
     env.CACHED_COMMIT_REF = BASE
     const { linesOfCode } = getGitUtils({ head: HEAD })
@@ -59,7 +59,7 @@ test.serial('Should allow using the environment variable CACHED_COMMIT_REF', t =
   }
 })
 
-test.serial('Should allow overriding the current directory', t => {
+test.serial('Should allow overriding the current directory', (t) => {
   const currentCwd = getCwd()
   try {
     chdir('/')
@@ -70,18 +70,18 @@ test.serial('Should allow overriding the current directory', t => {
   }
 })
 
-test('Should throw when the current directory is invalid', t => {
+test('Should throw when the current directory is invalid', (t) => {
   t.throws(() => {
     getGitUtils({ ...DEFAULT_OPTS, cwd: '/does/not/exist' })
   })
 })
 
-test('Should return the number of lines of code', t => {
+test('Should return the number of lines of code', (t) => {
   const { linesOfCode } = getGitUtils(DEFAULT_OPTS)
   t.is(linesOfCode, 163)
 })
 
-test('Should return the commits', t => {
+test('Should return the commits', (t) => {
   const { commits } = getGitUtils(DEFAULT_OPTS)
   t.is(commits.length, 3)
   const [{ sha, author, committer, message }] = commits
@@ -96,14 +96,14 @@ test('Should return the commits', t => {
   )
 })
 
-test('Should return the modified/created/deleted files', t => {
+test('Should return the modified/created/deleted files', (t) => {
   const { modifiedFiles, createdFiles, deletedFiles } = getGitUtils(DEFAULT_OPTS)
   t.deepEqual(modifiedFiles, ['src/install/node/bower.js'])
   t.deepEqual(createdFiles, ['src/install/node/install-node.js', 'src/install/node/run-npm.js'])
   t.deepEqual(deletedFiles, ['src/install/node/index.js', 'src/install/node/npm.js'])
 })
 
-test('Should return whether specific files are modified/created/deleted/edited', t => {
+test('Should return whether specific files are modified/created/deleted/edited', (t) => {
   const { fileMatch } = getGitUtils(DEFAULT_OPTS)
   const { modified, created, deleted, edited } = fileMatch('**/*npm*', '!**/*run-npm*')
   t.deepEqual(modified, [])

--- a/packages/run-utils/src/main.js
+++ b/packages/run-utils/src/main.js
@@ -3,7 +3,7 @@ const process = require('process')
 const execa = require('execa')
 
 // Run a command, with arguments being an array
-const run = function(file, args, options) {
+const run = function (file, args, options) {
   const [argsA, optionsA] = parseArgs(args, options)
   const optionsB = { ...DEFAULT_OPTIONS, ...optionsA }
   const childProcess = execa(file, argsA, optionsB)
@@ -12,7 +12,7 @@ const run = function(file, args, options) {
 }
 
 // Run a command, with file + arguments being a single string
-const runCommand = function(command, options) {
+const runCommand = function (command, options) {
   const optionsA = { ...DEFAULT_OPTIONS, ...options }
   const childProcess = execa.command(command, optionsA)
   redirectOutput(childProcess, optionsA)
@@ -20,7 +20,7 @@ const runCommand = function(command, options) {
 }
 
 // Both `args` and `options` are optional
-const parseArgs = function(args, options) {
+const parseArgs = function (args, options) {
   if (Array.isArray(args)) {
     return [args, options]
   }
@@ -36,7 +36,7 @@ const parseArgs = function(args, options) {
 const DEFAULT_OPTIONS = { preferLocal: true }
 
 // Redirect output by default, unless specified otherwise
-const redirectOutput = function(childProcess, { stdio, stdout, stderr }) {
+const redirectOutput = function (childProcess, { stdio, stdout, stderr }) {
   if (stdio !== undefined || stdout !== undefined || stderr !== undefined) {
     return
   }

--- a/packages/run-utils/tests/main.js
+++ b/packages/run-utils/tests/main.js
@@ -9,55 +9,55 @@ const run = require('..')
 const FIXTURES_DIR = `${__dirname}/fixtures`
 const RUN_FILE = `${FIXTURES_DIR}/run.js`
 
-const runInChildProcess = function(command, options) {
+const runInChildProcess = function (command, options) {
   const optionsA = options === undefined ? [] : [JSON.stringify(options)]
   return execa('node', [RUN_FILE, command, ...optionsA])
 }
 
-test('Should expose several methods', t => {
+test('Should expose several methods', (t) => {
   t.is(typeof run, 'function')
   t.is(typeof run.command, 'function')
 })
 
-test('Can run a command as a single string', async t => {
+test('Can run a command as a single string', async (t) => {
   const { stdout } = await run.command('ava --version', { stdio: 'pipe' })
   t.truthy(validVersion(stdout))
 })
 
 // `echo` in `cmd.exe` is different from Unix
 if (platform !== 'win32') {
-  test('Can run with no arguments', async t => {
+  test('Can run with no arguments', async (t) => {
     const { stdout } = await run('echo', { stdio: 'pipe' })
     t.is(stdout.trim(), '')
   })
 
-  test('Can run with no arguments nor options object', async t => {
+  test('Can run with no arguments nor options object', async (t) => {
     const { stdout } = await run('echo')
     t.is(stdout.trim(), '')
   })
 }
 
-test('Can run local binaries', async t => {
+test('Can run local binaries', async (t) => {
   const { stdout } = await run('ava', ['--version'], { stdio: 'pipe' })
   t.truthy(validVersion(stdout))
 })
 
-test('Should redirect stdout/stderr to parent', async t => {
+test('Should redirect stdout/stderr to parent', async (t) => {
   const { stdout } = await runInChildProcess('ava --version')
   t.truthy(validVersion(stdout))
 })
 
-test('Should not redirect stdout/stderr to parent when using "stdio" option', async t => {
+test('Should not redirect stdout/stderr to parent when using "stdio" option', async (t) => {
   const { stdout } = await runInChildProcess('ava --version', { stdio: 'pipe' })
   t.is(stdout, '')
 })
 
-test('Should not redirect stdout/stderr to parent when using "stdout" option', async t => {
+test('Should not redirect stdout/stderr to parent when using "stdout" option', async (t) => {
   const { stdout } = await runInChildProcess('ava --version', { stdout: 'pipe' })
   t.is(stdout, '')
 })
 
-test('Should not redirect stdout/stderr to parent when using "stderr" option', async t => {
+test('Should not redirect stdout/stderr to parent when using "stderr" option', async (t) => {
   const { stdout } = await runInChildProcess('ava --version', { stderr: 'pipe' })
   t.is(stdout, '')
 })

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,7 +28,6 @@
         'nock',
         'os-name',
         'p-locate',
-        'prettier',
         'pretty-ms',
         'update-notifier',
         'yargs',


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1962

This upgrades Prettier to `v2` now that it's only run on Node 14.

This new Prettier had lots of small changes, mostly: 
  - `function()` -> `function ()`
  - `arg => {}` -> `(arg) => {}`

Those small changes are >95% of this PR's diff. All of them were automatically generated by `prettier --fix`. I went through all of them. However, that's 200+ files :-/