### PR TITLE
chore(prepublish): use npm ci instead of npm install on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "run-s prepublishOnly:*",
     "prepublishOnly:checkout": "git checkout master",
     "prepublishOnly:pull": "git pull",
-    "prepublishOnly:install": "npm install",
+    "prepublishOnly:install": "npm ci",
     "prepublishOnly:test": "npm test"
   },
   "config": {


### PR DESCRIPTION
Wanted to know what you folks think of running `npm ci` instead of `npm install` on prepublish. This forces the `node_modules` dir to be recreated according to the lockfile (only), running tests against the exact dependency tree we expect. I've been tricked more than once, by checking out master, forgetting to run npm ci, and having the tests fail during a release because I've got an outdated dep locally installed for example (or some weird node_modules inconsistency).