### PR TITLE
feat: add `plugin.compatibility` field

### DIFF
--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -27,7 +27,7 @@ const logPluginsList = function ({ pluginsList, debug, logs }) {
   logArray(logs, pluginsListArray)
 }
 
-const getPluginsListItem = function ([packageName, [{ version }]]) {
+const getPluginsListItem = function ([packageName, { version }]) {
   return `${packageName}@${version}`
 }
 

--- a/packages/build/src/plugins/compatibility.js
+++ b/packages/build/src/plugins/compatibility.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// Find a plugin's version using a set of conditions. Default to latest version.
+// `conditions` is sorted from most to least recent version.
+const getExpectedVersion = function (latestVersion, compatibility) {
+  const matchingCondition = compatibility.find((compatField) => matchesCompatField(compatField))
+
+  if (matchingCondition === undefined) {
+    return latestVersion
+  }
+
+  return matchingCondition.version
+}
+
+const matchesCompatField = function ({ conditions }) {
+  return conditions.every(({ type, condition }) => CONDITIONS[type](condition))
+}
+
+// TODO: add some condition types: `nodeVersion`, `dependencies`
+const CONDITIONS = {}
+
+module.exports = { getExpectedVersion }

--- a/packages/build/src/plugins/expected_version.js
+++ b/packages/build/src/plugins/expected_version.js
@@ -3,6 +3,7 @@
 const { addErrorInfo } = require('../error/info')
 const { resolvePath } = require('../utils/resolve')
 
+const { getExpectedVersion } = require('./compatibility')
 const { getPluginsList } = require('./list')
 
 // When using plugins in our official list, those are installed in .netlify/plugins/
@@ -30,14 +31,14 @@ const addExpectedVersion = async function ({
     return pluginOptions
   }
 
-  const versions = pluginsList[packageName]
-
-  if (versions === undefined) {
+  if (pluginsList[packageName] === undefined) {
     validateUnlistedPlugin(packageName, loadedFrom)
     return pluginOptions
   }
 
-  const expectedVersion = getExpectedVersion(versions)
+  const { version: latestVersion, compatibility } = pluginsList[packageName]
+
+  const expectedVersion = getExpectedVersion(latestVersion, compatibility)
 
   // Plugin was not previously installed
   if (pluginPath === undefined) {
@@ -74,11 +75,6 @@ Please run "npm install -D ${packageName}" or "yarn add -D ${packageName}".`,
   )
   addErrorInfo(error, { type: 'resolveConfig' })
   throw error
-}
-
-// At the moment, we only allow a single `version` per plugin in `plugins.json`
-const getExpectedVersion = function ([{ version }]) {
-  return version
 }
 
 module.exports = { addExpectedVersions }

--- a/packages/build/src/plugins/list.js
+++ b/packages/build/src/plugins/list.js
@@ -53,27 +53,27 @@ const normalizePluginsList = function (pluginsList) {
   return fromEntries(pluginsList.map(normalizePluginItem))
 }
 
-// `version` in `plugins.json` can either be:
-//  - a `string`
-//  - an object with several possible versions. Each version can have conditions
-//    to apply that version.
-// We normalize it to an array of objects, sorted from most to least recent
-const normalizePluginItem = function ({ package: packageName, version }) {
-  const versions = normalizeVersions(version)
-  return [packageName, versions]
+// `version` in `plugins.json` is the latest version.
+// A `compatibility` object can be added to specify conditions to apply
+// different versions.
+// We normalize it to an array of objects, sorted from most to least recent.
+const normalizePluginItem = function ({ package: packageName, version, compatibility = {} }) {
+  const normalizedCompatibility = normalizeCompatibility(compatibility)
+  return [packageName, { version, compatibility: normalizedCompatibility }]
 }
 
-const normalizeVersions = function (version) {
-  if (typeof version === 'string') {
-    return [{ version }]
-  }
-
+const normalizeCompatibility = function (compatibility) {
   // eslint-disable-next-line fp/no-mutating-methods
-  return Object.keys(version).map(normalizeVersion).sort(compareVersion)
+  return Object.entries(compatibility).map(normalizeCompatField).sort(compareVersion)
 }
 
-const normalizeVersion = function (version) {
-  return { version }
+const normalizeCompatField = function ([version, conditions]) {
+  const normalizedConditions = Object.entries(conditions).map(normalizeCondition)
+  return { version, conditions: normalizedConditions }
+}
+
+const normalizeCondition = function ([type, condition]) {
+  return { type, condition }
 }
 
 const compareVersion = function ({ version: versionA }, { version: versionB }) {

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -552,7 +552,7 @@ const getPlugin = function (plugin) {
     return plugin
   }
 
-  return { ...plugin, version: { '0.3.0': {}, '0.2.0': {} } }
+  return { ...plugin, version: '0.3.0', compatibility: { '0.3.0': {}, '0.2.0': {} } }
 }
 
 const TEST_PLUGIN_NAME = 'netlify-plugin-contextual-env'


### PR DESCRIPTION
This adds a `compatibility` field to plugin so they can declare several versions.

This does not add any conditions yet, only the bare field.