### PR TITLE
feat: pass `netlifyConfig` to each event handler

### DIFF
--- a/packages/build/src/commands/plugin.js
+++ b/packages/build/src/commands/plugin.js
@@ -16,6 +16,7 @@ const firePluginCommand = async function ({
   loadedFrom,
   origin,
   envChanges,
+  netlifyConfig,
   constants,
   commands,
   error,
@@ -28,6 +29,7 @@ const firePluginCommand = async function ({
       event,
       error,
       envChanges,
+      netlifyConfig,
       constants,
     })
     const newStatus = getSuccessStatus(status, { commands, event, packageName })

--- a/packages/build/src/commands/run_command.js
+++ b/packages/build/src/commands/run_command.js
@@ -255,6 +255,7 @@ const tFireCommand = function ({
     loadedFrom,
     origin,
     envChanges,
+    netlifyConfig,
     constants,
     commands,
     error,

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -454,7 +454,6 @@ const runBuild = async function ({
   const { pluginsCommands, timers: timersA } = await loadPlugins({
     pluginsOptions,
     childProcesses,
-    netlifyConfig,
     packageJson,
     timers,
     debug,

--- a/packages/build/src/plugins/child/load.js
+++ b/packages/build/src/plugins/child/load.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { getLogic } = require('./logic')
-const { preventConfigMutations } = require('./mutations')
 const { validatePlugin } = require('./validate')
 
 // Load context passed to every plugin method.
@@ -9,17 +8,15 @@ const { validatePlugin } = require('./validate')
 // This also validates the plugin.
 // Do it when parent requests it using the `load` event.
 // Also figure out the list of plugin commands. This is also passed to the parent.
-const load = function ({ pluginPath, inputs, netlifyConfig, packageJson }) {
+const load = function ({ pluginPath, inputs, packageJson }) {
   const logic = getLogic({ pluginPath, inputs })
 
   validatePlugin(logic)
 
   const pluginCommands = getPluginCommands(logic)
 
-  const netlifyConfigA = preventConfigMutations(netlifyConfig)
-
   // Context passed to every event handler
-  const context = { pluginCommands, inputs, netlifyConfig: netlifyConfigA, packageJson }
+  const context = { pluginCommands, inputs, packageJson }
 
   return { pluginCommands, context }
 }

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -2,17 +2,19 @@
 
 const { getNewEnvChanges, setEnvChanges } = require('../../env/changes')
 
+const { preventConfigMutations } = require('./mutations')
 const { getUtils } = require('./utils')
 
 // Run a specific plugin event handler
 const run = async function (
-  { event, error, constants, envChanges },
-  { pluginCommands, inputs, netlifyConfig, packageJson },
+  { event, error, constants, envChanges, netlifyConfig },
+  { pluginCommands, inputs, packageJson },
 ) {
   const { method } = pluginCommands.find((pluginCommand) => pluginCommand.event === event)
   const runState = {}
   const utils = getUtils({ event, constants, runState })
-  const runOptions = { utils, constants, inputs, netlifyConfig, packageJson, error }
+  const netlifyConfigA = preventConfigMutations(netlifyConfig)
+  const runOptions = { utils, constants, inputs, netlifyConfig: netlifyConfigA, packageJson, error }
 
   const envBefore = setEnvChanges(envChanges)
   await method(runOptions)

--- a/packages/build/src/plugins/load.js
+++ b/packages/build/src/plugins/load.js
@@ -8,10 +8,10 @@ const { callChild } = require('./ipc')
 
 // Retrieve all plugins commands
 // Can use either a module name or a file path to the plugin.
-const tLoadPlugins = async function ({ pluginsOptions, childProcesses, netlifyConfig, packageJson, debug }) {
+const tLoadPlugins = async function ({ pluginsOptions, childProcesses, packageJson, debug }) {
   const pluginsCommands = await Promise.all(
     pluginsOptions.map((pluginOptions, index) =>
-      loadPlugin(pluginOptions, { childProcesses, index, netlifyConfig, packageJson, debug }),
+      loadPlugin(pluginOptions, { childProcesses, index, packageJson, debug }),
     ),
   )
   const pluginsCommandsA = pluginsCommands.flat()
@@ -24,13 +24,13 @@ const loadPlugins = measureDuration(tLoadPlugins, 'load_plugins')
 // Do it by executing the plugin `load` event handler.
 const loadPlugin = async function (
   { packageName, pluginPackageJson, pluginPackageJson: { version } = {}, pluginPath, inputs, loadedFrom, origin },
-  { childProcesses, index, netlifyConfig, packageJson, debug },
+  { childProcesses, index, packageJson, debug },
 ) {
   const { childProcess } = childProcesses[index]
   const loadEvent = 'load'
 
   try {
-    const { pluginCommands } = await callChild(childProcess, 'load', { pluginPath, inputs, netlifyConfig, packageJson })
+    const { pluginCommands } = await callChild(childProcess, 'load', { pluginPath, inputs, packageJson })
     const pluginCommandsA = pluginCommands.map(({ event }) => ({
       event,
       packageName,


### PR DESCRIPTION
Part of #1193 

At the moment, we pass `netlifyConfig` from the parent process to the plugin process only once, when the plugin starts. In order to make `netlifyConfig` mutable and ensure mutations propagate between plugins, we need to pass the latest `netlifyConfig` at the beginning of each plugin event handler instead. This PR implements this.