### PR TITLE
fix: fix `files` in `package.json` with `npm@7`

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -7,9 +7,8 @@
     "netlify-build": "./src/core/bin.js"
   },
   "files": [
-    "src",
-    "!*.test.*",
-    "!*~"
+    "src/**/*.js",
+    "src/**/*.yml"
   ],
   "author": "Netlify Inc.",
   "contributors": [

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -4,8 +4,7 @@
   "description": "Utility for caching files in Netlify Build",
   "main": "src/main.js",
   "files": [
-    "src",
-    "!*~"
+    "src/**/*.js"
   ],
   "author": "Netlify Inc.",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,8 +7,7 @@
     "netlify-config": "src/bin/main.js"
   },
   "files": [
-    "src",
-    "!*~"
+    "src/**/*.js"
   ],
   "author": "Netlify Inc.",
   "contributors": [

--- a/packages/functions-utils/package.json
+++ b/packages/functions-utils/package.json
@@ -4,8 +4,7 @@
   "description": "Utility for adding Functions files in Netlify Build",
   "main": "src/main.js",
   "files": [
-    "src",
-    "!*~"
+    "src/**/*.js"
   ],
   "author": "Netlify Inc.",
   "scripts": {

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -4,9 +4,7 @@
   "description": "Utility for dealing with modified, created, deleted files since a git commit",
   "main": "src/main.js",
   "files": [
-    "src",
-    "!*.test.*",
-    "!*~"
+    "src/**/*.js"
   ],
   "author": "Netlify Inc.",
   "scripts": {

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -4,8 +4,7 @@
   "description": "Utility for running commands inside Netlify Build",
   "main": "src/main.js",
   "files": [
-    "src",
-    "!*~"
+    "src/**/*.js"
   ],
   "author": "Netlify Inc.",
   "scripts": {


### PR DESCRIPTION
npm 7 changed the way globbing patterns are interpreted in `files` in `package.json`. This is undocumented, so I'm not sure whether this is a bug or not. This results in all `*~` files (Vim temporary files) to be published to npm, which can double the package size. 

This PR fixes this. I ran `npm pack --dry` before and after to ensure no files were being omitted.