### PR TITLE
fix(config): return empty object on undefined site id

### DIFF
--- a/packages/config/src/api/site_info.js
+++ b/packages/config/src/api/site_info.js
@@ -6,7 +6,10 @@
 // information instead.
 // Requires knowing the `siteId` and having the access `token`.
 const getSiteInfo = async function (api, siteId, mode) {
-  if (api === undefined || siteId === undefined || mode === 'buildbot') {
+  if (siteId === undefined) {
+    return {}
+  }
+  if (api === undefined || mode === 'buildbot') {
     return { id: siteId }
   }
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

Noticed this while doing some refactoring on the CLI (PR coming soon). When the passed `siteId` argument is `undefined` the return value is `{ id: undefined }` which makes it harder to check using `isEmpty` utility methods.

> We can also keep the current behavior if this was intended (to distinguish between an error and `undefined` argument).

**Describe the solution you've chosen**

This PR fixes the behavior to match the result when an error occurs.

**Describe alternatives you've considered**

Keep the code as is and check `siteInfo.id === undefined || isEmpty(siteInfo)`

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
