### PR TITLE
feat: refactor configuration property origins

### DIFF
--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -3,7 +3,7 @@
 const isPlainObj = require('is-plain-obj')
 
 const { normalizeBuildCase } = require('./case')
-const { addBuildCommandOrigin, CONFIG_ORIGIN } = require('./origin')
+const { addOrigins, CONFIG_ORIGIN } = require('./origin')
 const { deepMerge } = require('./utils/merge')
 const { validatePreContextConfig } = require('./validate/main')
 
@@ -48,7 +48,7 @@ const mergeContext = function (config, context, branch) {
     .filter(Boolean)
     .map(normalizeBuildCase)
     .map(addNamespace)
-    .map((contextConfig) => addBuildCommandOrigin(contextConfig, CONFIG_ORIGIN))
+    .map((contextConfig) => addOrigins(contextConfig, CONFIG_ORIGIN))
 
   return deepMerge(configA, ...allContextProps)
 }

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -15,6 +15,7 @@ const { logResult } = require('./log/main')
 const { mergeConfigs } = require('./merge')
 const { normalizeBeforeConfigMerge, normalizeAfterConfigMerge } = require('./merge_normalize')
 const { addDefaultOpts, normalizeOpts } = require('./options/main')
+const { UI_ORIGIN, CONFIG_ORIGIN } = require('./origin')
 const { parseConfig } = require('./parse')
 const { getConfigPath } = require('./path')
 
@@ -198,9 +199,9 @@ const getFullConfig = async function ({
 }
 
 const mergeAndNormalizeConfig = function ({ config, defaultConfig, inlineConfig, context, branch }) {
-  const configA = normalizeBeforeConfigMerge(config)
-  const defaultConfigA = normalizeBeforeConfigMerge(defaultConfig)
-  const inlineConfigA = normalizeBeforeConfigMerge(inlineConfig)
+  const configA = normalizeBeforeConfigMerge(config, CONFIG_ORIGIN)
+  const defaultConfigA = normalizeBeforeConfigMerge(defaultConfig, UI_ORIGIN)
+  const inlineConfigA = normalizeBeforeConfigMerge(inlineConfig, CONFIG_ORIGIN)
 
   const configB = mergeConfigs(defaultConfigA, configA, inlineConfigA)
   const configC = mergeContext(configB, context, branch)

--- a/packages/config/src/merge.js
+++ b/packages/config/src/merge.js
@@ -1,18 +1,15 @@
 'use strict'
 
 const { throwError } = require('./error')
-const { addBuildCommandOrigins, addPluginsOrigins } = require('./origin')
 const { deepMerge } = require('./utils/merge')
 
 // Merge `--defaultConfig` which is used to retrieve UI build settings and
 // UI-installed plugins.
 // Also merge `inlineConfig` which is used for Netlify CLI flags.
 const mergeConfigs = function (defaultConfig, config, inlineConfig) {
-  const [defaultConfigA, configA, inlineConfigA] = addBuildCommandOrigins(defaultConfig, config, inlineConfig)
-  const [defaultConfigB, configB, inlineConfigB] = addPluginsOrigins(defaultConfigA, configA, inlineConfigA)
-  const pluginsA = mergePlugins(defaultConfigB, configB, inlineConfigB)
-  const configC = deepMerge(defaultConfigB, configB, inlineConfigB)
-  return { ...configC, plugins: pluginsA }
+  const plugins = mergePlugins(defaultConfig, config, inlineConfig)
+  const configA = deepMerge(defaultConfig, config, inlineConfig)
+  return { ...configA, plugins }
 }
 
 // `defaultConfig` `plugins` are UI-installed plugins. Those are merged by

--- a/packages/config/src/merge_normalize.js
+++ b/packages/config/src/merge_normalize.js
@@ -2,6 +2,7 @@
 
 const { normalizeConfigCase } = require('./case')
 const { normalizeConfig } = require('./normalize')
+const { addOrigins } = require('./origin')
 const {
   validatePreCaseNormalize,
   validatePreMergeConfig,
@@ -13,11 +14,12 @@ const {
 //  - config, defaultConfig, inlineConfig
 //  - context-specific configs
 // Therefore, this is performing before merging those together.
-const normalizeBeforeConfigMerge = function (config) {
+const normalizeBeforeConfigMerge = function (config, origin) {
   validatePreCaseNormalize(config)
   const configA = normalizeConfigCase(config)
   validatePreMergeConfig(configA)
-  return configA
+  const configB = addOrigins(configA, origin)
+  return configB
 }
 
 // Validation and normalization logic performed after merging

--- a/packages/config/src/origin.js
+++ b/packages/config/src/origin.js
@@ -4,30 +4,19 @@
 const UI_ORIGIN = 'ui'
 const CONFIG_ORIGIN = 'config'
 
-// Add `build.commandOrigin`. This shows whether `build.command` came from the
-// `ui` or from the `config`.
-// This also removes empty build commands.
-const addBuildCommandOrigins = function (defaultConfig, config, inlineConfig) {
-  return [
-    addBuildCommandOrigin(defaultConfig, UI_ORIGIN),
-    addBuildCommandOrigin(config, CONFIG_ORIGIN),
-    addBuildCommandOrigin(inlineConfig, CONFIG_ORIGIN),
-  ]
+// Add `build.commandOrigin` and `plugins[*].origin`.
+// This shows whether those properties came from the `ui` or from the `config`.
+const addOrigins = function (config, origin) {
+  const configA = addBuildCommandOrigin(config, origin)
+  const configB = addConfigPluginOrigin(configA, origin)
+  return configB
 }
 
+// This also removes empty build commands.
 const addBuildCommandOrigin = function ({ build: { command, ...build } = {}, ...config }, commandOrigin) {
   return command === undefined || (typeof command === 'string' && command.trim() === '')
     ? { ...config, build }
     : { ...config, build: { ...build, command, commandOrigin } }
-}
-
-// Add `plugins[*].origin`. This is like `build.commandOrigin` but for plugins.
-const addPluginsOrigins = function (defaultConfig, config, inlineConfig) {
-  return [
-    addConfigPluginOrigin(defaultConfig, UI_ORIGIN),
-    addConfigPluginOrigin(config, CONFIG_ORIGIN),
-    addConfigPluginOrigin(inlineConfig, CONFIG_ORIGIN),
-  ]
 }
 
 const addConfigPluginOrigin = function ({ plugins = [], ...config }, origin) {
@@ -35,4 +24,4 @@ const addConfigPluginOrigin = function ({ plugins = [], ...config }, origin) {
   return { ...config, plugins: pluginsA }
 }
 
-module.exports = { addBuildCommandOrigins, addBuildCommandOrigin, addPluginsOrigins, CONFIG_ORIGIN }
+module.exports = { addOrigins, UI_ORIGIN, CONFIG_ORIGIN }


### PR DESCRIPTION
Part of #1169.

This refactors/simplifies how `config.build.commandOrigin` and `config.plugins[*].origin` are set in `@netlify/config`. This does not change behavior, except that it allows `origin` to be set in context-specific config.