### PR TITLE
fix: use the proper conventional commit in PR title

### DIFF
--- a/packages/build/src/plugins/pinned_version.js
+++ b/packages/build/src/plugins/pinned_version.js
@@ -21,7 +21,7 @@ const pinPlugins = async function ({
   sendStatus,
 }) {
   // @todo remove this after the API bug with `updateSite` is fixed
-  if (mode !== 'require' && siteId !== 'test') {
+  if (siteId !== 'test' && mode !== 'require') {
     return
   }
 


### PR DESCRIPTION
The previous PR used the wrong conventional commit prefix, which prevented `release-please` from creating a release PR.