### PR TITLE
Fix `resolve` bug

### DIFF
--- a/packages/build/src/utils/resolve.js
+++ b/packages/build/src/utils/resolve.js
@@ -2,7 +2,6 @@
 
 const { version: nodeVersion } = require('process')
 
-const pathExists = require('path-exists')
 const resolveLib = require('resolve')
 const { gte: gteVersion } = require('semver')
 
@@ -17,32 +16,29 @@ const tryResolvePath = async function (path, basedir) {
 }
 
 // This throws if the package cannot be found
-// We try not to use `resolve` because it gives unhelpful error messages.
-//   https://github.com/browserify/resolve/issues/223
-// Ideally we would use async I/O but that is not an option with
-// `require.resolve()`
 const resolvePath = async function (path, basedir) {
-  if (gteVersion(nodeVersion, REQUEST_RESOLVE_MIN_VERSION)) {
-    const filePath = require.resolve(path, { paths: [basedir] })
-
-    // There are some bugs in `require.resolve()` which make it return
-    // non-existing files. Those bugs do not exist in `resolve`.
-    if (await pathExists(filePath)) {
-      return filePath
+  try {
+    return await resolvePathWithBasedir(path, basedir)
+    // Fallback.
+    // `resolve` sometimes gives unhelpful error messages.
+    // https://github.com/browserify/resolve/issues/223
+  } catch (error) {
+    if (gteVersion(nodeVersion, REQUEST_RESOLVE_MIN_VERSION)) {
+      return require.resolve(path, { paths: [basedir] })
     }
-  }
 
-  return resolvePathFallback(path, basedir)
+    throw error
+  }
 }
 
 // `require.resolve()` option `paths` was introduced in Node 8.9.0
 const REQUEST_RESOLVE_MIN_VERSION = '8.9.0'
 
-// Like `require.resolve()` but works with Node <8.9.0
+// Like `require.resolve()` but as an external library.
 // We need to use `new Promise()` due to a bug with `utils.promisify()` on
 // `resolve`:
 //   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
-const resolvePathFallback = function (path, basedir) {
+const resolvePathWithBasedir = function (path, basedir) {
   return new Promise((resolve, reject) => {
     resolveLib(path, { basedir }, (error, resolvedPath) => {
       if (error) {


### PR DESCRIPTION
Follow-up on #2101.

`require.resolve()` is showing other instances of odd behavior. This time, it throws instead of returning an invalid file path.
This PR switches to using the `resolve()` external package first, and `require.resolve()` as a fallback instead. `require.resolve()` is hard to debug (since its code is inside the `node` binary) and seems to have a couple of issues.