### PR TITLE
feat: add an error type for Functions bundling user errors

### DIFF
--- a/packages/build/src/error/parse/location.js
+++ b/packages/build/src/error/parse/location.js
@@ -25,6 +25,10 @@ const getBuildCommandLocation = function ({ buildCommand, buildCommandOrigin }) 
 ${buildCommand}`
 }
 
+const getFunctionsBundlingLocation = function ({ functionName }) {
+  return `While bundling Function "${functionName}"`
+}
+
 const getCoreCommandLocation = function ({ coreCommandName }) {
   return `During ${coreCommandName}`
 }
@@ -49,6 +53,7 @@ const getApiLocation = function ({ endpoint, parameters }) {
 
 const LOCATIONS = {
   buildCommand: getBuildCommandLocation,
+  functionsBundling: getFunctionsBundlingLocation,
   coreCommand: getCoreCommandLocation,
   buildFail: getBuildFailLocation,
   api: getApiLocation,

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -71,6 +71,14 @@ const TYPES = {
     severity: 'info',
   },
 
+  // User error during Functions bundling
+  functionsBundling: {
+    title: ({ location: { functionName } }) => `Bundling of Function "${functionName}" failed`,
+    stackType: 'none',
+    locationType: 'functionsBundling',
+    severity: 'info',
+  },
+
   // Plugin called `utils.build.failBuild()`
   failBuild: {
     title: ({ location: { packageName } }) => `Plugin "${packageName}" failed`,


### PR DESCRIPTION
Part of https://github.com/netlify/zip-it-and-ship-it/issues/384

This adds an error type for user errors happening during Functions bundling.

`zip-it-and-ship-it` would throw those user errors like this:

```js
try {
  await esbuild(opts)
} catch (error) {
  error.errorInfo = { type: 'functionsBundling', location: { functionName } }
  throw error
}
```

Note: `functionName` would be required. If we don't always know the Function name, please let me know so I adjust the PR.