### PR TITLE
Add `id-length` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
     'func-name-matching': [2, { considerPropertyDescriptor: true }],
     'func-names': [2, 'as-needed'],
     'func-style': 2,
+    'id-length': [2, { exceptions: ['t', '_'] }],
     'line-comment-position': 2,
     'max-classes-per-file': 2,
     'max-params': [2, { max: 4 }],


### PR DESCRIPTION
This adds the [`id-length`](https://eslint.org/docs/rules/id-length) ESLint rule.

Even with autocompletion, long variables can be annoying. On the other hand, too short variables can be obscure. So this PR gives a 24 characters maximum per variable, which is hopefully a good balance. Please let me know if this should be decreased or increased.