### PR TITLE
Rename `addLatestDependencies()`

### DIFF
--- a/packages/build/src/install/main.js
+++ b/packages/build/src/install/main.js
@@ -13,7 +13,7 @@ const installDependencies = function ({ packageRoot, isLocal }) {
 }
 
 // Add new Node.js dependencies
-const addLatestDependencies = function ({ packageRoot, isLocal, packages }) {
+const addDependencies = function ({ packageRoot, isLocal, packages }) {
   return runCommand({ packageRoot, packages, isLocal, type: 'add' })
 }
 
@@ -38,7 +38,7 @@ const getCommand = async function ({ packageRoot, type, isLocal }) {
 }
 
 const getManager = async function (type, packageRoot) {
-  // `addLatestDependencies()` is only supported with npm at the moment
+  // `addDependencies()` always uses npm
   if (type === 'add') {
     return 'npm'
   }
@@ -82,4 +82,4 @@ const isNotNpmLogMessage = function (line) {
 }
 const NPM_LOG_MESSAGES = ['complete log of this run', '-debug.log']
 
-module.exports = { installDependencies, addLatestDependencies }
+module.exports = { installDependencies, addDependencies }

--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -8,7 +8,7 @@ const pathExists = require('path-exists')
 
 const { logInstallMissingPlugins, logMissingPluginsWarning } = require('../log/messages/install')
 
-const { addLatestDependencies } = require('./main')
+const { addDependencies } = require('./main')
 
 const pWriteFile = promisify(writeFile)
 
@@ -36,7 +36,7 @@ const installMissingPlugins = async function ({ pluginsOptions, autoPluginsDir, 
   logInstallMissingPlugins(logs, packages)
 
   await createAutoPluginsDir(autoPluginsDir)
-  await addLatestDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
+  await addDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
 }
 
 const getMissingPlugins = function (pluginsOptions) {


### PR DESCRIPTION
This renames an internal variable due to its semantics changing.
Soon, this function will allow adding dependencies with any package version, not only latest.