### PR TITLE
chore: refactor missing plugins logic

### DIFF
--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -20,24 +20,12 @@ const pUnlink = promisify(unlink)
 // options. We do not allow configure the package manager nor its options.
 // Users requiring `yarn` or custom npm/yarn flags should install the plugin in
 // their `package.json`.
-const installMissingPlugins = async function ({ pluginsOptions, autoPluginsDir, mode, logs }) {
-  const packages = getMissingPlugins(pluginsOptions)
-  if (packages.length === 0) {
-    return
-  }
-
+const installMissingPlugins = async function ({ missingPlugins, autoPluginsDir, mode, logs }) {
+  const packages = missingPlugins.map(getPackage)
   logInstallMissingPlugins(logs, packages)
 
   await createAutoPluginsDir(logs, autoPluginsDir)
   await addExactDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
-}
-
-const getMissingPlugins = function (pluginsOptions) {
-  return pluginsOptions.filter(isMissingPlugin).map(getPackage)
-}
-
-const isMissingPlugin = function ({ expectedVersion }) {
-  return expectedVersion !== undefined
 }
 
 // We pin the version without using semver ranges ^ nor ~

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -101,24 +101,30 @@ const validateLocalPluginPath = function (error, localPackageName) {
 // Install plugins from the official list that have not been previously installed.
 // Print a warning if they have not been installed through the UI.
 const handleMissingPlugins = async function ({ pluginsOptions, autoPluginsDir, mode, logs }) {
-  await installMissingPlugins({ pluginsOptions, autoPluginsDir, mode, logs })
+  const missingPlugins = pluginsOptions.filter(isMissingPlugin)
+
+  if (missingPlugins.length === 0) {
+    return pluginsOptions
+  }
+
+  await installMissingPlugins({ missingPlugins, autoPluginsDir, mode, logs })
   return await Promise.all(
     pluginsOptions.map((pluginOptions) => resolveMissingPluginPath({ pluginOptions, autoPluginsDir })),
   )
 }
 
 // Resolve the plugins that just got automatically installed
-const resolveMissingPluginPath = async function ({
-  pluginOptions,
-  pluginOptions: { packageName, expectedVersion },
-  autoPluginsDir,
-}) {
-  if (expectedVersion === undefined) {
+const resolveMissingPluginPath = async function ({ pluginOptions, pluginOptions: { packageName }, autoPluginsDir }) {
+  if (!isMissingPlugin(pluginOptions)) {
     return pluginOptions
   }
 
-  const automaticPath = await resolvePath(packageName, autoPluginsDir)
-  return { ...pluginOptions, pluginPath: automaticPath }
+  const pluginPath = await resolvePath(packageName, autoPluginsDir)
+  return { ...pluginOptions, pluginPath }
+}
+
+const isMissingPlugin = function ({ expectedVersion }) {
+  return expectedVersion !== undefined
 }
 
 module.exports = { resolvePluginsPath }


### PR DESCRIPTION
Part of https://github.com/netlify/next-on-netlify-enterprise/issues/16

This refactors some code related to how we install UI plugins when they are "missing" (i.e. either not cached yet, or cached with a version that does not match the latest in `plugins.json`). This does not change the logic, only moves code around. This refactoring should help with some upcoming related PRs.