### PR TITLE
fix: improve config normalization logic

### DIFF
--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -5,6 +5,7 @@ const isPlainObj = require('is-plain-obj')
 const { normalizeBuildCase } = require('./case')
 const { addBuildCommandOrigin, CONFIG_ORIGIN } = require('./origin')
 const { deepMerge } = require('./utils/merge')
+const { validatePreContextConfig } = require('./validate/main')
 
 // Takes a config object and adds each key to a namespace. This namespace is
 // usually `build`, since `context.*.{key}` is merged to `build.{key}`. The
@@ -34,9 +35,12 @@ const addNamespace = (context) => {
 // Merge `config.context.{CONTEXT|BRANCH}.*` to `config.build.*`
 // CONTEXT is the `--context` CLI flag.
 // BRANCH is the `--branch` CLI flag.
-const mergeContext = function ({ context: contextProps, ...config }, context, branch) {
-  if (!isPlainObj(contextProps)) {
-    return config
+const mergeContext = function (config, context, branch) {
+  validatePreContextConfig(config)
+
+  const { context: contextProps, ...configA } = config
+  if (contextProps === undefined) {
+    return configA
   }
 
   const allContextProps = [context, branch]
@@ -46,7 +50,7 @@ const mergeContext = function ({ context: contextProps, ...config }, context, br
     .map(addNamespace)
     .map((contextConfig) => addBuildCommandOrigin(contextConfig, CONFIG_ORIGIN))
 
-  return deepMerge(config, ...allContextProps)
+  return deepMerge(configA, ...allContextProps)
 }
 
 module.exports = { mergeContext }

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -5,7 +5,6 @@ require('./utils/polyfills')
 
 const { getApiClient } = require('./api/client')
 const { getSiteInfo } = require('./api/site_info')
-const { normalizeConfigCase } = require('./case')
 const { mergeContext } = require('./context')
 const { getConfig, parseDefaultConfig } = require('./default')
 const { getEnv } = require('./env/main')
@@ -14,17 +13,10 @@ const { getInlineConfig } = require('./inline_config')
 const { cleanupConfig } = require('./log/cleanup')
 const { logResult } = require('./log/main')
 const { mergeConfigs } = require('./merge')
-const { normalizeConfig } = require('./normalize')
+const { normalizeBeforeConfigMerge, normalizeAfterConfigMerge } = require('./merge_normalize')
 const { addDefaultOpts, normalizeOpts } = require('./options/main')
 const { parseConfig } = require('./parse')
 const { getConfigPath } = require('./path')
-const {
-  validatePreCaseNormalize,
-  validatePreMergeConfig,
-  validatePreContextConfig,
-  validatePreNormalizeConfig,
-  validatePostNormalizeConfig,
-} = require('./validate/main')
 
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
@@ -206,20 +198,14 @@ const getFullConfig = async function ({
 }
 
 const mergeAndNormalizeConfig = function ({ config, defaultConfig, inlineConfig, context, branch }) {
-  validatePreCaseNormalize(config)
-  const configA = normalizeConfigCase(config)
+  const configA = normalizeBeforeConfigMerge(config)
+  const defaultConfigA = normalizeBeforeConfigMerge(defaultConfig)
+  const inlineConfigA = normalizeBeforeConfigMerge(inlineConfig)
 
-  validatePreMergeConfig(defaultConfig, configA, inlineConfig)
-  const configB = mergeConfigs(defaultConfig, configA, inlineConfig)
-
-  validatePreContextConfig(configB)
+  const configB = mergeConfigs(defaultConfigA, configA, inlineConfigA)
   const configC = mergeContext(configB, context, branch)
 
-  validatePreNormalizeConfig(configC)
-  const configD = normalizeConfig(configC)
-
-  validatePostNormalizeConfig(configD)
-
+  const configD = normalizeAfterConfigMerge(configC)
   return configD
 }
 

--- a/packages/config/src/merge_normalize.js
+++ b/packages/config/src/merge_normalize.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { normalizeConfigCase } = require('./case')
+const { normalizeConfig } = require('./normalize')
+const {
+  validatePreCaseNormalize,
+  validatePreMergeConfig,
+  validatePreNormalizeConfig,
+  validatePostNormalizeConfig,
+} = require('./validate/main')
+
+// Perform validation and normalization logic to apply to all of:
+//  - config, defaultConfig, inlineConfig
+//  - context-specific configs
+// Therefore, this is performing before merging those together.
+const normalizeBeforeConfigMerge = function (config) {
+  validatePreCaseNormalize(config)
+  const configA = normalizeConfigCase(config)
+  validatePreMergeConfig(configA)
+  return configA
+}
+
+// Validation and normalization logic performed after merging
+const normalizeAfterConfigMerge = function (config) {
+  validatePreNormalizeConfig(config)
+  const configA = normalizeConfig(config)
+  validatePostNormalizeConfig(configA)
+  return configA
+}
+
+module.exports = {
+  normalizeBeforeConfigMerge,
+  normalizeAfterConfigMerge,
+}

--- a/packages/config/src/validate/main.js
+++ b/packages/config/src/validate/main.js
@@ -18,10 +18,8 @@ const validatePreCaseNormalize = function (config) {
 }
 
 // Validate the configuration file, before `defaultConfig` merge.
-const validatePreMergeConfig = function (defaultConfig, config, inlineConfig) {
-  validateConfig(defaultConfig, PRE_MERGE_VALIDATIONS)
+const validatePreMergeConfig = function (config) {
   validateConfig(config, PRE_MERGE_VALIDATIONS)
-  validateConfig(inlineConfig, PRE_MERGE_VALIDATIONS)
 }
 
 // Validate the configuration file, before context merge.


### PR DESCRIPTION
Part of #1169.

This refactors the config validation and normalization logic. This does not change behavior except that it now ensures that that logic applies not only to the main `config` object, but also to `inlineConfig` and `defaultConfig` (UI config).

This is part of a larger refactoring needed for plugins-specific config.