### PR TITLE
fix: support `main` branch in `@netlify/config`

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -67,7 +67,7 @@ const exampleFunction = async function () {
   // "configPath": "/home/me/cv-website/netlify.toml",
   // "buildDir": "/home/me/cv-website",
   // "context": "production",
-  // "branch": "master",
+  // "branch": "main",
   // "siteInfo": {
   //     "id": "418b94bc-93cd-411a-937a-ae4c734f17c4",
   //     "name": "mick",
@@ -179,7 +179,7 @@ The `netlify.toml` can contain `contexts.{CONTEXT}` properties, which are like `
 #### branch
 
 _Type_: `string`\
-_Default value_: environment variable `BRANCH`, current `git` branch, or `"master"`
+_Default value_: environment variable `BRANCH`, current `git` branch, `"main"` or `"master"`.
 
 Same as [`context`](#context) but using a `git` branch name.
 

--- a/packages/config/src/options/branch.js
+++ b/packages/config/src/options/branch.js
@@ -5,24 +5,30 @@ const execa = require('execa')
 // Find out git branch among (in priority order):
 //   - `branch` option
 //   - `BRANCH` environment variable
-//   - Running `git`
+//   - `HEAD` branch (using `git`)
+//   - `main` (using `git`)
 //   - 'master' (fallback)
 const getBranch = async function ({ branch, repositoryRoot }) {
   if (branch) {
     return branch
   }
 
-  const gitBranch = await getGitBranch(repositoryRoot)
-  if (gitBranch !== undefined) {
-    return gitBranch
+  const headBranch = await getGitBranch(repositoryRoot, 'HEAD')
+  if (headBranch !== undefined) {
+    return headBranch
+  }
+
+  const mainBranch = await getGitBranch(repositoryRoot, 'main')
+  if (mainBranch !== undefined) {
+    return mainBranch
   }
 
   return FALLBACK_BRANCH
 }
 
-const getGitBranch = async function (repositoryRoot) {
+const getGitBranch = async function (repositoryRoot, gitRef) {
   try {
-    const { stdout } = await execa.command('git rev-parse --abbrev-ref HEAD', { cwd: repositoryRoot })
+    const { stdout } = await execa.command(`git rev-parse --abbrev-ref ${gitRef}`, { cwd: repositoryRoot })
     return stdout
   } catch (error) {}
 }


### PR DESCRIPTION
`@netlify/config` uses the git branch to apply branch-specific context configuration.

In production, this is [passed by the buildbot](https://github.com/netlify/buildbot/blob/b47b671c7e5601877c51968241eb899bf590a815/bot/configuration.go#L124).

In local builds, we use the `--branch` CLI flag. If undefined, we use the branch of `HEAD`. If this is also undefined, this means the user has done a `git checkout` outside of a branch, which is very unlikely. In that unlikely scenario, we use `master`. This PR adds an additional check for a `main` branch, if it exists, before falling back to `master`.