### PR TITLE
fix: `@netlify/config` major release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23688,7 +23688,7 @@
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^1.0.7",
-        "@netlify/config": "^5.1.0",
+        "@netlify/config": "^6.0.0",
         "@netlify/functions-utils": "^1.3.13",
         "@netlify/git-utils": "^1.0.8",
         "@netlify/plugin-edge-handlers": "^1.11.6",
@@ -28873,7 +28873,7 @@
       "requires": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^1.0.7",
-        "@netlify/config": "^5.1.0",
+        "@netlify/config": "^6.0.0",
         "@netlify/functions-utils": "^1.3.13",
         "@netlify/git-utils": "^1.0.8",
         "@netlify/plugin-edge-handlers": "^1.11.6",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bugsnag/js": "^7.0.0",
     "@netlify/cache-utils": "^1.0.7",
-    "@netlify/config": "^5.1.0",
+    "@netlify/config": "^6.0.0",
     "@netlify/functions-utils": "^1.3.13",
     "@netlify/git-utils": "^1.0.8",
     "@netlify/plugin-edge-handlers": "^1.11.6",


### PR DESCRIPTION
This fixes tests failing due to not upgrading the new major release of `@netlify/config`.