### PR TITLE
fix: do not fail when there are no lingering processes

### DIFF
--- a/packages/build/src/core/lingering.js
+++ b/packages/build/src/core/lingering.js
@@ -15,7 +15,7 @@ const warnOnLingeringProcesses = async function ({ mode, logs, testOpts: { silen
     stdout: processList,
   } = await execa(
     'ps axho command | grep -v ps | grep -v grep | grep -v bash | grep -v "/opt/build-bin/buildbot" | grep -v defunct | grep -v "\\[build\\]" | grep -v "@netlify/build" | grep -v "buildbot.*\\[node\\]" | grep -v "gatsby-telemetry" | grep -v "jest-worker" | grep -v "broccoli-babel-transpiler"',
-    { shell: 'bash' },
+    { shell: 'bash', reject: false },
   )
 
   if (processList.trim() === '') {


### PR DESCRIPTION
When there are no lingering processes, the build currently fails. This is because `grep` (with default options) returns an exit code `1` when there are no matches.
This is since #2475, which was not released to production.

This was caught while testing in the buildbot PR. Automated tests are currently partial for this feature, due to #1888. This will be fixed in follow-up PRs.