### PR TITLE
feat: change shape of `compatibility` field

### DIFF
--- a/packages/build/src/plugins/list.js
+++ b/packages/build/src/plugins/list.js
@@ -60,8 +60,16 @@ const normalizePluginsList = function (pluginsList) {
 //  - Is sorted from the highest to lowest version.
 //  - Does not include the latest `version`.
 const normalizePluginItem = function ({ package: packageName, version, compatibility = [] }) {
-  const normalizedCompatibility = compatibility.map(normalizeCompatVersion)
-  return [packageName, { version, compatibility: normalizedCompatibility }]
+  const normalizedCompatibility = addLatestVersion(compatibility, version)
+  const normalizedCompatibilityA = normalizedCompatibility.map(normalizeCompatVersion)
+  return [packageName, { version, compatibility: normalizedCompatibilityA }]
+}
+
+// TODO: remove once `netlify/plugins` validates that `compatibility` includes
+// the latest `version`
+const addLatestVersion = function (compatibility, version) {
+  const hasLastestVersion = compatibility.some((compatibleEntry) => compatibleEntry.version === version)
+  return hasLastestVersion ? compatibility : [{ version }, ...compatibility]
 }
 
 const normalizeCompatVersion = function ({ version, migrationGuide, ...conditions }) {


### PR DESCRIPTION
As a first step to fix #2788, this PR adds the `version` property in `plugins.json` as a first item in the `compatibility` array.

Once this is done and released, I will update the `plugins.json` to change the few plugins in `plugins.json` with a `compatibility` array so they include the latest version. I will then add some validation in the automated tests in `netlify/plugins`.

Once this is done, this PR can be reverted.