### PR TITLE
Refactor `commandsCount`

### DIFF
--- a/packages/build/src/commands/get.js
+++ b/packages/build/src/commands/get.js
@@ -6,9 +6,8 @@ const { EVENTS } = require('../plugins/events')
 const getCommands = function (pluginsCommands, netlifyConfig) {
   const commands = addBuildCommand(pluginsCommands, netlifyConfig)
   const commandsA = sortCommands(commands)
-  const commandsCount = commandsA.filter(({ event }) => !runsOnlyOnBuildFailure(event)).length
   const events = getEvents(commandsA)
-  return { commands: commandsA, commandsCount, events }
+  return { commands: commandsA, events }
 }
 
 // Merge `build.command` with plugin event handlers

--- a/packages/build/src/core/dry.js
+++ b/packages/build/src/core/dry.js
@@ -4,9 +4,10 @@ const { runsOnlyOnBuildFailure } = require('../commands/get')
 const { logDryRunStart, logDryRunCommand, logDryRunEnd } = require('../log/messages/dry')
 
 // If the `dry` flag is specified, do a dry run
-const doDryRun = function ({ commands, commandsCount, logs }) {
+const doDryRun = function ({ commands, logs }) {
   const successCommands = commands.filter(({ event }) => !runsOnlyOnBuildFailure(event))
   const eventWidth = Math.max(...successCommands.map(getEventLength))
+  const commandsCount = successCommands.length
 
   logDryRunStart({ logs, eventWidth, commandsCount })
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -396,14 +396,14 @@ const runBuild = async function ({
     debug,
   })
 
-  const { commands, commandsCount, events } = getCommands(pluginsCommands, netlifyConfig)
+  const { commands, events } = getCommands(pluginsCommands, netlifyConfig)
 
   if (dry) {
-    doDryRun({ commands, commandsCount, logs })
+    doDryRun({ commands, logs })
     return {}
   }
 
-  const { commandsCount: commandsCountA, statuses, timers: timersB } = await runCommands({
+  const { commandsCount, statuses, timers: timersB } = await runCommands({
     commands,
     events,
     configPath,
@@ -421,7 +421,7 @@ const runBuild = async function ({
     timers: timersA,
     testOpts,
   })
-  return { commandsCount: commandsCountA, statuses, timers: timersB }
+  return { commandsCount, statuses, timers: timersB }
 }
 
 // Logs and reports that a build successfully ended


### PR DESCRIPTION
We need to count the number of "commands" (build command or plugin) run for two reasons:
  - To print some arrow symbol in dry runs
  - To send to telemetry

Those two use cases are slightly different, because dry runs to not take into account that some commands might not end up being run during build (for example if they errored).

This PR refactors the logic to make the distinction between those use cases clearer, by moving code. It does not modify behavior.