### PR TITLE
chore: simplify cache directory logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6542,6 +6542,7 @@
     },
     "node_modules/cachedir": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12538,6 +12539,7 @@
     },
     "node_modules/global-cache-dir": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.2.0",
@@ -21633,7 +21635,7 @@
     },
     "packages/build": {
       "name": "@netlify/build",
-      "version": "9.9.0",
+      "version": "9.9.1",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
@@ -21653,7 +21655,6 @@
         "execa": "^3.3.0",
         "figures": "^3.2.0",
         "filter-obj": "^2.0.1",
-        "global-cache-dir": "^1.0.1",
         "got": "^9.6.0",
         "indent-string": "^4.0.0",
         "is-plain-obj": "^2.1.0",
@@ -22233,7 +22234,6 @@
         "cpy": "^8.1.0",
         "del": "^5.1.0",
         "get-stream": "^5.1.0",
-        "global-cache-dir": "^1.0.1",
         "globby": "^10.0.2",
         "locate-path": "^5.0.0",
         "make-dir": "^3.1.0",
@@ -22344,7 +22344,7 @@
     },
     "packages/config": {
       "name": "@netlify/config",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@ungap/from-entries": "^0.2.1",
@@ -22791,7 +22791,7 @@
     },
     "packages/run-utils": {
       "name": "@netlify/run-utils",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "execa": "^3.4.0"
@@ -25989,7 +25989,6 @@
         "get-node": "^6.6.0",
         "get-port": "^5.1.1",
         "get-stream": "^5.2.0",
-        "global-cache-dir": "^1.0.1",
         "got": "^9.6.0",
         "has-ansi": "^4.0.0",
         "indent-string": "^4.0.0",
@@ -26350,7 +26349,6 @@
         "cpy": "^8.1.0",
         "del": "^5.1.0",
         "get-stream": "^5.1.0",
-        "global-cache-dir": "^1.0.1",
         "globby": "^10.0.2",
         "locate-path": "^5.0.0",
         "make-dir": "^3.1.0",
@@ -28247,7 +28245,8 @@
       }
     },
     "cachedir": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -32239,6 +32238,7 @@
     },
     "global-cache-dir": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "cachedir": "^2.2.0",
         "make-dir": "^3.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -68,7 +68,6 @@
     "execa": "^3.3.0",
     "figures": "^3.2.0",
     "filter-obj": "^2.0.1",
-    "global-cache-dir": "^1.0.1",
     "got": "^9.6.0",
     "indent-string": "^4.0.0",
     "is-plain-obj": "^2.1.0",

--- a/packages/build/src/core/constants.js
+++ b/packages/build/src/core/constants.js
@@ -35,7 +35,7 @@ const getConstants = async function ({
   await checkForLegacyDefaultFunctionsDir(logs, buildDir)
 
   const isLocal = mode !== 'buildbot'
-  const normalizedCacheDir = await getCacheDir({ mode, cacheDir, cwd: buildDir })
+  const normalizedCacheDir = getCacheDir({ cacheDir, cwd: buildDir })
 
   const constants = {
     /**

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -47,7 +47,6 @@
     "cpy": "^8.1.0",
     "del": "^5.1.0",
     "get-stream": "^5.1.0",
-    "global-cache-dir": "^1.0.1",
     "globby": "^10.0.2",
     "locate-path": "^5.0.0",
     "make-dir": "^3.1.0",

--- a/packages/cache-utils/src/dir.js
+++ b/packages/cache-utils/src/dir.js
@@ -1,30 +1,12 @@
 'use strict'
 
 const { resolve } = require('path')
-const { platform } = require('process')
-
-const globalCacheDir = require('global-cache-dir')
 
 // Retrieve the cache directory location
-const getCacheDir = function ({ cacheDir, cwd = '.', mode, isTest } = {}) {
-  if (cacheDir !== undefined) {
-    return resolve(cwd, cacheDir)
-  }
-
-  if (mode !== 'buildbot') {
-    return resolve(cwd, LOCAL_CACHE_DIR)
-  }
-
-  // Do not use in tests since /opt might not be writable by current user
-  if (platform === 'linux' && !isTest) {
-    return CI_CACHE_DIR
-  }
-
-  return globalCacheDir(PROJECT_NAME)
+const getCacheDir = function ({ cacheDir = DEFAULT_CACHE_DIR, cwd = '.' } = {}) {
+  return resolve(cwd, cacheDir)
 }
 
-const LOCAL_CACHE_DIR = '.netlify/cache/'
-const CI_CACHE_DIR = '/opt/build/cache/'
-const PROJECT_NAME = 'netlify-build'
+const DEFAULT_CACHE_DIR = '.netlify/cache/'
 
 module.exports = { getCacheDir }

--- a/packages/cache-utils/src/list.js
+++ b/packages/cache-utils/src/list.js
@@ -9,9 +9,9 @@ const { isManifest } = require('./manifest')
 const { getBases } = require('./path')
 
 // List all cached files/directories, at the top-level
-const list = async function ({ cacheDir, cwd: cwdOpt, mode, depth = DEFAULT_DEPTH } = {}) {
+const list = async function ({ cacheDir, cwd: cwdOpt, depth = DEFAULT_DEPTH } = {}) {
   const bases = await getBases(cwdOpt)
-  const cacheDirA = await getCacheDir({ cacheDir, mode })
+  const cacheDirA = getCacheDir({ cacheDir, cwd: cwdOpt })
   const files = await Promise.all(bases.map(({ name, base }) => listBase({ name, base, cacheDir: cacheDirA, depth })))
   const filesA = files.flat()
   return filesA

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -13,9 +13,9 @@ const { parsePath } = require('./path')
 // Cache a file
 const saveOne = async function (
   path,
-  { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [], cacheDir, cwd: cwdOpt, mode } = {},
+  { move = DEFAULT_MOVE, ttl = DEFAULT_TTL, digests = [], cacheDir, cwd: cwdOpt } = {},
 ) {
-  const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
+  const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt })
 
   if (!(await hasFiles(srcPath))) {
     return false
@@ -34,8 +34,8 @@ const saveOne = async function (
 }
 
 // Restore a cached file
-const restoreOne = async function (path, { move = DEFAULT_MOVE, cacheDir, cwd: cwdOpt, mode } = {}) {
-  const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
+const restoreOne = async function (path, { move = DEFAULT_MOVE, cacheDir, cwd: cwdOpt } = {}) {
+  const { srcPath, cachePath } = await parsePath({ path, cacheDir, cwdOpt })
 
   if (!(await hasFiles(cachePath))) {
     return false
@@ -52,8 +52,8 @@ const restoreOne = async function (path, { move = DEFAULT_MOVE, cacheDir, cwd: c
 }
 
 // Remove the cache of a file
-const removeOne = async function (path, { cacheDir, cwd: cwdOpt, mode } = {}) {
-  const { cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
+const removeOne = async function (path, { cacheDir, cwd: cwdOpt } = {}) {
+  const { cachePath } = await parsePath({ path, cacheDir, cwdOpt })
 
   if (!(await hasFiles(cachePath))) {
     return false
@@ -66,8 +66,8 @@ const removeOne = async function (path, { cacheDir, cwd: cwdOpt, mode } = {}) {
 }
 
 // Check if a file is cached
-const hasOne = async function (path, { cacheDir, cwd: cwdOpt, mode } = {}) {
-  const { cachePath } = await parsePath({ path, cacheDir, cwdOpt, mode })
+const hasOne = async function (path, { cacheDir, cwd: cwdOpt } = {}) {
+  const { cachePath } = await parsePath({ path, cacheDir, cwdOpt })
 
   return (await hasFiles(cachePath)) && !(await isExpired(cachePath))
 }

--- a/packages/cache-utils/src/path.js
+++ b/packages/cache-utils/src/path.js
@@ -7,9 +7,9 @@ const { getCacheDir } = require('./dir')
 const { safeGetCwd } = require('./utils/cwd')
 
 // Find the paths of the file before/after caching
-const parsePath = async function ({ path, cacheDir, cwdOpt, mode }) {
+const parsePath = async function ({ path, cacheDir, cwdOpt }) {
   const srcPath = await getSrcPath(path, cwdOpt)
-  const cachePath = await getCachePath({ srcPath, cacheDir, cwdOpt, mode })
+  const cachePath = await getCachePath({ srcPath, cacheDir, cwdOpt })
   return { srcPath, cachePath }
 }
 
@@ -52,8 +52,8 @@ const isParentPath = function (srcPath, cwd) {
   return `${cwd}${sep}`.startsWith(`${srcPath}${sep}`)
 }
 
-const getCachePath = async function ({ srcPath, cacheDir, cwdOpt, mode }) {
-  const cacheDirA = await getCacheDir({ cacheDir, mode })
+const getCachePath = async function ({ srcPath, cacheDir, cwdOpt }) {
+  const cacheDirA = getCacheDir({ cacheDir, cwd: cwdOpt })
   const { name, relPath } = await findBase(srcPath, cwdOpt)
   const cachePath = join(cacheDirA, name, relPath)
   return cachePath

--- a/packages/cache-utils/tests/dir.js
+++ b/packages/cache-utils/tests/dir.js
@@ -7,26 +7,22 @@ const pathExists = require('path-exists')
 
 const cacheUtils = require('..')
 
-const { pWriteFile, createTmpDir, removeFiles } = require('./helpers/main')
+const { pWriteFile, pReaddir, createTmpDir, removeFiles } = require('./helpers/main')
 
-test('Should allow not changing the cache directory', async (t) => {
+test('Should allow changing the cache directory', async (t) => {
   const [cacheDir, srcDir] = await Promise.all([createTmpDir(), createTmpDir()])
   const currentDir = getCwd()
   chdir(srcDir)
   try {
     const srcFile = `${srcDir}/test`
     await pWriteFile(srcFile, '')
-    t.true(await cacheUtils.save(srcFile))
+    t.true(await cacheUtils.save(srcFile, { cacheDir }))
+    t.is((await pReaddir(cacheDir)).length, 1)
     await removeFiles(srcFile)
-    t.true(await cacheUtils.restore(srcFile))
+    t.true(await cacheUtils.restore(srcFile, { cacheDir }))
     t.true(await pathExists(srcFile))
   } finally {
     chdir(currentDir)
     await removeFiles([cacheDir, srcDir])
   }
-})
-
-test('Should allow not changing the cache directory in CI', async (t) => {
-  const cacheDir = await cacheUtils.getCacheDir({ mode: 'buildbot', isTest: true })
-  t.true(await pathExists(cacheDir))
 })

--- a/packages/cache-utils/tests/helpers/main.js
+++ b/packages/cache-utils/tests/helpers/main.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { writeFile, readFile } = require('fs')
+const { writeFile, readFile, readdir } = require('fs')
 const { join, basename } = require('path')
 const { promisify } = require('util')
 
@@ -11,6 +11,7 @@ const { dir: getTmpDir, tmpName } = require('tmp-promise')
 const pSetTimeout = promisify(setTimeout)
 const pWriteFile = promisify(writeFile)
 const pReadFile = promisify(readFile)
+const pReaddir = promisify(readdir)
 
 const createTmpDir = async function (opts) {
   const { path } = await getTmpDir({ ...opts, prefix: PREFIX })
@@ -35,6 +36,7 @@ module.exports = {
   pSetTimeout,
   pWriteFile,
   pReadFile,
+  pReaddir,
   createTmpDir,
   createTmpFile,
   removeFiles,

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,7 +18,6 @@
         'get-bin-path',
         'get-node',
         'get-stream',
-        'global-cache-dir',
         'globby',
         'got',
         'is-plain-obj',


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/2369

This removes some logic used to retrieve the cache directory that is not used anymore:
  - The buildbot now uses the `--cache-dir=/opt/build/cache` CLI flag
  - CLI and programmatic builds now rely on the default value `{buildDir}/.netlify/cache/`

The OS-specific and mode-specific can now be safely removed. This allows simplifying the logic.