### PR TITLE
fix(deps): memoize-one cjs exports breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16688,9 +16688,9 @@
       "dev": true
     },
     "node_modules/memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
+      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -23713,7 +23713,7 @@
         "log-process-errors": "^5.1.2",
         "make-dir": "^3.0.2",
         "map-obj": "^4.1.0",
-        "memoize-one": "^5.1.1",
+        "memoize-one": "^5.2.0",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
         "p-every": "^2.0.0",
@@ -28909,7 +28909,7 @@
         "log-process-errors": "^5.1.2",
         "make-dir": "^3.0.2",
         "map-obj": "^4.1.0",
-        "memoize-one": "^5.1.1",
+        "memoize-one": "^5.2.0",
         "moize": "^6.0.0",
         "nock": "^11.9.1",
         "os-name": "^3.1.0",
@@ -39177,9 +39177,9 @@
       "dev": true
     },
     "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
+      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -78,7 +78,7 @@
     "log-process-errors": "^5.1.2",
     "make-dir": "^3.0.2",
     "map-obj": "^4.1.0",
-    "memoize-one": "^5.1.1",
+    "memoize-one": "^5.2.0",
     "os-name": "^3.1.0",
     "p-event": "^4.1.0",
     "p-every": "^2.0.0",

--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Bugsnag = require('@bugsnag/js')
-const memoizeOne = require('memoize-one')
+const { memoizeOne } = require('memoize-one')
 
 const { name, version } = require('../../../package.json')
 const { log } = require('../../log/logger.js')

--- a/packages/build/src/plugins/child/lazy.js
+++ b/packages/build/src/plugins/child/lazy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const memoizeOne = require('memoize-one')
+const { memoizeOne } = require('memoize-one')
 
 // Add a `object[propName]` whose value is the return value of `getFunc()`, but
 // is only retrieved when accessed.


### PR DESCRIPTION
**Which problem is this pull request solving?**

The latest release of `memoize-one` introduced a breaking change for the `cjs` exports - https://github.com/alexreardon/memoize-one/releases/tag/v5.2.0 - this PR addresses those.

**List other issues or pull requests related to this problem**

Fixes #2642 

