### PR TITLE
feat: refactor configuration merge logic

### DIFF
--- a/packages/config/src/context.js
+++ b/packages/config/src/context.js
@@ -4,7 +4,7 @@ const isPlainObj = require('is-plain-obj')
 
 const { normalizeBeforeConfigMerge } = require('./merge_normalize.js')
 const { CONFIG_ORIGIN } = require('./origin')
-const { deepMerge } = require('./utils/merge')
+const { mergeConfigs } = require('./utils/merge')
 const { validatePreContextConfig } = require('./validate/main')
 
 // Merge `config.context.{CONTEXT|BRANCH}.*` to `config.build.*` or `config.*`
@@ -24,7 +24,7 @@ const mergeContext = function (config, context, branch) {
     .map(addNamespace)
     .map((contextConfig) => normalizeBeforeConfigMerge(contextConfig, CONFIG_ORIGIN))
 
-  return deepMerge(configA, ...allContextProps)
+  return mergeConfigs([configA, ...allContextProps])
 }
 
 // `config.context.{context}.*` properties are merged either to `config.*` or

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -12,7 +12,7 @@ const { handleFiles } = require('./files')
 const { getInlineConfig } = require('./inline_config')
 const { cleanupConfig } = require('./log/cleanup')
 const { logResult } = require('./log/main')
-const { mergeConfigs } = require('./merge')
+const { mergeAllConfigs } = require('./merge')
 const { normalizeBeforeConfigMerge, normalizeAfterConfigMerge } = require('./merge_normalize')
 const { addDefaultOpts, normalizeOpts } = require('./options/main')
 const { UI_ORIGIN, CONFIG_ORIGIN } = require('./origin')
@@ -203,7 +203,7 @@ const mergeAndNormalizeConfig = function ({ config, defaultConfig, inlineConfig,
   const defaultConfigA = normalizeBeforeConfigMerge(defaultConfig, UI_ORIGIN)
   const inlineConfigA = normalizeBeforeConfigMerge(inlineConfig, CONFIG_ORIGIN)
 
-  const configB = mergeConfigs(defaultConfigA, configA, inlineConfigA)
+  const configB = mergeAllConfigs([defaultConfigA, configA, inlineConfigA])
   const configC = mergeContext(configB, context, branch)
 
   const configD = normalizeAfterConfigMerge(configC)

--- a/packages/config/src/merge.js
+++ b/packages/config/src/merge.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const { throwError } = require('./error')
-const { deepMerge } = require('./utils/merge')
+const { mergeConfigs } = require('./utils/merge')
 
 // Merge `--defaultConfig` which is used to retrieve UI build settings and
 // UI-installed plugins.
 // Also merge `inlineConfig` which is used for Netlify CLI flags.
-const mergeConfigs = function (defaultConfig, config, inlineConfig) {
+const mergeAllConfigs = function ([defaultConfig, config, inlineConfig]) {
   const plugins = mergePlugins([defaultConfig, config, inlineConfig])
-  const configA = deepMerge(defaultConfig, config, inlineConfig)
+  const configA = mergeConfigs([defaultConfig, config, inlineConfig])
   return { ...configA, plugins }
 }
 
@@ -38,4 +38,4 @@ const isNotOverridenPlugin = function (plugin, index, plugins) {
   return overridingPlugin === undefined
 }
 
-module.exports = { mergeConfigs }
+module.exports = { mergeAllConfigs }

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { extractFunctionsDirectory, normalize: normalizeFunctionsConfig } = require('./functions_config')
-const { deepMerge } = require('./utils/merge')
+const { mergeConfigs } = require('./utils/merge')
 const { removeFalsy } = require('./utils/remove_falsy')
 
 const addFunctionsDirectory = ({ functionsDirectory, v1FunctionsDirectory }) => {
@@ -24,7 +24,7 @@ const addFunctionsDirectory = ({ functionsDirectory, v1FunctionsDirectory }) => 
 
 // Normalize configuration object
 const normalizeConfig = function (config) {
-  const { build, functions, plugins, ...configA } = deepMerge(DEFAULT_CONFIG, config)
+  const { build, functions, plugins, ...configA } = mergeConfigs([DEFAULT_CONFIG, config])
 
   // Removing the legacy `functions` from the `build` block.
   const { functions: v1FunctionsDirectory, ...buildB } = build

--- a/packages/config/src/utils/merge.js
+++ b/packages/config/src/utils/merge.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const deepmerge = require('deepmerge')
-const isPlainObj = require('is-plain-obj')
 
-// Deep merge utility for configuration objects
-const deepMerge = function (...values) {
-  const objects = values.filter(isPlainObj)
-  return deepmerge.all(objects, { arrayMerge })
+// Merge an array of configuration objects.
+// Last items have higher priority.
+// Configuration objects are deeply merged.
+//   - Arrays are overridden, not concatenated.
+const mergeConfigs = function (configs) {
+  return deepmerge.all(configs, { arrayMerge })
 }
 
 // By default `deepmerge` concatenates arrays. We use the `arrayMerge` option
@@ -15,4 +16,4 @@ const arrayMerge = function (arrayA, arrayB) {
   return arrayB
 }
 
-module.exports = { deepMerge }
+module.exports = { mergeConfigs }


### PR DESCRIPTION
Part of #1169.

This refactors the logic that merges configuration objects.
This does not change it, just refactors it.

This makes it clearer that this logic is only intended to merge configuration objects. This also removes the usage of a variadic argument and enforces that the arguments are defined.