### PR TITLE
chore: add `read-pkg-up` to list of dependencies which cannot be upgraded

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,6 +36,7 @@
         'yargs',
         // Those cannot be upgraded to a major version until we drop support for Node 10
         'path-type',
+        'read-pkg-up',
       ],
       major: {
         enabled: false,


### PR DESCRIPTION
We cannot upgrade `read-pkg-up` since it drops support for Node 8 and 10.