### PR TITLE
Add `no-underscore-dangle` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
     'no-nested-ternary': 2,
     'no-plusplus': [2, { allowForLoopAfterthoughts: true }],
     'no-promise-executor-return': 2,
+    'no-underscore-dangle': [2, { enforceInMethodNames: true }],
     'no-unreachable-loop': 2,
     'no-useless-backreference': 2,
     'no-useless-computed-key': [2, { enforceForClassMembers: true }],

--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -122,6 +122,7 @@ const onError = function (event, eventProps) {
   Object.assign(event, {
     ...eventProps,
     unhandled: event.unhandled || eventProps.unhandled,
+    // eslint-disable-next-line no-underscore-dangle
     _metadata: { ...event._metadata, ...eventProps._metadata },
     app: { ...event.app, ...eventProps.app },
   })

--- a/packages/build/src/time/report.js
+++ b/packages/build/src/time/report.js
@@ -32,6 +32,7 @@ const sendTimers = async function ({ timers, host, port, framework }) {
 // the internal API.
 const startClient = async function (host, port) {
   const client = new StatsdClient({ host, port, socketTimeout: 0 })
+  // eslint-disable-next-line no-underscore-dangle
   await promisify(client._socket._createSocket.bind(client._socket))()
   return client
 }


### PR DESCRIPTION
This adds the [`no-underscore-dangle`](https://eslint.org/docs/rules/no-underscore-dangle) ESLint rule.