### PR TITLE
chore: do not upgrade modules using ES modules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,13 @@
         'path-key',
         'path-type',
         'read-pkg-up',
+        // Those cannot be upgraded to using ES modules
+        'ansi-escapes',
+        'has-ansi',
+        'indent-string',
+        'string-width',
+        'strip-ansi',
+        '@sindresorhus/slugify',
       ],
       major: {
         enabled: false,


### PR DESCRIPTION
Do not upgrade modules that use ES modules.