### PR TITLE
fix(deps): memoize-one breaking change in exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16688,9 +16688,9 @@
       "dev": true
     },
     "node_modules/memoize-one": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
-      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -23683,7 +23683,7 @@
     },
     "packages/build": {
       "name": "@netlify/build",
-      "version": "11.2.3",
+      "version": "11.2.4",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
@@ -23713,7 +23713,7 @@
         "log-process-errors": "^5.1.2",
         "make-dir": "^3.0.2",
         "map-obj": "^4.1.0",
-        "memoize-one": "^5.2.0",
+        "memoize-one": "^5.2.1",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
         "p-every": "^2.0.0",
@@ -24447,7 +24447,7 @@
     },
     "packages/config": {
       "name": "@netlify/config",
-      "version": "6.0.2",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "@ungap/from-entries": "^0.2.1",
@@ -24772,7 +24772,7 @@
     },
     "packages/functions-utils": {
       "name": "@netlify/functions-utils",
-      "version": "1.3.27",
+      "version": "1.3.28",
       "license": "MIT",
       "dependencies": {
         "@netlify/zip-it-and-ship-it": "^3.7.0",
@@ -24847,7 +24847,7 @@
     },
     "packages/git-utils": {
       "name": "@netlify/git-utils",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "execa": "^3.4.0",
@@ -28921,7 +28921,7 @@
         "log-process-errors": "^5.1.2",
         "make-dir": "^3.0.2",
         "map-obj": "^4.1.0",
-        "memoize-one": "^5.2.0",
+        "memoize-one": "^5.2.1",
         "moize": "^6.0.0",
         "nock": "^11.9.1",
         "os-name": "^3.1.0",
@@ -39195,9 +39195,9 @@
       "dev": true
     },
     "memoize-one": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
-      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -78,7 +78,7 @@
     "log-process-errors": "^5.1.2",
     "make-dir": "^3.0.2",
     "map-obj": "^4.1.0",
-    "memoize-one": "^5.2.0",
+    "memoize-one": "^5.2.1",
     "os-name": "^3.1.0",
     "p-event": "^4.1.0",
     "p-every": "^2.0.0",

--- a/packages/build/src/error/monitor/start.js
+++ b/packages/build/src/error/monitor/start.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Bugsnag = require('@bugsnag/js')
-const { memoizeOne } = require('memoize-one')
+const memoizeOne = require('memoize-one')
 
 const { name, version } = require('../../../package.json')
 const { log } = require('../../log/logger.js')

--- a/packages/build/src/plugins/child/lazy.js
+++ b/packages/build/src/plugins/child/lazy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { memoizeOne } = require('memoize-one')
+const memoizeOne = require('memoize-one')
 
 // Add a `object[propName]` whose value is the return value of `getFunc()`, but
 // is only retrieved when accessed.


### PR DESCRIPTION
Addresses https://github.com/alexreardon/memoize-one/releases/tag/v5.2.1 and its latest changes to the exports.
