### PR TITLE
fix: do not show an empty list of lingering processes

### DIFF
--- a/packages/build/src/core/lingering.js
+++ b/packages/build/src/core/lingering.js
@@ -18,13 +18,17 @@ const warnOnLingeringProcesses = async function ({ mode, logs, testOpts: { silen
     { shell: 'bash', reject: false },
   )
 
-  const processes = stdout.trim().split('\n')
+  const processes = stdout.trim().split('\n').filter(isNotEmptyLine)
 
   if (processes.length === 0) {
     return
   }
 
   logLingeringProcesses(logs, processes)
+}
+
+const isNotEmptyLine = function (line) {
+  return line.trim() !== ''
 }
 
 module.exports = { warnOnLingeringProcesses }


### PR DESCRIPTION
This fixes an empty list of lingering processes being shown in build logs.
Example: https://app.netlify.com/sites/mick/deploys/605e1f6baff2cb000778c50c#L283

That bug was not released to production.