### PR TITLE
Add `tryResolvePath()`

### DIFF
--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -4,7 +4,7 @@ const pathExists = require('path-exists')
 
 const { addErrorInfo } = require('../error/info')
 const { installMissingPlugins, warnOnMissingPlugins } = require('../install/missing')
-const { resolvePath } = require('../utils/resolve')
+const { resolvePath, tryResolvePath } = require('../utils/resolve')
 
 const { getPluginsList } = require('./list.js')
 
@@ -68,13 +68,14 @@ const resolvePluginPath = async function ({
 
   // Local plugins
   if (packageNameA.startsWith('.')) {
-    const localPath = await tryLocalPath(packageNameA, buildDir)
+    const { path: localPath, error } = await tryResolvePath(packageNameA, buildDir)
+    validateLocalPluginPath(error, packageNameA)
     return { ...pluginOptions, pluginPath: localPath, loadedFrom: 'local' }
   }
 
   // Plugin already installed in the project, most likely either local plugins,
   // or external plugins added to `package.json`
-  const manualPath = await tryResolvePath(packageNameA, buildDir)
+  const { path: manualPath } = await tryResolvePath(packageNameA, buildDir)
   if (manualPath !== undefined) {
     return { ...pluginOptions, pluginPath: manualPath, loadedFrom: 'package.json' }
   }
@@ -100,12 +101,10 @@ const resolvePackagePath = function (packageName) {
   return packageName
 }
 
-// Try to `resolve()` a local plugin
-const tryLocalPath = async function (packageName, baseDir) {
-  try {
-    return await resolvePath(packageName, baseDir)
-  } catch (error) {
-    error.message = `Plugin could not be found using local path: ${packageName}\n${error.message}`
+// When requiring a local plugin with an invalid file path
+const validateLocalPluginPath = function (error, localPackageName) {
+  if (error !== undefined) {
+    error.message = `Plugin could not be found using local path: ${localPackageName}\n${error.message}`
     addErrorInfo(error, { type: 'resolveConfig' })
     throw error
   }
@@ -124,13 +123,6 @@ const tryBuildImagePath = async function ({ packageName, buildDir, buildImagePlu
   }
 
   return resolvePath(buildImagePath, buildDir)
-}
-
-// Try to `resolve()` the plugin from the build directory
-const tryResolvePath = async function (packageName, baseDir) {
-  try {
-    return await resolvePath(packageName, baseDir)
-  } catch (error) {}
 }
 
 // Handle plugins that were neither local, in the build image cache nor in

--- a/packages/build/src/utils/resolve.js
+++ b/packages/build/src/utils/resolve.js
@@ -5,6 +5,16 @@ const { version: nodeVersion } = require('process')
 const resolveLib = require('resolve')
 const { gte: gteVersion } = require('semver')
 
+// Like `resolvePath()` but does not throw
+const tryResolvePath = async function (path, basedir) {
+  try {
+    const resolvedPath = await resolvePath(path, basedir)
+    return { path: resolvedPath }
+  } catch (error) {
+    return { error }
+  }
+}
+
 // This throws if the package cannot be found
 // We try not to use `resolve` because it gives unhelpful error messages.
 //   https://github.com/browserify/resolve/issues/223
@@ -38,4 +48,4 @@ const resolvePathFallback = function (path, basedir) {
   })
 }
 
-module.exports = { resolvePath }
+module.exports = { tryResolvePath, resolvePath }


### PR DESCRIPTION
This refactors how `require.resolve()` is called. This does not change behavior.