### PR TITLE
feat: turn `compatibility` field into an array

### DIFF
--- a/packages/build/src/plugins/list.js
+++ b/packages/build/src/plugins/list.js
@@ -54,20 +54,15 @@ const normalizePluginsList = function (pluginsList) {
 }
 
 // `version` in `plugins.json` is the latest version.
-// A `compatibility` object can be added to specify conditions to apply
-// different versions.
-// We normalize it to an array of objects, sorted from most to least recent.
-const normalizePluginItem = function ({ package: packageName, version, compatibility = {} }) {
-  const normalizedCompatibility = normalizeCompatibility(compatibility)
+// A `compatibility` array of objects can be added to specify conditions to
+// apply different versions.
+const normalizePluginItem = function ({ package: packageName, version, compatibility = [] }) {
+  // eslint-disable-next-line fp/no-mutating-methods
+  const normalizedCompatibility = compatibility.map(normalizeCompatVersion).sort(compareCompatVersion)
   return [packageName, { version, compatibility: normalizedCompatibility }]
 }
 
-const normalizeCompatibility = function (compatibility) {
-  // eslint-disable-next-line fp/no-mutating-methods
-  return Object.entries(compatibility).map(normalizeCompatField).sort(compareVersion)
-}
-
-const normalizeCompatField = function ([version, conditions]) {
+const normalizeCompatVersion = function ({ version, ...conditions }) {
   const normalizedConditions = Object.entries(conditions).map(normalizeCondition)
   return { version, conditions: normalizedConditions }
 }
@@ -76,7 +71,7 @@ const normalizeCondition = function ([type, condition]) {
   return { type, condition }
 }
 
-const compareVersion = function ({ version: versionA }, { version: versionB }) {
+const compareCompatVersion = function ({ version: versionA }, { version: versionB }) {
   return rcompare(versionA, versionB)
 }
 

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -566,7 +566,7 @@ const TEST_PLUGIN_NAME = 'netlify-plugin-contextual-env'
 const PLUGINS_LIST_URL = '/'
 const DEFAULT_TEST_PLUGIN = {
   version: '0.3.0',
-  compatibility: { '0.3.0': {}, '0.2.0': {} },
+  compatibility: [{ version: '0.3.0' }, { version: '0.2.0' }],
 }
 
 test('Install plugins in .netlify/plugins/ when not cached', async (t) => {
@@ -642,7 +642,7 @@ test.serial('Plugins can specify non-matching compatibility.nodeVersion', async 
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
       version: '0.3.0',
-      compatibility: { '0.3.0': { nodeVersion: '<6.0.0' }, '0.2.0': {} },
+      compatibility: [{ version: '0.3.0', nodeVersion: '<6.0.0' }, { version: '0.2.0' }],
     },
   })
 })
@@ -652,7 +652,7 @@ test.serial('Plugins can specify matching compatibility.nodeVersion', async (t) 
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
       version: '0.3.0',
-      compatibility: { '0.3.0': { nodeVersion: '>6.0.0' }, '0.2.0': {} },
+      compatibility: [{ version: '0.3.0', nodeVersion: '>6.0.0' }, { version: '0.2.0' }],
     },
   })
 })
@@ -662,7 +662,10 @@ test.serial('Plugins compatibility defaults to version field', async (t) => {
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
       version: '0.3.0',
-      compatibility: { '0.3.0': { nodeVersion: '<6.0.0' }, '0.2.0': { nodeVersion: '<7.0.0' } },
+      compatibility: [
+        { version: '0.3.0', nodeVersion: '<6.0.0' },
+        { version: '0.2.0', nodeVersion: '<7.0.0' },
+      ],
     },
   })
 })


### PR DESCRIPTION
Part of https://github.com/netlify/next-on-netlify-enterprise/issues/16

This makes the `compatibility` field an array of object:

```js

{
  "package": "netlify-plugin-example",
  "version": "2.0.1"
  "compatibility": [
    { "version": "1.0.5", nodeVersion: "<14" },
    { "version": "0.3.8", nodeVersion: "<12" }
  ]
}
```

instead of an object of objects:

```js
{
  "package": "netlify-plugin-example",
  "version": "2.0.1"
  "compatibility": {
    "1.0.5": { nodeVersion: "<14" },
    "0.3.8": { nodeVersion: "<12" }
  }
}
```

I believe this format might be a little cleaner, and more explicit about the priority order.