### PR TITLE
chore: fix typo in test

### DIFF
--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -548,7 +548,7 @@ const getPluginsList = function () {
 }
 
 const getPlugin = function (plugin) {
-  if (plugin.packageName !== TEST_PLUGIN_NAME) {
+  if (plugin.package !== TEST_PLUGIN_NAME) {
     return plugin
   }
 


### PR DESCRIPTION
This fixes a typo in a test.
The field in `plugins.json` is named `package` not `packageName`.