### PR TITLE
Fix Node globals linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,15 +95,17 @@ module.exports = {
     'node/no-mixed-requires': 2,
     // Browser globals should not use `require()`. Non-browser globals should
     'node/prefer-global/console': 2,
-    'node/prefer-global/url-search-params': 2,
-    'node/prefer-global/text-decoder': 2,
-    'node/prefer-global/text-encoder': 2,
-    'node/prefer-global/url': 2,
     'node/prefer-global/buffer': [2, 'never'],
     'node/prefer-global/process': [2, 'never'],
+    // TODO: enable after dropping support for Node <10.0.0
+    'node/prefer-global/url-search-params': 0,
+    'node/prefer-global/url': 0,
+    // TODO: enable after dropping support for Node <11.0.0
+    'node/prefer-global/text-decoder': 0,
+    'node/prefer-global/text-encoder': 0,
     // TODO: enable after dropping support for Node <11.4.0
-    'node/prefer-promises/fs': 2,
-    'node/prefer-promises/dns': 2,
+    'node/prefer-promises/fs': 0,
+    'node/prefer-promises/dns': 0,
     // This does not work well in a monorepo
     'node/shebang': 0,
   },


### PR DESCRIPTION
This fixes some linting which does not work when targeting Node `8.3.0` since those global variables have been added by Node `11.0.0` and `12.0.0`.