### PR TITLE
Add `func-names` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
 
     // Those ESLint rules are not enabled by Prettier, ESLint recommended rules
     // nor standard JavaScript. However, they are still useful
+    'func-names': [2, 'as-needed'],
     'multiline-comment-style': [2, 'separate-lines'],
     'no-await-in-loop': 2,
 

--- a/packages/build/src/time/main.js
+++ b/packages/build/src/time/main.js
@@ -15,7 +15,7 @@ const initTimers = function () {
 // The `durationNs` will be returned by the function. A new `timers` with the
 // additional duration timer will be returned as well.
 const kMeasureDuration = function (func, stageTag, { parentTag, category } = {}) {
-  return async function ({ timers, ...opts }, ...args) {
+  return async function measuredFunc({ timers, ...opts }, ...args) {
     const timerNs = startTimer()
     const { timers: timersA = timers, ...returnObject } = await func({ timers, ...opts }, ...args)
     const durationNs = endTimer(timerNs)


### PR DESCRIPTION
This adds the [`func-names`](https://eslint.org/docs/rules/func-names) ESLint rule.