### PR TITLE
fix: stop printing output from esbuild

### DIFF
--- a/packages/build/src/log/messages/core_commands.js
+++ b/packages/build/src/log/messages/core_commands.js
@@ -2,40 +2,8 @@
 
 const path = require('path')
 
-const { log, logArray, logErrorSubHeader, pointer } = require('../logger')
+const { log, logArray, logErrorSubHeader } = require('../logger')
 const { THEME } = require('../theme')
-
-const logBundleErrorObject = ({ logs, object }) => {
-  const { location = {}, text } = object
-  const { column, file, line, lineText } = location
-  const locationMessage = `${file} ${line}:${column}`
-  const logMessage = `${pointer} ${lineText}
-  (in ${locationMessage})
-
-  ${text}
-  
-  `
-
-  log(logs, logMessage, { indent: true })
-}
-
-const logBundleResult = ({ errorMessage, logs, result }) => {
-  const { bundlerErrors = [], bundlerWarnings = [] } = result
-
-  if (bundlerErrors.length === 0 && bundlerWarnings.length === 0) {
-    return
-  }
-
-  if (errorMessage) {
-    logErrorSubHeader(logs, errorMessage)
-  }
-
-  const bundlerEvents = [...bundlerErrors, ...bundlerWarnings]
-
-  bundlerEvents.forEach((bundlerEvent) => {
-    logBundleErrorObject({ logs, object: bundlerEvent })
-  })
-}
 
 const logBundleResults = ({ logs, results = [], zisiParameters = {} }) => {
   if (!zisiParameters.jsBundler) {
@@ -50,17 +18,9 @@ const logBundleResults = ({ logs, results = [], zisiParameters = {} }) => {
     const functionName = path.basename(result.path)
 
     if (result.bundler === 'zisi') {
-      logBundleResult({
-        errorMessage: `Failed to bundle function \`${functionName}\` (fallback bundler used):`,
-        logs,
-        result,
-      })
+      logErrorSubHeader(logs, `Failed to bundle function \`${functionName}\` (fallback bundler used).`)
     } else if (result.bundler === 'esbuild') {
-      logBundleResult({
-        errorMessage: `Function \`${functionName}\` bundled with warnings:`,
-        logs,
-        result,
-      })
+      logErrorSubHeader(logs, `Function \`${functionName}\` bundled with warnings.`)
     }
   })
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

With this PR, Build delegates the responsibility of printing esbuild errors/warnings to `zip-it-and-ship-it` (depends on https://github.com/netlify/zip-it-and-ship-it/pull/357). This hugely simplifies the logic of handling the errors, which helps in situations like https://github.com/netlify/cli/issues/1838#issuecomment-790481394.

I've tried to add custom logic for truncating error messages, but unfortunately esbuild seems to have a bug where it misreports the line/column of the error. I think that using the default error/warning logging from esbuild is the best course of action for now.

**List other issues or pull requests related to this problem**

Depends on https://github.com/netlify/zip-it-and-ship-it/pull/357

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
