### PR TITLE
fix: fix `host` option in `@netlify/config`

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -110,7 +110,7 @@ const resolveFullConfig = async function ({
       context,
       branch,
       baseRelDir,
-      apiHost,
+      host: apiHost,
       token,
       siteId,
       deployId,

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -30,12 +30,12 @@ const {
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
 const resolveConfig = async function (opts) {
-  const { cachedConfig, apiHost, token, offline, ...optsA } = addDefaultOpts(opts)
+  const { cachedConfig, host, token, offline, ...optsA } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
   const api = getApiClient({
     token,
     offline,
-    host: apiHost,
+    host,
     scheme: optsA.scheme,
     pathPrefix: optsA.pathPrefix,
     testOpts: optsA.testOpts,

--- a/packages/config/src/options/main.js
+++ b/packages/config/src/options/main.js
@@ -35,7 +35,7 @@ const getDefaultOpts = function ({ env: envOpt = {}, cwd: cwdOpt, defaultConfig 
     env: envOpt,
     context: combinedEnv.CONTEXT || 'production',
     branch: combinedEnv.BRANCH,
-    apiHost: combinedEnv.NETLIFY_API_HOST,
+    host: combinedEnv.NETLIFY_API_HOST,
     token: combinedEnv.NETLIFY_AUTH_TOKEN,
     siteId: combinedEnv.NETLIFY_SITE_ID,
     deployId: combinedEnv.DEPLOY_ID,


### PR DESCRIPTION
This renames the `apiHost` option in `@netlify/config` to `host` in order to maintain backward compatibility.

The `apiHost` option in `@netlify/build` is kept as is since no `host` option existed there before. If you think this should be renamed for naming consistency, please let me know.