### PR TITLE
Configure `ava/no-only-test` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,7 +154,9 @@ module.exports = {
 
     'ava/no-ignored-test-files': [2, { files: ['tests/**/*.js', '!tests/{helpers,fixtures}/**/*.{js,json}'] }],
     'ava/no-import-test-files': [2, { files: ['tests/**/*.js', '!tests/{helpers,fixtures}/**/*.{js,json}'] }],
+    // The autofix makes it impossible to use those in debugging
     'ava/no-skip-test': 0,
+    'ava/no-only-test': 0,
   },
   overrides: [
     {


### PR DESCRIPTION
`test.only()` and `test.skip()` are useful in debugging. Enabling those ESLint rules would prevent from using those due to the autofix on file save.