### PR TITLE
chore: upgrade `@netlify/plugins-list` and `js-client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5000,9 +5000,9 @@
       }
     },
     "node_modules/@netlify/plugins-list": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.10.0.tgz",
-      "integrity": "sha512-JaK6604NU21J1akEsw2MBorZkKwCsfrosWmtQKjK+5qhuDBWsNlvmpzbIUwvHezKdCopozwec9hVEVrDSLsNWQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.11.0.tgz",
+      "integrity": "sha512-/KCWSNDsTx+57MaAT2eyx1Onr7VxHwTobnIKh1WixXMWX762a/5aWijhh6KmkmdpwKdtLdKQgheeeHTvGXnbWA==",
       "engines": {
         "node": ">=8.3.0"
       }
@@ -17376,9 +17376,9 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "node_modules/netlify": {
-      "version": "6.1.27",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-6.1.27.tgz",
-      "integrity": "sha512-vGz23QlLRyepXMMu3YbJHdp2gV2Ti9G56e8wTqfTuyJiv57A4fBviJmS2Viw6LMDi1cQvwVWSxkuPcVSJ9R3cw==",
+      "version": "6.1.29",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-6.1.29.tgz",
+      "integrity": "sha512-Xr26CcTLt7ChN2cWysCWbAItJHmTufVhVkF3VEd25uOtBNufvg674Amw6bkyWwvfGJzrNP+tj07YVtsQGdlOZQ==",
       "dependencies": {
         "@netlify/open-api": "^2.4.0",
         "@netlify/zip-it-and-ship-it": "^3.9.1",
@@ -23769,7 +23769,7 @@
     },
     "packages/build": {
       "name": "@netlify/build",
-      "version": "11.10.0",
+      "version": "11.12.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
@@ -23778,7 +23778,7 @@
         "@netlify/functions-utils": "^1.3.13",
         "@netlify/git-utils": "^1.0.8",
         "@netlify/plugin-edge-handlers": "^1.11.7",
-        "@netlify/plugins-list": "^2.10.0",
+        "@netlify/plugins-list": "^2.11.0",
         "@netlify/run-utils": "^1.0.6",
         "@netlify/zip-it-and-ship-it": "^3.9.1",
         "@sindresorhus/slugify": "^1.1.0",
@@ -24549,7 +24549,7 @@
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^4.0.0",
         "map-obj": "^4.0.0",
-        "netlify": "^6.1.27",
+        "netlify": "^6.1.29",
         "omit.js": "^2.0.2",
         "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
@@ -29015,7 +29015,7 @@
         "@netlify/functions-utils": "^1.3.13",
         "@netlify/git-utils": "^1.0.8",
         "@netlify/plugin-edge-handlers": "^1.11.7",
-        "@netlify/plugins-list": "^2.10.0",
+        "@netlify/plugins-list": "^2.11.0",
         "@netlify/run-utils": "^1.0.6",
         "@netlify/zip-it-and-ship-it": "^3.9.1",
         "@sindresorhus/slugify": "^1.1.0",
@@ -29587,7 +29587,7 @@
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^4.0.0",
         "map-obj": "^4.0.0",
-        "netlify": "^6.1.27",
+        "netlify": "^6.1.29",
         "omit.js": "^2.0.2",
         "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
@@ -30038,9 +30038,9 @@
       }
     },
     "@netlify/plugins-list": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.10.0.tgz",
-      "integrity": "sha512-JaK6604NU21J1akEsw2MBorZkKwCsfrosWmtQKjK+5qhuDBWsNlvmpzbIUwvHezKdCopozwec9hVEVrDSLsNWQ=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.11.0.tgz",
+      "integrity": "sha512-/KCWSNDsTx+57MaAT2eyx1Onr7VxHwTobnIKh1WixXMWX762a/5aWijhh6KmkmdpwKdtLdKQgheeeHTvGXnbWA=="
     },
     "@netlify/run-utils": {
       "version": "file:packages/run-utils",
@@ -39848,9 +39848,9 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "6.1.27",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-6.1.27.tgz",
-      "integrity": "sha512-vGz23QlLRyepXMMu3YbJHdp2gV2Ti9G56e8wTqfTuyJiv57A4fBviJmS2Viw6LMDi1cQvwVWSxkuPcVSJ9R3cw==",
+      "version": "6.1.29",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-6.1.29.tgz",
+      "integrity": "sha512-Xr26CcTLt7ChN2cWysCWbAItJHmTufVhVkF3VEd25uOtBNufvg674Amw6bkyWwvfGJzrNP+tj07YVtsQGdlOZQ==",
       "requires": {
         "@netlify/open-api": "^2.4.0",
         "@netlify/zip-it-and-ship-it": "^3.9.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -57,7 +57,7 @@
     "@netlify/functions-utils": "^1.3.13",
     "@netlify/git-utils": "^1.0.8",
     "@netlify/plugin-edge-handlers": "^1.11.7",
-    "@netlify/plugins-list": "^2.10.0",
+    "@netlify/plugins-list": "^2.11.0",
     "@netlify/run-utils": "^1.0.6",
     "@netlify/zip-it-and-ship-it": "^3.9.1",
     "@sindresorhus/slugify": "^1.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -62,7 +62,7 @@
     "is-plain-obj": "^2.1.0",
     "js-yaml": "^4.0.0",
     "map-obj": "^4.0.0",
-    "netlify": "^6.1.27",
+    "netlify": "^6.1.29",
     "omit.js": "^2.0.2",
     "p-locate": "^4.1.0",
     "path-exists": "^4.0.0",


### PR DESCRIPTION
This upgrades `@netlify/plugins-list` and `js-client` without upgrading `zip-it-and-ship-it` yet (see https://github.com/netlify/build/pull/2771)