### PR TITLE
feat: simplify version pinning logic

### DIFF
--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -28,8 +28,8 @@ const logPluginsList = function ({ pluginsList, debug, logs }) {
   logArray(logs, pluginsListArray)
 }
 
-const getPluginsListItem = function ([packageName, { version }]) {
-  return `${packageName}@${version}`
+const getPluginsListItem = function ([packageName, versions]) {
+  return `${packageName}@${versions[0].version}`
 }
 
 const logLoadingPlugins = function (logs, pluginsOptions, debug) {
@@ -118,7 +118,7 @@ const getOutdatedPlugin = function ({ packageName, pluginPackageJson: { version 
 }
 
 const getOutdatedDescription = function (latestVersion, compatWarning) {
-  if (compatWarning === undefined) {
+  if (compatWarning === '') {
     return `latest version is ${latestVersion}`
   }
 
@@ -141,7 +141,7 @@ const logIncompatiblePlugins = function (logs, pluginsOptions) {
 
 const hasIncompatibleVersion = function ({ pluginPackageJson: { version }, compatibleVersion, compatWarning }) {
   return (
-    compatWarning !== undefined &&
+    compatWarning !== '' &&
     version !== undefined &&
     compatibleVersion !== undefined &&
     // Using only the major version prevents printing this warning message when

--- a/packages/build/src/plugins/expected_version.js
+++ b/packages/build/src/plugins/expected_version.js
@@ -50,10 +50,11 @@ const addExpectedVersion = async function ({
     return pluginOptions
   }
 
-  const { version: latestVersion, compatibility } = pluginsList[packageName]
+  const versions = pluginsList[packageName]
+  const latestVersion = versions[0].version
   const [{ version: expectedVersion }, { version: compatibleVersion, compatWarning }] = await Promise.all([
-    getExpectedVersion({ latestVersion, compatibility, nodeVersion, packageJson, buildDir, pinnedVersion }),
-    getExpectedVersion({ latestVersion, compatibility, nodeVersion, packageJson, buildDir }),
+    getExpectedVersion({ versions, nodeVersion, packageJson, buildDir, pinnedVersion }),
+    getExpectedVersion({ versions, nodeVersion, packageJson, buildDir }),
   ])
 
   const isMissing = await isMissingVersion({ autoPluginsDir, packageName, pluginPath, loadedFrom, expectedVersion })

--- a/packages/build/src/plugins/list.js
+++ b/packages/build/src/plugins/list.js
@@ -60,16 +60,9 @@ const normalizePluginsList = function (pluginsList) {
 //  - Is sorted from the highest to lowest version.
 //  - Does not include the latest `version`.
 const normalizePluginItem = function ({ package: packageName, version, compatibility = [] }) {
-  const normalizedCompatibility = addLatestVersion(compatibility, version)
-  const normalizedCompatibilityA = normalizedCompatibility.map(normalizeCompatVersion)
-  return [packageName, { version, compatibility: normalizedCompatibilityA }]
-}
-
-// TODO: remove once `netlify/plugins` validates that `compatibility` includes
-// the latest `version`
-const addLatestVersion = function (compatibility, version) {
-  const hasLastestVersion = compatibility.some((compatibleEntry) => compatibleEntry.version === version)
-  return hasLastestVersion ? compatibility : [{ version }, ...compatibility]
+  const versions = compatibility.length === 0 ? [{ version }] : compatibility
+  const versionsA = versions.map(normalizeCompatVersion)
+  return [packageName, versionsA]
 }
 
 const normalizeCompatVersion = function ({ version, migrationGuide, ...conditions }) {

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -597,8 +597,7 @@ test('Prints outdated plugins installed in package.json', async (t) => {
 test('Prints incompatible plugins installed in package.json', async (t) => {
   await runWithApiMock(t, 'plugins_incompatible_package_json', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', nodeVersion: '<100' }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0', nodeVersion: '<100' }],
     },
   })
 })
@@ -606,8 +605,7 @@ test('Prints incompatible plugins installed in package.json', async (t) => {
 test('Does not print incompatible plugins installed in package.json if major version is same', async (t) => {
   await runWithApiMock(t, 'plugins_incompatible_package_json_same_major', {
     testPlugin: {
-      version: '0.4.0',
-      compatibility: [{ version: '0.4.1', nodeVersion: '<100' }],
+      compatibility: [{ version: '0.4.0' }, { version: '0.4.1', nodeVersion: '<100' }],
     },
   })
 })
@@ -621,8 +619,8 @@ test.serial('Plugins can specify non-matching compatibility.nodeVersion', async 
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
       compatibility: [
+        { version: '0.3.0' },
         { version: '0.2.0', nodeVersion: '100 - 120' },
         { version: '0.1.0', nodeVersion: '<100' },
       ],
@@ -634,8 +632,7 @@ test.serial('Plugins ignore compatibility entries without conditions unless pinn
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0' }, { version: '0.1.0', nodeVersion: '<100' }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0' }, { version: '0.1.0', nodeVersion: '<100' }],
     },
   })
 })
@@ -644,8 +641,7 @@ test.serial('Plugins does not ignore compatibility entries without conditions if
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0' }, { version: '0.1.0' }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0' }, { version: '0.1.0' }],
     },
     defaultConfig: { plugins: [{ package: TEST_PLUGIN_NAME, pinned_version: '0.2.0' }] },
   })
@@ -655,8 +651,7 @@ test.serial('Plugins ignore compatibility conditions if pinned', async (t) => {
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', nodeVersion: '100 - 200' }, { version: '0.1.0' }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0', nodeVersion: '100 - 200' }, { version: '0.1.0' }],
     },
     defaultConfig: { plugins: [{ package: TEST_PLUGIN_NAME, pinned_version: '0.2.0' }] },
   })
@@ -666,8 +661,8 @@ test.serial('Plugins can specify matching compatibility.nodeVersion', async (t) 
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
       compatibility: [
+        { version: '0.3.0' },
         { version: '0.2.0', nodeVersion: '6 - 120' },
         { version: '0.1.0', nodeVersion: '<6' },
       ],
@@ -679,8 +674,8 @@ test.serial('Plugins compatibility defaults to version field', async (t) => {
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
       compatibility: [
+        { version: '0.3.0' },
         { version: '0.2.0', nodeVersion: '4 - 6' },
         { version: '0.1.0', nodeVersion: '<4' },
       ],
@@ -692,8 +687,8 @@ test.serial('Plugins can specify compatibility.migrationGuide', async (t) => {
   await removeDir(`${FIXTURES_DIR}/plugins_compat_node_version/.netlify`)
   await runWithApiMock(t, 'plugins_compat_node_version', {
     testPlugin: {
-      version: '0.3.0',
       compatibility: [
+        { version: '0.3.0' },
         { version: '0.2.0', nodeVersion: '100 - 120' },
         { version: '0.1.0', nodeVersion: '<100', migrationGuide: 'http://test.com' },
       ],
@@ -705,8 +700,7 @@ test.serial('Plugins can specify matching compatibility.siteDependencies', async
   await removeDir(`${FIXTURES_DIR}/plugins_compat_site_dependencies/.netlify`)
   await runWithApiMock(t, 'plugins_compat_site_dependencies', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', siteDependencies: { 'ansi-styles': '<3' } }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0', siteDependencies: { 'ansi-styles': '<3' } }],
     },
   })
 })
@@ -715,8 +709,7 @@ test.serial('Plugins can specify non-matching compatibility.siteDependencies', a
   await removeDir(`${FIXTURES_DIR}/plugins_compat_site_dependencies/.netlify`)
   await runWithApiMock(t, 'plugins_compat_site_dependencies', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', siteDependencies: { 'ansi-styles': '<2' } }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0', siteDependencies: { 'ansi-styles': '<2' } }],
     },
   })
 })
@@ -725,8 +718,7 @@ test.serial('Plugins can specify non-existing compatibility.siteDependencies', a
   await removeDir(`${FIXTURES_DIR}/plugins_compat_site_dependencies/.netlify`)
   await runWithApiMock(t, 'plugins_compat_site_dependencies', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', siteDependencies: { 'does-not-exist': '<3' } }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0', siteDependencies: { 'does-not-exist': '<3' } }],
     },
   })
 })
@@ -735,8 +727,10 @@ test.serial('Plugins can specify multiple non-matching compatibility conditions'
   await removeDir(`${FIXTURES_DIR}/plugins_compat_site_dependencies/.netlify`)
   await runWithApiMock(t, 'plugins_compat_site_dependencies', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', siteDependencies: { 'ansi-styles': '<3' }, nodeVersion: '100 - 120' }],
+      compatibility: [
+        { version: '0.3.0' },
+        { version: '0.2.0', siteDependencies: { 'ansi-styles': '<3' }, nodeVersion: '100 - 120' },
+      ],
     },
   })
 })
@@ -745,8 +739,10 @@ test.serial('Plugins can specify multiple matching compatibility conditions', as
   await removeDir(`${FIXTURES_DIR}/plugins_compat_site_dependencies/.netlify`)
   await runWithApiMock(t, 'plugins_compat_site_dependencies', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', siteDependencies: { 'ansi-styles': '<3' }, nodeVersion: '<100' }],
+      compatibility: [
+        { version: '0.3.0' },
+        { version: '0.2.0', siteDependencies: { 'ansi-styles': '<3' }, nodeVersion: '<100' },
+      ],
     },
   })
 })
@@ -755,8 +751,7 @@ test.serial('Plugins can specify non-matching compatibility.siteDependencies ran
   await removeDir(`${FIXTURES_DIR}/plugins_compat_site_dependencies_range/.netlify`)
   await runWithApiMock(t, 'plugins_compat_site_dependencies_range', {
     testPlugin: {
-      version: '0.3.0',
-      compatibility: [{ version: '0.2.0', siteDependencies: { 'dependency-with-range': '<10' } }],
+      compatibility: [{ version: '0.3.0' }, { version: '0.2.0', siteDependencies: { 'dependency-with-range': '<10' } }],
     },
   })
 })
@@ -836,8 +831,8 @@ test('Pinning plugin versions takes into account the compatibility field', async
   await runWithUpdatePluginMock(t, 'pin_success', {
     flags: { defaultConfig: { plugins: [{ package: TEST_PLUGIN_NAME, pinned_version: '0' }] } },
     testPlugin: {
-      version: '1.0.0',
       compatibility: [
+        { version: '1.0.0' },
         { version: '100.0.0', nodeVersion: '<100' },
         { version: '0.3.0', nodeVersion: '<100' },
       ],


### PR DESCRIPTION
This fixes #2788.

Now that the `compatibility` field is either `undefined` or includes the latest version as the first item, some of the logic can be simplified, which this PR implements. 