### PR TITLE
Improve mock HTTP server

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1098,6 +1098,16 @@
 				"move-file": "^1.2.0",
 				"path-exists": "^4.0.0",
 				"readdirp": "^3.4.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@netlify/config": {
@@ -1604,6 +1614,15 @@
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
 					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
 					"dev": true
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -2791,6 +2810,14 @@
 				"responselike": "^1.0.2"
 			},
 			"dependencies": {
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
 				"lowercase-keys": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -4153,6 +4180,14 @@
 				"strip-final-newline": "^2.0.0"
 			},
 			"dependencies": {
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
 				"p-finally": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -4409,6 +4444,17 @@
 						"responselike": "^1.0.2",
 						"to-readable-stream": "^2.0.0",
 						"type-fest": "^0.8.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+							"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						}
 					}
 				},
 				"lowercase-keys": {
@@ -4659,6 +4705,15 @@
 					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
 					"dev": true
 				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -4704,6 +4759,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
 			"requires": {
 				"pump": "^3.0.0"
 			}

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -112,6 +112,7 @@
     "get-bin-path": "^4.0.1",
     "get-node": "^6.6.0",
     "get-port": "^5.1.1",
+    "get-stream": "^5.2.0",
     "has-ansi": "^4.0.0",
     "moize": "^5.4.6",
     "nock": "^11.9.1",

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -252,7 +252,7 @@ if (platform !== 'win32') {
 const TELEMETRY_PATH = '/collect'
 
 test('Telemetry success', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: TELEMETRY_PATH })
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: true },
     snapshot: false,
@@ -263,7 +263,7 @@ test('Telemetry success', async (t) => {
 })
 
 test('Telemetry disabled', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: TELEMETRY_PATH })
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` } },
     env: { BUILD_TELEMETRY_DISABLED: 'true' },
@@ -274,7 +274,7 @@ test('Telemetry disabled', async (t) => {
 })
 
 test('Telemetry disabled with flag', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: TELEMETRY_PATH })
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: false },
     snapshot: false,
@@ -284,7 +284,7 @@ test('Telemetry disabled with flag', async (t) => {
 })
 
 test('Telemetry disabled with mode', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(TELEMETRY_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: TELEMETRY_PATH })
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `${scheme}://${host}` }, telemetry: undefined },
     snapshot: false,
@@ -294,7 +294,7 @@ test('Telemetry disabled with mode', async (t) => {
 })
 
 test('Telemetry error', async (t) => {
-  const { stopServer } = await startServer(TELEMETRY_PATH)
+  const { stopServer } = await startServer({ path: TELEMETRY_PATH })
   await runFixture(t, 'success', {
     flags: { siteId: 'test', testOpts: { telemetryOrigin: `https://...` }, telemetry: true },
   })

--- a/packages/build/tests/env/tests.js
+++ b/packages/build/tests/env/tests.js
@@ -62,13 +62,13 @@ const SITE_INFO_PATH = '/api/v1/sites/test'
 const SITE_INFO_DATA = { url: 'test', build_settings: { repo_url: 'test' } }
 
 test('Environment variable siteInfo success', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_DATA })
   await runFixture(t, 'site_info', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo empty', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, {})
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH })
   await runFixture(t, 'site_info', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -51,21 +51,21 @@ test('build.cancelBuild() error option', async (t) => {
 })
 
 test('build.cancelBuild() API call', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: CANCEL_PATH })
   await runFixture(t, 'cancel', { flags: { token: 'test', deployId: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.snapshot(requests)
 })
 
 test('build.cancelBuild() API call no DEPLOY_ID', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: CANCEL_PATH })
   await runFixture(t, 'cancel', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.is(requests.length, 0)
 })
 
 test('build.cancelBuild() API call no token', async (t) => {
-  const { scheme, host, requests, stopServer } = await startServer(CANCEL_PATH)
+  const { scheme, host, requests, stopServer } = await startServer({ path: CANCEL_PATH })
   await runFixture(t, 'cancel', { flags: { deployId: 'test', testOpts: { scheme, host } } })
   await stopServer()
   t.is(requests.length, 0)

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -31,7 +31,7 @@ const comparePackage = function ({ body: { package: packageA } }, { body: { pack
 }
 
 const runWithApiMock = async function (t, fixture, { flags = { token: 'test' }, status } = {}) {
-  const { scheme, host, requests, stopServer } = await startServer(STATUS_PATH, {}, { status })
+  const { scheme, host, requests, stopServer } = await startServer({ path: STATUS_PATH, status })
   await runFixture(t, fixture, {
     flags: { deployId: 'test', ...flags, sendStatus: true, testOpts: { scheme, host } },
   })

--- a/packages/config/tests/api/tests.js
+++ b/packages/config/tests/api/tests.js
@@ -29,31 +29,35 @@ const SITE_INFO_DATA = { url: 'test', build_settings: { repo_url: 'test' } }
 const SITE_INFO_ERROR = { error: 'invalid' }
 
 test('Environment variable siteInfo success', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_DATA })
   await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo API error', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_ERROR, { status: 400 })
+  const { scheme, host, stopServer } = await startServer({
+    path: SITE_INFO_PATH,
+    response: SITE_INFO_ERROR,
+    status: 400,
+  })
   await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo no token', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_DATA })
   await runFixture(t, 'empty', { flags: { siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo no siteId', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_DATA })
   await runFixture(t, 'empty', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Environment variable siteInfo CI', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_DATA)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_DATA })
   await runFixture(t, 'empty', {
     flags: { token: 'test', siteId: 'test', mode: 'buildbot', testOpts: { scheme, host } },
   })
@@ -66,7 +70,10 @@ const SITE_INFO_BUILD_SETTINGS_NULL = {
 }
 
 test('Build settings can be null', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS_NULL)
+  const { scheme, host, stopServer } = await startServer({
+    path: SITE_INFO_PATH,
+    response: SITE_INFO_BUILD_SETTINGS_NULL,
+  })
   await runFixture(t, 'empty', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
@@ -85,13 +92,13 @@ const SITE_INFO_BUILD_SETTINGS = {
 }
 
 test('Use build settings if a siteId and token are provided', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_BUILD_SETTINGS })
   await runFixture(t, 'base', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings have low merging priority', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_BUILD_SETTINGS })
   await runFixture(t, 'build_settings', {
     flags: { token: 'test', siteId: 'test', baseRelDir: true, testOpts: { scheme, host } },
   })
@@ -99,25 +106,29 @@ test('Build settings have low merging priority', async (t) => {
 })
 
 test('Build settings are not used if getSite call fails', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS, { status: 400 })
+  const { scheme, host, stopServer } = await startServer({
+    path: SITE_INFO_PATH,
+    response: SITE_INFO_BUILD_SETTINGS,
+    status: 400,
+  })
   await runFixture(t, 'base', { flags: { token: 'test', siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings are not used without a token', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_BUILD_SETTINGS })
   await runFixture(t, 'base', { flags: { siteId: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings are not used without a siteId', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_BUILD_SETTINGS })
   await runFixture(t, 'base', { flags: { token: 'test', testOpts: { scheme, host } } })
   await stopServer()
 })
 
 test('Build settings are not used in CI', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BUILD_SETTINGS)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_BUILD_SETTINGS })
   await runFixture(t, 'base', {
     flags: { token: 'test', siteId: 'test', mode: 'buildbot', testOpts: { scheme, host } },
   })
@@ -130,7 +141,7 @@ const SITE_INFO_BASE_REL_DIR = {
 }
 
 test('baseRelDir is true if build.base is overridden', async (t) => {
-  const { scheme, host, stopServer } = await startServer(SITE_INFO_PATH, SITE_INFO_BASE_REL_DIR)
+  const { scheme, host, stopServer } = await startServer({ path: SITE_INFO_PATH, response: SITE_INFO_BASE_REL_DIR })
   try {
     await runFixture(t, 'build_base_override', {
       flags: {


### PR DESCRIPTION
We use a mock HTTP server in automated tests.
Note: we unfortunately cannot use `nock` or similar library because they do not work across processes (since they rely on modifying global variables), which is why we have our own test helper.

This PR improves it to allow mocking several endpoints at once in a single test. Previously, only one endpoint could be mocked at a time.