### PR TITLE
chore(release-please): checkout code with all history

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,8 @@ jobs:
           monorepo-tags: true
           path: packages/${{ matrix.package }}
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
We have some tests that rely on git history.
By default the checkout action doesn't pull the history, so these test fail at the moment when trying to release.