### PR TITLE
Improve renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,11 @@
   automerge: false,
   packageRules: [
     {
+      packagePatterns: ['^@netlify', '^netlify'],
+      groupName: 'netlify packages',
+      schedule: null,
+    },
+    {
       // Those cannot be upgraded to a major version until we drop support for Node 8
       packageNames: [
         'ava',


### PR DESCRIPTION
This improves the Renovate config so new Netlify packages are creating PRs right away.