### PR TITLE
feat: refactor how `origin` is added to context-specific configs

### DIFF
--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -3,7 +3,7 @@
 const isPlainObj = require('is-plain-obj')
 
 const { normalizeBuildCase } = require('./case')
-const { addCommandConfigOrigin } = require('./origin')
+const { addBuildCommandOrigin, CONFIG_ORIGIN } = require('./origin')
 const { deepMerge } = require('./utils/merge')
 
 // Takes a config object and adds each key to a namespace. This namespace is
@@ -43,8 +43,8 @@ const mergeContext = function ({ context: contextProps, ...config }, context, br
     .map((key) => contextProps[key])
     .filter(Boolean)
     .map(normalizeBuildCase)
-    .map(addCommandConfigOrigin)
     .map(addNamespace)
+    .map((contextConfig) => addBuildCommandOrigin(contextConfig, CONFIG_ORIGIN))
 
   return deepMerge(config, ...allContextProps)
 }

--- a/packages/config/src/origin.js
+++ b/packages/config/src/origin.js
@@ -9,29 +9,17 @@ const CONFIG_ORIGIN = 'config'
 // This also removes empty build commands.
 const addBuildCommandOrigins = function (defaultConfig, config, inlineConfig) {
   return [
-    addBuildCommandUiOrigin(defaultConfig),
-    addBuildCommandConfigOrigin(config),
-    addBuildCommandConfigOrigin(inlineConfig),
+    addBuildCommandOrigin(defaultConfig, UI_ORIGIN),
+    addBuildCommandOrigin(config, CONFIG_ORIGIN),
+    addBuildCommandOrigin(inlineConfig, CONFIG_ORIGIN),
   ]
 }
 
-const addBuildCommandOrigin = function (commandOrigin, { build = {}, ...config }) {
-  const buildA = addCommandOrigin(commandOrigin, build)
-  return { ...config, build: buildA }
+const addBuildCommandOrigin = function ({ build: { command, ...build } = {}, ...config }, commandOrigin) {
+  return command === undefined || (typeof command === 'string' && command.trim() === '')
+    ? { ...config, build }
+    : { ...config, build: { ...build, command, commandOrigin } }
 }
-
-const addBuildCommandUiOrigin = addBuildCommandOrigin.bind(null, UI_ORIGIN)
-const addBuildCommandConfigOrigin = addBuildCommandOrigin.bind(null, CONFIG_ORIGIN)
-
-const addCommandOrigin = function (commandOrigin, { command, ...build }) {
-  if (command === undefined || (typeof command === 'string' && command.trim() === '')) {
-    return build
-  }
-
-  return { ...build, command, commandOrigin }
-}
-
-const addCommandConfigOrigin = addCommandOrigin.bind(null, CONFIG_ORIGIN)
 
 // Add `plugins[*].origin`. This is like `build.commandOrigin` but for plugins.
 const addPluginsOrigins = function (defaultConfig, config, inlineConfig) {
@@ -47,4 +35,4 @@ const addConfigPluginOrigin = function ({ plugins = [], ...config }, origin) {
   return { ...config, plugins: pluginsA }
 }
 
-module.exports = { addBuildCommandOrigins, addCommandConfigOrigin, addPluginsOrigins }
+module.exports = { addBuildCommandOrigins, addBuildCommandOrigin, addPluginsOrigins, CONFIG_ORIGIN }


### PR DESCRIPTION
Part of #1169.

This refactors how `commandOrigin` is added when using `context.{context}.command`.
This refactoring does not change any behavior, but will help with some upcoming PRs.