### PR TITLE
Small refactoring of `loadedFrom` attribute

### DIFF
--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -87,8 +87,10 @@ const resolvePluginPath = async function ({
     return { ...pluginOptions, pluginPath: buildImagePath, loadedFrom: 'image_cache' }
   }
 
-  // Otherwise, it must be automatically installed, as a fallback
-  return pluginOptions
+  // Happens if the plugin:
+  //  - name is mispelled
+  //  - is not in our official list
+  return { ...pluginOptions, loadedFrom: 'auto_install' }
 }
 
 // `packageName` starting with `/` are relative to the build directory
@@ -155,7 +157,7 @@ const resolveMissingPluginPath = async function ({
   }
 
   const automaticPath = await resolvePath(packageName, autoPluginsDir)
-  return { ...pluginOptions, pluginPath: automaticPath, loadedFrom: 'auto_install' }
+  return { ...pluginOptions, pluginPath: automaticPath }
 }
 
 module.exports = { resolvePluginsPath }


### PR DESCRIPTION
This is a small refactoring of the `loadedFrom` attribute related to plugins build caching. This does not change behavior.