### PR TITLE
chore: add p-reduce and path-key to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,6 +36,8 @@
         'update-notifier',
         'yargs',
         // Those cannot be upgraded to a major version until we drop support for Node 10
+        'p-reduce',
+        'path-key',
         'path-type',
         'read-pkg-up',
       ],


### PR DESCRIPTION
Those dependencies now need Node 12