### PR TITLE
chore: refactor `plugin.expectedVersion`

### DIFF
--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -136,8 +136,8 @@ const resolveMissingPluginPath = async function ({ pluginOptions, pluginOptions:
   return { ...pluginOptions, pluginPath }
 }
 
-const isMissingPlugin = function ({ expectedVersion, loadedFrom }) {
-  return expectedVersion !== undefined && loadedFrom === 'auto_install'
+const isMissingPlugin = function ({ isMissing }) {
+  return isMissing
 }
 
 module.exports = { resolvePluginsPath }


### PR DESCRIPTION
Part of #2403.

This refactors how `plugin.expectedVersion` and `isMissing` are computed. This does not change any behavior, just makes it clearer.