### PR TITLE
feat: improve lingering processes list

### DIFF
--- a/packages/build/src/core/lingering.js
+++ b/packages/build/src/core/lingering.js
@@ -14,24 +14,15 @@ const warnOnLingeringProcesses = async function ({ mode, logs, testOpts: { silen
   const {
     stdout: processList,
   } = await execa(
-    'ps aux | grep -v ps | grep -v grep | grep -v bash | grep -v "/opt/build-bin/buildbot" | grep -v defunct | grep -v "\\[build\\]" | grep -v "@netlify/build" | grep -v "buildbot.*\\[node\\]" | grep -v "gatsby-telemetry" | grep -v "jest-worker" | grep -v "broccoli-babel-transpiler"',
+    'ps axho command | grep -v ps | grep -v grep | grep -v bash | grep -v "/opt/build-bin/buildbot" | grep -v defunct | grep -v "\\[build\\]" | grep -v "@netlify/build" | grep -v "buildbot.*\\[node\\]" | grep -v "gatsby-telemetry" | grep -v "jest-worker" | grep -v "broccoli-babel-transpiler"',
     { shell: 'bash' },
   )
 
-  if (!hasLingeringProcesses(processList)) {
+  if (processList.trim() === '') {
     return
   }
 
   logLingeringProcesses(logs, processList)
-}
-
-// Note that `ps aux` has a header line which is always printed.
-const hasLingeringProcesses = function (processList) {
-  return processList.split('\n').filter(isNotEmptyLine).length > 1
-}
-
-const isNotEmptyLine = function (line) {
-  return line.trim() !== ''
 }
 
 module.exports = { warnOnLingeringProcesses }


### PR DESCRIPTION
Part of #1966.

This improves the `ps` command call:
  - `u` is not needed since we only need the command names + arguments
  - `o command` allows printing only command names, since that's the only thing we want to `grep` 
  - thanks to `o command`, the warning message now print only the command names + arguments, since the other columns are just confusing to users and not helpful
  - `h` removes the top header row, which allows simplifying some of the logic