### PR TITLE
feat: allow `version` in `plugins.json` to be an object

### DIFF
--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -27,7 +27,7 @@ const logPluginsList = function ({ pluginsList, debug, logs }) {
   logArray(logs, pluginsListArray)
 }
 
-const getPluginsListItem = function ([packageName, version]) {
+const getPluginsListItem = function ([packageName, [{ version }]]) {
   return `${packageName}@${version}`
 }
 

--- a/packages/build/src/plugins/expected_version.js
+++ b/packages/build/src/plugins/expected_version.js
@@ -30,12 +30,14 @@ const addExpectedVersion = async function ({
     return pluginOptions
   }
 
-  const expectedVersion = pluginsList[packageName]
+  const versions = pluginsList[packageName]
 
-  if (expectedVersion === undefined) {
+  if (versions === undefined) {
     validateUnlistedPlugin(packageName, loadedFrom)
     return pluginOptions
   }
+
+  const expectedVersion = getExpectedVersion(versions)
 
   // Plugin was not previously installed
   if (pluginPath === undefined) {
@@ -72,6 +74,11 @@ Please run "npm install -D ${packageName}" or "yarn add -D ${packageName}".`,
   )
   addErrorInfo(error, { type: 'resolveConfig' })
   throw error
+}
+
+// At the moment, we only allow a single `version` per plugin in `plugins.json`
+const getExpectedVersion = function ([{ version }]) {
+  return version
 }
 
 module.exports = { addExpectedVersions }

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -552,7 +552,7 @@ const getPlugin = function (plugin) {
     return plugin
   }
 
-  return { ...plugin, version: '0.3.0' }
+  return { ...plugin, version: { '0.3.0': {}, '0.2.0': {} } }
 }
 
 const TEST_PLUGIN_NAME = 'netlify-plugin-contextual-env'


### PR DESCRIPTION
Part of https://github.com/netlify/next-on-netlify-enterprise/issues/16

This allows the `version` field in `plugins.json` to an an object instead of a string. Using a string is still supported.
This enables specifying several supported versions per plugin.

More upcoming PRs will add more logic to that field, so that our system can choose between different versions of each plugin.