### PR TITLE
fix: warning message link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6027,7 +6027,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -22654,7 +22653,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -23850,7 +23848,7 @@
     },
     "packages/build": {
       "name": "@netlify/build",
-      "version": "10.2.5",
+      "version": "10.2.6",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
@@ -23864,6 +23862,7 @@
         "@netlify/zip-it-and-ship-it": "^3.2.0",
         "@sindresorhus/slugify": "^1.1.0",
         "@ungap/from-entries": "^0.2.1",
+        "ansi-escapes": "^4.3.2",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "clean-stack": "^2.2.0",
@@ -24645,7 +24644,7 @@
     },
     "packages/config": {
       "name": "@netlify/config",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "license": "MIT",
       "dependencies": {
         "@ungap/from-entries": "^0.2.1",
@@ -29077,6 +29076,7 @@
         "@netlify/zip-it-and-ship-it": "^3.2.0",
         "@sindresorhus/slugify": "^1.1.0",
         "@ungap/from-entries": "^0.2.1",
+        "ansi-escapes": "^4.3.2",
         "array-flat-polyfill": "^1.0.1",
         "atob": "^2.1.2",
         "ava": "^2.4.0",
@@ -31560,7 +31560,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
       }
@@ -44616,8 +44615,7 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -62,6 +62,7 @@
     "@netlify/zip-it-and-ship-it": "^3.2.0",
     "@sindresorhus/slugify": "^1.1.0",
     "@ungap/from-entries": "^0.2.1",
+    "ansi-escapes": "^4.3.2",
     "array-flat-polyfill": "^1.0.1",
     "chalk": "^3.0.0",
     "clean-stack": "^2.2.0",

--- a/packages/build/src/log/messages/core.js
+++ b/packages/build/src/log/messages/core.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { link } = require('ansi-escapes')
 const prettyMs = require('pretty-ms')
 
 const { name, version } = require('../../../package.json')
@@ -41,6 +42,9 @@ const logTimer = function (logs, durationNs, timerName) {
   log(logs, THEME.dimWords(`(${timerName} completed in ${duration})`))
 }
 
+// @todo use `terminal-link` (https://github.com/sindresorhus/terminal-link)
+// instead of `ansi-escapes` once
+// https://github.com/jamestalmage/supports-hyperlinks/pull/12 is fixed
 const logLingeringProcesses = function (logs, commands) {
   logWarning(
     logs,
@@ -52,7 +56,10 @@ The build completed successfully, but the following processes were still running
   logWarning(
     logs,
     `
-These processes have been terminated. In case this creates a problem for your build, refer to [this article](https://answers.netlify.com/t/support-guide-how-to-address-the-warning-message-related-to-terminating-processes-in-builds/35277) for details about why this process termination happens and how to fix it.`,
+These processes have been terminated. In case this creates a problem for your build, refer to this ${link(
+      'article',
+      'https://answers.netlify.com/t/support-guide-how-to-address-the-warning-message-related-to-terminating-processes-in-builds/35277',
+    )} for details about why this process termination happens and how to fix it.`,
   )
 }
 


### PR DESCRIPTION
A warning message is including a link as Markdown. However, we don't support Markdown using `console.log()` :man_facepalming: 

Instead, this PR switches it to an OSC hyperlink.

This properly works. [Example build logs](https://app.netlify.com/sites/mick/deploys/607090e64d1fe20007f2403b#L224)