### PR TITLE
Simplify Prettier configuration

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "endOfLine": "lf",
   "proseWrap": "always",
   "trailingComma": "all"
 }


### PR DESCRIPTION
The `endOfOption` Prettier option defaults to `lf`, so this can be removed.