### PR TITLE
feat: distinguish between warnings and errors in build logs

### DIFF
--- a/packages/build/src/log/logger.js
+++ b/packages/build/src/log/logger.js
@@ -50,6 +50,10 @@ const serializeIndentedItem = function (item) {
   return indentString(item, INDENT_SIZE + 1).trimLeft()
 }
 
+const logError = function (logs, string, opts) {
+  log(logs, string, { color: THEME.errorLine, ...opts })
+}
+
 const logWarning = function (logs, string, opts) {
   log(logs, string, { color: THEME.warningLine, ...opts })
 }
@@ -67,6 +71,11 @@ const logObject = function (logs, object, opts) {
 // Print an array
 const logArray = function (logs, array, opts) {
   logMessage(logs, serializeIndentedArray(array), { color: THEME.none, ...opts })
+}
+
+// Print an array of errors
+const logErrorArray = function (logs, array, opts) {
+  logMessage(logs, serializeIndentedArray(array), { color: THEME.errorLine, ...opts })
 }
 
 // Print an array of warnings
@@ -102,10 +111,12 @@ const logWarningSubHeader = function (logs, string, opts) {
 module.exports = {
   getBufferLogs,
   log,
+  logError,
   logWarning,
   logMessage,
   logObject,
   logArray,
+  logErrorArray,
   logWarningArray,
   logHeader,
   logErrorHeader,

--- a/packages/build/src/log/logger.js
+++ b/packages/build/src/log/logger.js
@@ -50,8 +50,8 @@ const serializeIndentedItem = function (item) {
   return indentString(item, INDENT_SIZE + 1).trimLeft()
 }
 
-const logError = function (logs, string, opts) {
-  log(logs, string, { color: THEME.errorLine, ...opts })
+const logWarning = function (logs, string, opts) {
+  log(logs, string, { color: THEME.warningLine, ...opts })
 }
 
 // Print a message that is under a header/subheader, i.e. indented
@@ -69,9 +69,9 @@ const logArray = function (logs, array, opts) {
   logMessage(logs, serializeIndentedArray(array), { color: THEME.none, ...opts })
 }
 
-// Print an array of errors
-const logErrorArray = function (logs, array, opts) {
-  logMessage(logs, serializeIndentedArray(array), { color: THEME.errorLine, ...opts })
+// Print an array of warnings
+const logWarningArray = function (logs, array, opts) {
+  logMessage(logs, serializeIndentedArray(array), { color: THEME.warningLine, ...opts })
 }
 
 // Print a main section header
@@ -94,17 +94,23 @@ const logErrorSubHeader = function (logs, string, opts) {
   logSubHeader(logs, string, { color: THEME.errorSubHeader, ...opts })
 }
 
+// Print a sub-section header, when a warning happened
+const logWarningSubHeader = function (logs, string, opts) {
+  logSubHeader(logs, string, { color: THEME.warningSubHeader, ...opts })
+}
+
 module.exports = {
   getBufferLogs,
   log,
-  logError,
+  logWarning,
   logMessage,
   logObject,
   logArray,
-  logErrorArray,
+  logWarningArray,
   logHeader,
   logErrorHeader,
   logSubHeader,
   logErrorSubHeader,
+  logWarningSubHeader,
   pointer,
 }

--- a/packages/build/src/log/messages/core.js
+++ b/packages/build/src/log/messages/core.js
@@ -7,7 +7,7 @@ const { getFullErrorInfo } = require('../../error/parse/parse')
 const { serializeLogError } = require('../../error/parse/serialize_log')
 const { roundTimerToMillisecs } = require('../../time/measure')
 const { getLogHeaderFunc } = require('../header_func')
-const { log, logMessage, logError, logHeader, logSubHeader, logErrorArray } = require('../logger')
+const { log, logMessage, logWarning, logHeader, logSubHeader, logWarningArray } = require('../logger')
 const { logOldCliVersionError } = require('../old_version')
 const { THEME } = require('../theme')
 
@@ -42,15 +42,15 @@ const logTimer = function (logs, durationNs, timerName) {
 }
 
 const logLingeringProcesses = function (logs, processes) {
-  logError(
+  logWarning(
     logs,
     `
 ** WARNING **
 There are some lingering processes even after the build process finished:
 `,
   )
-  logErrorArray(logs, processes)
-  logError(
+  logWarningArray(logs, processes)
+  logWarning(
     logs,
     `
 Our builds do not kill your processes automatically, so please make sure

--- a/packages/build/src/log/messages/core_commands.js
+++ b/packages/build/src/log/messages/core_commands.js
@@ -2,13 +2,18 @@
 
 const path = require('path')
 
-const { log, logArray, logErrorSubHeader } = require('../logger')
+const { log, logArray, logErrorSubHeader, logWarningSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
-const logBundleResultFunctions = ({ functions, headerMessage, logs }) => {
+const logBundleResultFunctions = ({ functions, headerMessage, logs, error }) => {
   const functionNames = functions.map(({ path: functionPath }) => path.basename(functionPath))
 
-  logErrorSubHeader(logs, headerMessage)
+  if (error) {
+    logErrorSubHeader(logs, headerMessage)
+  } else {
+    logWarningSubHeader(logs, headerMessage)
+  }
+
   logArray(logs, functionNames)
 }
 
@@ -23,6 +28,7 @@ const logBundleResults = ({ logs, results = [] }) => {
       functions: resultsWithErrors,
       headerMessage: 'Failed to bundle functions with selected bundler (fallback used):',
       logs,
+      error: true,
     })
   }
 
@@ -31,6 +37,7 @@ const logBundleResults = ({ logs, results = [] }) => {
       functions: resultsWithWarnings,
       headerMessage: 'Functions bundled with warnings:',
       logs,
+      error: false,
     })
   }
 }

--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -3,11 +3,11 @@
 const { lt: ltVersion, major } = require('semver')
 
 const { getPluginOrigin } = require('../description')
-const { log, logArray, logErrorArray, logError, logSubHeader, logErrorSubHeader } = require('../logger')
+const { log, logArray, logWarningArray, logWarning, logSubHeader, logWarningSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
 const logPluginsFetchError = function (logs, message) {
-  logError(
+  logWarning(
     logs,
     `
 Warning: could not fetch latest plugins list. Plugins versions might not be the latest.
@@ -62,8 +62,8 @@ const logOutdatedPlugins = function (logs, pluginsOptions) {
     return
   }
 
-  logErrorSubHeader(logs, 'Outdated plugins')
-  logErrorArray(logs, outdatedPlugins)
+  logWarningSubHeader(logs, 'Outdated plugins')
+  logWarningArray(logs, outdatedPlugins)
 }
 
 const getOutdatedPlugin = function ({ packageName, pluginPackageJson: { version }, latestVersion, compatWarning }) {
@@ -73,7 +73,7 @@ const getOutdatedPlugin = function ({ packageName, pluginPackageJson: { version 
 
   const versionedPackage = getVersionedPackage(packageName, version)
   const outdatedDescription = getOutdatedDescription(latestVersion, compatWarning)
-  return `${THEME.errorHighlightWords(packageName)}${versionedPackage}: ${outdatedDescription}`
+  return `${THEME.warningHighlightWords(packageName)}${versionedPackage}: ${outdatedDescription}`
 }
 
 const hasOutdatedVersion = function (version, latestVersion) {
@@ -98,8 +98,8 @@ const logIncompatiblePlugins = function (logs, pluginsOptions) {
     return
   }
 
-  logErrorSubHeader(logs, 'Incompatible plugins')
-  logErrorArray(logs, incompatiblePlugins)
+  logWarningSubHeader(logs, 'Incompatible plugins')
+  logWarningArray(logs, incompatiblePlugins)
 }
 
 const getIncompatiblePlugin = function ({
@@ -113,7 +113,7 @@ const getIncompatiblePlugin = function ({
   }
 
   const versionedPackage = getVersionedPackage(packageName, version)
-  return `${THEME.errorHighlightWords(
+  return `${THEME.warningHighlightWords(
     packageName,
   )}${versionedPackage}: expected version ${expectedVersion} which is the last version compatible with ${compatWarning}`
 }
@@ -138,7 +138,7 @@ const getVersionedPackage = function (packageName, version = '') {
 }
 
 const logFailPluginWarning = function (methodName, event) {
-  logError(
+  logWarning(
     undefined,
     `Plugin error: since "${event}" happens after deploy, the build has already succeeded and cannot fail anymore. This plugin should either:
 - use utils.build.failPlugin() instead of utils.build.${methodName}() to clarify that the plugin failed, but not the build.

--- a/packages/build/src/log/theme.js
+++ b/packages/build/src/log/theme.js
@@ -7,6 +7,9 @@ const {
   redBright: { bold: redBrightBold },
   redBright,
   red: { bold: redBold },
+  yellowBright: { bold: yellowBrightBold },
+  yellowBright,
+  yellow: { bold: yellowBold },
   gray,
 } = require('chalk')
 
@@ -17,15 +20,18 @@ const THEME = {
   header: cyanBrightBold,
   // Single lines used as subheaders
   subHeader: cyanBold,
-  // Main headers indicating an error
-  errorHeader: redBrightBold,
-  // Single lines used as subheaders indicating an error
-  errorSubHeader: redBold,
-  // Non-headers indicating an error
-  errorLine: redBright,
   // One of several words that should be highlighted inside a line
   highlightWords: cyan,
+  // Same for errors
+  errorHeader: redBrightBold,
+  errorSubHeader: redBold,
+  errorLine: redBright,
   errorHighlightWords: redBrightBold,
+  // Same for warnings
+  warningHeader: yellowBrightBold,
+  warningSubHeader: yellowBold,
+  warningLine: yellowBright,
+  warningHighlightWords: yellowBrightBold,
   // One of several words that should be dimmed inside a line
   dimWords: gray,
   // No colors


### PR DESCRIPTION
Fixes #2389.

This uses a yellow/orange color for warnings, to distinguish them from errors (red).

Example:

![warning_color](https://user-images.githubusercontent.com/8136211/112386146-ce882280-8cf0-11eb-9603-920005a7b52c.png)
