### PR TITLE
Do not spawn some core plugins in child processes

### DIFF
--- a/packages/build/src/commands/error.js
+++ b/packages/build/src/commands/error.js
@@ -101,7 +101,7 @@ const getPluginErrorType = function (error, loadedFrom) {
 
 const isCorePluginBug = function (error, loadedFrom) {
   const { severity } = parseErrorInfo(error)
-  return severity === 'warning' && loadedFrom === 'core'
+  return (severity === 'warning' || severity === 'error') && loadedFrom === 'core'
 }
 
 module.exports = { handleCommandError, getPluginErrorType }

--- a/packages/build/src/commands/run_command.js
+++ b/packages/build/src/commands/run_command.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 'use strict'
 
 const { logCommand } = require('../log/messages/commands')
@@ -13,10 +14,12 @@ const { getCommandReturn } = require('./return')
 const runCommand = async function ({
   event,
   childProcess,
+  context,
   packageName,
   pluginPackageJson,
   loadedFrom,
   origin,
+  sameProcess,
   buildCommand,
   buildCommandOrigin,
   configPath,
@@ -52,10 +55,12 @@ const runCommand = async function ({
   const { newEnvChanges, newError, newStatus, timers: timersA, durationNs } = await fireCommand({
     event,
     childProcess,
+    context,
     packageName,
     pluginPackageJson,
     loadedFrom,
     origin,
+    sameProcess,
     buildCommand,
     buildCommandOrigin,
     configPath,
@@ -141,10 +146,12 @@ const getFireCommand = function ({ packageName, event }) {
 const tFireCommand = function ({
   event,
   childProcess,
+  context,
   packageName,
   pluginPackageJson,
   loadedFrom,
   origin,
+  sameProcess,
   buildCommand,
   buildCommandOrigin,
   configPath,
@@ -174,10 +181,13 @@ const tFireCommand = function ({
   return firePluginCommand({
     event,
     childProcess,
+    context,
     packageName,
     pluginPackageJson,
     loadedFrom,
     origin,
+    sameProcess,
+    buildDir,
     envChanges,
     constants,
     commands,
@@ -188,3 +198,4 @@ const tFireCommand = function ({
 }
 
 module.exports = { runCommand }
+/* eslint-enable max-lines */

--- a/packages/build/src/commands/run_commands.js
+++ b/packages/build/src/commands/run_commands.js
@@ -34,7 +34,18 @@ const runCommands = async function ({
     commands,
     async (
       { index, error, failedPlugins, envChanges, statuses, timers: timersA },
-      { event, childProcess, packageName, pluginPackageJson, loadedFrom, origin, buildCommand, buildCommandOrigin },
+      {
+        event,
+        childProcess,
+        context,
+        packageName,
+        pluginPackageJson,
+        loadedFrom,
+        origin,
+        sameProcess,
+        buildCommand,
+        buildCommandOrigin,
+      },
     ) => {
       const {
         newIndex = index,
@@ -46,10 +57,12 @@ const runCommands = async function ({
       } = await runCommand({
         event,
         childProcess,
+        context,
         packageName,
         pluginPackageJson,
         loadedFrom,
         origin,
+        sameProcess,
         buildCommand,
         buildCommandOrigin,
         configPath,

--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -36,14 +36,14 @@ const logFailPluginWarning = function (methodName, event) {
 }
 
 // Print the list of Netlify Functions about to be bundled
-const logFunctionsToBundle = function (functions, FUNCTIONS_SRC) {
+const logFunctionsToBundle = function ({ functions, FUNCTIONS_SRC, logs }) {
   if (functions.length === 0) {
-    log(undefined, `No Functions were found in ${THEME.highlightWords(FUNCTIONS_SRC)} directory`)
+    log(logs, `No Functions were found in ${THEME.highlightWords(FUNCTIONS_SRC)} directory`)
     return
   }
 
-  log(undefined, `Packaging Functions from ${THEME.highlightWords(FUNCTIONS_SRC)} directory:`)
-  logArray(undefined, functions, { indent: false })
+  log(logs, `Packaging Functions from ${THEME.highlightWords(FUNCTIONS_SRC)} directory:`)
+  logArray(logs, functions, { indent: false })
 }
 
 const logDeploySuccess = function () {

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -6,12 +6,12 @@ const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
 const run = async function (
-  { event, events, error, envChanges, constants, loadedFrom },
+  { event, events, error, envChanges, constants, loadedFrom, logs },
   { pluginCommands, inputs, netlifyConfig, packageJson },
 ) {
   const { method } = pluginCommands.find((pluginCommand) => pluginCommand.event === event)
   const runState = {}
-  const utils = getUtils({ event, constants, runState })
+  const utils = getUtils({ event, constants, runState, logs })
   const runOptions = { utils, constants, inputs, netlifyConfig, packageJson, error, events }
   const runOptionsA = cleanRunOptions({ loadedFrom, runOptions })
 

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -7,9 +7,9 @@ const { addLazyProp } = require('./lazy')
 const { show } = require('./status')
 
 // Retrieve the `utils` argument.
-const getUtils = function ({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runState }) {
+const getUtils = function ({ event, constants: { FUNCTIONS_SRC, CACHE_DIR }, runState, logs }) {
   const build = getBuildUtils(event)
-  const utils = { build }
+  const utils = { build, ...(logs === undefined ? {} : { logs }) }
   addLazyProp(utils, 'git', getGitUtils)
   addLazyProp(utils, 'cache', getCacheUtils.bind(null, CACHE_DIR))
   addLazyProp(utils, 'run', getRunUtils)

--- a/packages/build/src/plugins/options.js
+++ b/packages/build/src/plugins/options.js
@@ -66,8 +66,15 @@ const isUserPlugin = function (plugin) {
   return !isCorePlugin(plugin.package)
 }
 
-const normalizePluginOptions = function ({ package: packageName, pluginPath, loadedFrom, origin, inputs }) {
-  return { packageName, pluginPath, loadedFrom, origin, inputs }
+const normalizePluginOptions = function ({
+  package: packageName,
+  pluginPath,
+  loadedFrom,
+  origin,
+  inputs,
+  sameProcess,
+}) {
+  return { packageName, pluginPath, loadedFrom, origin, inputs, sameProcess }
 }
 
 // Retrieve plugin's main file path.

--- a/packages/build/src/plugins_core/functions/error.js
+++ b/packages/build/src/plugins_core/functions/error.js
@@ -3,8 +3,8 @@
 const readdirp = require('readdirp')
 
 // Handle errors coming from zip-it-and-ship-it
-const getZipError = async function (error, FUNCTIONS_SRC) {
-  if (await isModuleNotFound(error, FUNCTIONS_SRC)) {
+const getZipError = async function (error, functionsSrc) {
+  if (await isModuleNotFound(error, functionsSrc)) {
     return getModuleNotFoundError(error)
   }
 
@@ -13,29 +13,29 @@ const getZipError = async function (error, FUNCTIONS_SRC) {
 
 // A common mistake is to assume Netlify Functions dependencies are
 // automatically installed. This checks for this pattern.
-const isModuleNotFound = function (error, FUNCTIONS_SRC) {
+const isModuleNotFound = function (error, functionsSrc) {
   return (
     error instanceof Error &&
     error.code === MODULE_NOT_FOUND_CODE &&
     getModuleName(error) !== undefined &&
-    lacksNodeModules(FUNCTIONS_SRC)
+    lacksNodeModules(functionsSrc)
   )
 }
 
 const MODULE_NOT_FOUND_CODE = 'MODULE_NOT_FOUND'
 
 // Netlify Functions has a `package.json` but no `node_modules`
-const lacksNodeModules = async function (FUNCTIONS_SRC) {
+const lacksNodeModules = async function (functionsSrc) {
   return (
-    (await hasFunctionRootFile('package.json', FUNCTIONS_SRC)) &&
-    !(await hasFunctionRootFile('node_modules', FUNCTIONS_SRC))
+    (await hasFunctionRootFile('package.json', functionsSrc)) &&
+    !(await hasFunctionRootFile('node_modules', functionsSrc))
   )
 }
 
 // Functions can be either files or directories, so we need to check on two
 // depth levels
-const hasFunctionRootFile = async function (filename, FUNCTIONS_SRC) {
-  const files = await readdirp.promise(FUNCTIONS_SRC, { depth: 1, fileFilter: filename })
+const hasFunctionRootFile = async function (filename, functionsSrc) {
+  const files = await readdirp.promise(functionsSrc, { depth: 1, fileFilter: filename })
   return files.length !== 0
 }
 

--- a/packages/build/src/plugins_core/main.js
+++ b/packages/build/src/plugins_core/main.js
@@ -48,7 +48,7 @@ const getFunctionsPlugin = function (FUNCTIONS_SRC) {
     return
   }
 
-  return { package: FUNCTIONS_PLUGIN_NAME, pluginPath: FUNCTIONS_PLUGIN }
+  return { package: FUNCTIONS_PLUGIN_NAME, pluginPath: FUNCTIONS_PLUGIN, sameProcess: true }
 }
 
 const getFunctionsInstallPlugin = function (FUNCTIONS_SRC) {


### PR DESCRIPTION
Fixes #2056.

This allows some core plugins to not be spawned as child process by declaring themselves with `sameProcess: true`.

Ths adds `sameProcess: true` to the Functions core plugin.