### PR TITLE
fix(windows): show windows path separator in netlify dir warning message

### DIFF
--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { relative, normalize } = require('path')
+const { relative, normalize, join } = require('path')
 
 const { getCacheDir } = require('@netlify/cache-utils')
 const mapObj = require('map-obj')
@@ -92,7 +92,7 @@ const validateNetlifyDir = async function (logs, buildDir) {
 }
 
 const NETLIFY_DIR = 'netlify'
-const DEFAULT_FUNCTIONS_SRC = `${NETLIFY_DIR}/functions`
+const DEFAULT_FUNCTIONS_SRC = join(NETLIFY_DIR, 'functions')
 
 // The current directory is `buildDir`. Most constants are inside this `buildDir`.
 // Instead of passing absolute paths, we pass paths relative to `buildDir`, so


### PR DESCRIPTION
A small follow up on https://github.com/netlify/build/pull/2175 to show `\` instead of `/` when printing the log message on Windows.