### PR TITLE
chore: rename default branch from master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,4 +35,4 @@ please copy/paste the deploy logs below instead.
 **Pull requests**
 
 Pull requests are welcome! If you would like to help us fix this bug, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,5 +36,5 @@ Yes/No.
 
 <!--
 Pull requests are welcome! If you would like to help us add this feature, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,5 +26,5 @@ Example: Another solution would be [...]
 
 Please add a `x` inside each checkbox:
 
-- [ ] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
+- [ ] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
 - [ ] The status checks are successful (continuous integration). Those can be seen below.

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release-package:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   # Ensure GitHub actions are not run twice for same commits
   push:
-    branches: [master]
+    branches: [main]
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Netlify Build](build.png)
 
-[![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
+[![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
 Netlify Build runs the build command and Build Plugins and bundles Netlify Functions.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  strict_yaml_branch: master
+  strict_yaml_branch: main
 coverage:
   range: [80, 100]
   parsers:

--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
+[![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
 Utility for caching files in Netlify Build.

--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
+[![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
 Utility for handling Netlify Functions in Netlify Build plugins.

--- a/packages/git-utils/README.md
+++ b/packages/git-utils/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
+[![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
 # Git Utility

--- a/packages/run-utils/README.md
+++ b/packages/run-utils/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://codecov.io/gh/netlify/build/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/build)
+[![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
 Utility for running commands inside Netlify Build. Currently, there is just one utility, `run`, which is a thin wrapper


### PR DESCRIPTION
Aligns this repo with our other repos

I haven't done the renaming yet - I'll do it + merge the PR at the same time

> We also have other references to `master` in our codebase:
https://github.com/netlify/build/blob/5be097a578c0e1b1459901724a075708a4cae59f/packages/config/src/options/branch.js#L30
https://github.com/netlify/build/blob/5be097a578c0e1b1459901724a075708a4cae59f/packages/git-utils/src/refs.js#L34
We should think about on how to address those separately