### PR TITLE
fix: fix `utils.git` for repositories with `main` branch

### DIFF
--- a/packages/git-utils/src/refs.js
+++ b/packages/git-utils/src/refs.js
@@ -29,9 +29,9 @@ const getBaseRefs = function (base, head) {
     return [env.CACHED_COMMIT_REF]
   }
 
-  // Some git repositories are missing `master` branches, so we also try HEAD^.
+  // Some git repositories are missing `master` or `main` branches, so we also try HEAD^.
   // We end with HEAD as a failsafe.
-  return ['master', `${head}^`, head]
+  return ['main', 'master', `${head}^`, head]
 }
 
 // Use the first commit that exists


### PR DESCRIPTION
This ensures `utils.git` works for repositories with a `main` branch (as opposed to `master`).

This only impacts local builds.

`main` has priority over `master`, but this should not be a breaking change unless a repository has both branches, which seems unlikely. Note: if neither is present, `HEAD` is used instead.