### PR TITLE
fix: improve Bugsnag reporting of upload errors

### DIFF
--- a/packages/build/src/error/monitor/normalize.js
+++ b/packages/build/src/error/monitor/normalize.js
@@ -61,6 +61,9 @@ const NORMALIZE_REGEXPS = [
   // were not installed
   [/(Cannot find module) '([^']+)'/g, "$1 'moduleName'"],
   [/(A Netlify Function is using) "[^"]+"/g, '$1 "moduleName"'],
+  // Deploy upload errors include the filename
+  [/(Upload cancelled).*/g, '$1'],
+  [/(aborting upload of file).*/g, '$1'],
   // netlify-plugin-inline-critical-css errors prints a list of file paths
   [/Searched in: .*/g, ''],
   // netlify-plugin-subfont prints font name in errors


### PR DESCRIPTION
Bugsnag [is currently reporting](https://app.bugsnag.com/netlify/netlify-build/errors?filters[event.since][0][type]=eq&filters[event.since][0][value]=all&filters[app.release_stage][0][type]=ne&filters[app.release_stage][0][value]=require&filters[event.severity][0][type]=eq&filters[event.severity][0][value]=error&filters[event.severity][1][type]=eq&filters[event.severity][1][value]=warning&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[metaData.location.loadedFrom][0][type]=ne&filters[metaData.location.loadedFrom][0][value]=local&filters[error.has_issue][0][type]=eq&filters[error.has_issue][0][value]=false&filters[search][0][type]=eq&filters[search][0][value]=upload&sort=last_seen) every new instance of deploy upload errors separately. This PR groups them instead.