### PR TITLE
fix: improve temporary fix for the `updatePlugin` bug

### DIFF
--- a/packages/build/src/plugins/pinned_version.js
+++ b/packages/build/src/plugins/pinned_version.js
@@ -21,7 +21,7 @@ const pinPlugins = async function ({
   sendStatus,
 }) {
   // @todo remove this after the API bug with `updateSite` is fixed
-  if (siteId !== 'test' && mode !== 'require') {
+  if (siteId !== 'test' || mode !== 'require') {
     return
   }
 


### PR DESCRIPTION
This is a small improvement over https://github.com/netlify/build/pull/2693, which ensures the fix works even if `siteId` is `test`.
I do not think `siteId` can be `test` in production since I'd assume it is always a UUID, but this is just in case.