### PR TITLE
Add a `eslint-disable` comment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 const { version } = require('process')
 
 const isNode8 = version.startsWith('v8.')
@@ -193,3 +194,4 @@ module.exports = {
     },
   ],
 }
+/* eslint-enable max-lines */


### PR DESCRIPTION
The `.eslintrc.js` file is quite big. This triggers the `max-lines` ESLint rule. However, there might not be strong benefits in breaking that specific file into smaller files.