### PR TITLE
fix: percent-encode the `package` parameter of the `updatePlugin` endpoint

### DIFF
--- a/packages/build/src/plugins/pinned_version.js
+++ b/packages/build/src/plugins/pinned_version.js
@@ -73,7 +73,11 @@ const pinPlugin = async function ({
 }) {
   const pinnedVersion = String(major(version))
   try {
-    await api.updatePlugin({ package: packageName, site_id: siteId, body: { pinned_version: pinnedVersion } })
+    await api.updatePlugin({
+      package: encodeURIComponent(packageName),
+      site_id: siteId,
+      body: { pinned_version: pinnedVersion },
+    })
     // Bitballoon API randomly fails with 502.
     // Builds should be successful when this API call fails, but we still want
     // to report the error both in logs and in error monitoring.


### PR DESCRIPTION
Fixes https://github.com/netlify/build/issues/2700

The `packageName` request to `updatePlugin` should be URI-encoded. The `js-client` does not currently do this by default. (see https://github.com/netlify/js-client/issues/404)