### PR TITLE
chore(docs): capitalize all instances of noun Renovate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ netlify/plugins             -> buildbot
                             -> netlify-cli
 ```
 
-Note that renovate should take care of opening PRs to update the relevant packages that depend upon the modules you just published. However, to make good use of your time, make sure to follow the dependency graph above. I.e. `@netlify/config` is a dependency of `@netlify/build`, so if you've just updated the former you should first start by updating `@netlify/build` and let renovate bundle those two changes together when updating buildbot.
+Note that Renovate should take care of opening PRs to update the relevant packages that depend upon the modules you just published. However, to make good use of your time, make sure to follow the dependency graph above. I.e. `@netlify/config` is a dependency of `@netlify/build`, so if you've just updated the former you should first start by updating `@netlify/build` and let Renovate bundle those two changes together when updating buildbot.
 
 ### Buildbot
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

Fix inconsistencies in capitalization of noun Renovate.

**List other issues or pull requests related to this problem**

There are no other issues that I'm fixing with this.

**Describe the solution you've chosen**

Fix typo.

**Describe alternatives you've considered**

Not applicable.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
