### PR TITLE
Add `prepublish` npm scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,39 +54,36 @@ After submitting the pull request, please make sure the Continuous Integration c
 
 To release a specific package:
 
-1. Merge the relevant package release PR
-2. Switch to the default branch `git checkout master`
-3. Pull latest changes `git pull`
-4. Inside the root run `npm install`
-5. Inside the root directory run `npm test` - do not release if linting or tests are failing. This might indicate a bug
-6. Navigate to the specific package directory via `cd packages/packageName`
-7. Run `npm publish`
+1. Merge the relevant package release PR created by `release-please`
+2. Run `npm publish packages/packageName`
 
-If a package is released, the other packages that depend on it should increment their version of that package inside
-their own `package.json`, and a new release of them should be made. This means releasing one package usually ends up
-releasing all upstream packages in order.
+Linting and tests will automatically run before publish.
+
+Packages dependencies graph:
 
 ```
 @netlify/zip-it-and-ship-it -> js-client
                             -> @netlify/function-utils
                             -> @netlify/build
-                            -> @netlify/cli
+                            -> netlify-cli
 js-client                   -> @netlify/config
-                            -> @netlify/cli
+                            -> netlify-cli
 any @netlify/*-utils        -> @netlify/build
 @netlify/config             -> @netlify/build
-                            -> @netlify/cli
+                            -> netlify-cli
                             -> buildbot
-@netlify/build              -> @netlify/cli
+@netlify/build              -> netlify-cli
                             -> buildbot
 build-image                 -> buildbot
 netlify/plugins             -> buildbot
+@netlify/framework-info     -> buildbot
+                            -> netlify-cli
 ```
 
-To upgrade Netlify Build in the buildbot, a PR must be created that increments the version of `@netlify/build` and
-`@netlify/cli`. An example can be found [here](https://github.com/netlify/buildbot/pull/852). Once the Jenkins build has
-passed and finished building, the PR can be tested in production by updating the `Site.build_image` property of any test
-Site. This can be done with the following Netlify CLI commands:
+When `@netlify/build` or `@netlify/config` is published to npm, Renovate will automatically create a release PR in the
+buildbot after a short while. Once the Jenkins build has passed and finished building, the PR can be tested in
+production by updating the `Site.build_image` property of any test Site. This can be done with the following Netlify CLI
+commands:
 
 ```bash
 netlify api updateSite --data='{ "site_id": "{{siteId}}", "body": { "build_image": "{{buildImage}}" }}'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "test:dev": "run-s test:dev:*",
     "test:ci": "run-s test:ci:*",
     "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava"
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
+    "prepublishOnly": "run-s prepublishOnly:*",
+    "prepublishOnly:checkout": "git checkout master",
+    "prepublishOnly:pull": "git pull",
+    "prepublishOnly:install": "npm install",
+    "prepublishOnly:test": "npm test"
   },
   "scriptsArgs": {
     "eslint": "--ignore-path .gitignore --cache --format=codeframe --max-warnings=0 \"{packages,.github}/**/*.{js,md,html}\" \"*.{js,md,html}\" \".*.{js,md,html}\"",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -17,9 +17,7 @@
     "Swyx <swyx@netlify.com> (https://www.swyx.io)"
   ],
   "scripts": {
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "prepublishOnly": "cd ../../ && npm run prepublishOnly"
   },
   "keywords": [
     "nodejs",

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -9,9 +9,7 @@
   ],
   "author": "Netlify Inc.",
   "scripts": {
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "prepublishOnly": "cd ../../ && npm run prepublishOnly"
   },
   "keywords": [
     "nodejs",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -15,9 +15,7 @@
     "David Wells <hello@davidwells.io> (https://davidwells.io/)"
   ],
   "scripts": {
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "prepublishOnly": "cd ../../ && npm run prepublishOnly"
   },
   "keywords": [
     "nodejs",

--- a/packages/functions-utils/package.json
+++ b/packages/functions-utils/package.json
@@ -9,9 +9,7 @@
   ],
   "author": "Netlify Inc.",
   "scripts": {
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "prepublishOnly": "cd ../../ && npm run prepublishOnly"
   },
   "keywords": [
     "nodejs",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -10,9 +10,7 @@
   ],
   "author": "Netlify Inc.",
   "scripts": {
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "prepublishOnly": "cd ../../ && npm run prepublishOnly"
   },
   "keywords": [
     "nodejs",

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -9,9 +9,7 @@
   ],
   "author": "Netlify Inc.",
   "scripts": {
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "prepublishOnly": "cd ../../ && npm run prepublishOnly"
   },
   "keywords": [
     "nodejs",


### PR DESCRIPTION
This adds a `prepublish` npm script to automate the release process even further.
I have tried it locally both on Unix and Windows.