### PR TITLE
feat: make lingering processes logic work on Windows

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -88,6 +88,7 @@
     "path-type": "^4.0.0",
     "pkg-dir": "^4.2.0",
     "pretty-ms": "^5.1.0",
+    "ps-list": "^6.3.0",
     "read-pkg-up": "^7.0.1",
     "readdirp": "^3.4.0",
     "resolve": "^2.0.0-next.1",

--- a/packages/build/src/core/lingering.js
+++ b/packages/build/src/core/lingering.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const execa = require('execa')
+const psList = require('ps-list')
 
 const { logLingeringProcesses } = require('../log/messages/core')
 
@@ -11,9 +11,9 @@ const warnOnLingeringProcesses = async function ({ mode, logs, testOpts: { silen
     return
   }
 
-  const { stdout } = await execa('ps', ['axho', 'command'])
+  const processes = await psList()
 
-  const commands = stdout.trim().split('\n').filter(isNotEmptyLine).filter(isNotIgnoredCommand)
+  const commands = processes.map(getCommand).filter(isNotIgnoredCommand)
 
   if (commands.length === 0) {
     return
@@ -22,8 +22,9 @@ const warnOnLingeringProcesses = async function ({ mode, logs, testOpts: { silen
   logLingeringProcesses(logs, commands)
 }
 
-const isNotEmptyLine = function (line) {
-  return line.trim() !== ''
+// `cmd` is only available on Unix. Unlike `name`, it includes the arguments.
+const getCommand = function ({ name, cmd = name }) {
+  return cmd
 }
 
 // We ignore any command known to be internal to the buildbot.

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { platform, kill } = require('process')
+const { kill, platform } = require('process')
 
 const test = require('ava')
 const getNode = require('get-node')
@@ -211,23 +211,21 @@ test('--apiHost is used to set Netlify API host', async (t) => {
   t.snapshot(requests)
 })
 
-if (platform !== 'win32') {
-  test('Print warning on lingering processes', async (t) => {
-    const { returnValue } = await runFixture(t, 'lingering', {
-      flags: { testOpts: { silentLingeringProcesses: false }, mode: 'buildbot' },
-      snapshot: false,
-    })
-
-    // Cleanup the lingering process
-    const [, pid] = PID_LINE_REGEXP.exec(returnValue)
-    kill(pid)
-
-    t.true(returnValue.includes('There are some lingering processes'))
-    t.true(returnValue.includes('forever.js'))
+test('Print warning on lingering processes', async (t) => {
+  const { returnValue } = await runFixture(t, 'lingering', {
+    flags: { testOpts: { silentLingeringProcesses: false }, mode: 'buildbot' },
+    snapshot: false,
   })
 
-  const PID_LINE_REGEXP = /^PID: (\d+)$/m
-}
+  // Cleanup the lingering process
+  const [, pid] = PID_LINE_REGEXP.exec(returnValue)
+  kill(pid)
+
+  t.true(returnValue.includes('There are some lingering processes'))
+  t.true(returnValue.includes(platform === 'win32' ? 'node.exe' : 'forever.js'))
+})
+
+const PID_LINE_REGEXP = /^PID: (\d+)$/m
 
 test('Functions config is passed to zip-it-and-ship-it (1)', async (t) => {
   await runFixture(t, 'functions_config_1')


### PR DESCRIPTION
Part of #1966.

This makes the lingering processes logic work on Windows.

`ps-list` uses the following commands internally on Unix: `ps wwxo pid,comm,args,ppid,%cpu,%mem`
  - `ww` and removing `h` are only formatting options
  - the `a` is removed, which is good since we don't want to print lingering processes owned by a different user
  - the extra columns are not used by our code
  - the `command` column is now `args`, which is an alias

I.e. the behavior should be the same (I manually tested it in production)