### PR TITLE
feat: pass mutated `netlifyConfig` everywhere

### DIFF
--- a/packages/build/src/commands/plugin.js
+++ b/packages/build/src/commands/plugin.js
@@ -16,6 +16,7 @@ const firePluginCommand = async function ({
   loadedFrom,
   origin,
   envChanges,
+  errorParams,
   netlifyConfig,
   constants,
   commands,
@@ -25,15 +26,21 @@ const firePluginCommand = async function ({
   const listeners = pipePluginOutput(childProcess, logs)
 
   try {
-    const { newEnvChanges, status } = await callChild(childProcess, 'run', {
+    const {
+      newEnvChanges,
+      netlifyConfig: netlifyConfigA,
+      status,
+    } = await callChild(childProcess, 'run', {
       event,
       error,
       envChanges,
       netlifyConfig,
       constants,
     })
+    // eslint-disable-next-line fp/no-mutation,no-param-reassign
+    errorParams.netlifyConfig = netlifyConfigA
     const newStatus = getSuccessStatus(status, { commands, event, packageName })
-    return { newEnvChanges, newStatus }
+    return { newEnvChanges, netlifyConfig: netlifyConfigA, newStatus }
   } catch (newError) {
     const errorType = getPluginErrorType(newError, loadedFrom)
     addErrorInfo(newError, {

--- a/packages/build/src/commands/return.js
+++ b/packages/build/src/commands/return.js
@@ -50,7 +50,7 @@ const getCommandReturn = function ({
   const timerName = getTimerName({ coreCommandName, buildCommand, packageName, event })
   logTimer(logs, durationNs, timerName)
 
-  return { newEnvChanges, newStatus, timers }
+  return { newEnvChanges, netlifyConfig, newStatus, timers }
 }
 
 const getTimerName = function ({ coreCommandName, buildCommand, packageName, event }) {

--- a/packages/build/src/commands/run_command.js
+++ b/packages/build/src/commands/run_command.js
@@ -40,6 +40,7 @@ const runCommand = async function ({
   api,
   errorMonitor,
   deployId,
+  errorParams,
   error,
   failedPlugins,
   netlifyConfig,
@@ -70,6 +71,7 @@ const runCommand = async function ({
   const fireCommand = getFireCommand({ packageName, buildCommand, coreCommandId, event })
   const {
     newEnvChanges,
+    netlifyConfig: netlifyConfigA = netlifyConfig,
     newError,
     newStatus,
     timers: timersA,
@@ -98,6 +100,7 @@ const runCommand = async function ({
     logs,
     timers,
     featureFlags,
+    errorParams,
     netlifyConfig,
   })
 
@@ -115,7 +118,7 @@ const runCommand = async function ({
     api,
     errorMonitor,
     deployId,
-    netlifyConfig,
+    netlifyConfig: netlifyConfigA,
     logs,
     debug,
     timers: timersA,
@@ -217,6 +220,7 @@ const tFireCommand = function ({
   error,
   logs,
   featureFlags,
+  errorParams,
   netlifyConfig,
 }) {
   if (coreCommand !== undefined) {
@@ -255,6 +259,7 @@ const tFireCommand = function ({
     loadedFrom,
     origin,
     envChanges,
+    errorParams,
     netlifyConfig,
     constants,
     commands,

--- a/packages/build/src/commands/run_commands.js
+++ b/packages/build/src/commands/run_commands.js
@@ -26,6 +26,7 @@ const runCommands = async function ({
   api,
   errorMonitor,
   deployId,
+  errorParams,
   netlifyConfig,
   logs,
   debug,
@@ -35,13 +36,14 @@ const runCommands = async function ({
   const {
     index: commandsCount,
     error: errorA,
+    netlifyConfig: netlifyConfigC,
     statuses: statusesB,
     failedPlugins: failedPluginsA,
     timers: timersC,
   } = await pReduce(
     commands,
     async (
-      { index, error, failedPlugins, envChanges, statuses, timers: timersA },
+      { index, error, failedPlugins, envChanges, netlifyConfig: netlifyConfigA, statuses, timers: timersA },
       {
         event,
         childProcess,
@@ -62,6 +64,7 @@ const runCommands = async function ({
         newError = error,
         failedPlugin = [],
         newEnvChanges = {},
+        netlifyConfig: netlifyConfigB = netlifyConfigA,
         newStatus,
         timers: timersB = timersA,
       } = await runCommand({
@@ -92,9 +95,10 @@ const runCommands = async function ({
         api,
         errorMonitor,
         deployId,
+        errorParams,
         error,
         failedPlugins,
-        netlifyConfig,
+        netlifyConfig: netlifyConfigA,
         logs,
         debug,
         timers: timersA,
@@ -106,11 +110,12 @@ const runCommands = async function ({
         error: newError,
         failedPlugins: [...failedPlugins, ...failedPlugin],
         envChanges: { ...envChanges, ...newEnvChanges },
+        netlifyConfig: netlifyConfigB,
         statuses: statusesA,
         timers: timersB,
       }
     },
-    { index: 0, failedPlugins: [], envChanges: {}, statuses: [], timers },
+    { index: 0, failedPlugins: [], envChanges: {}, netlifyConfig, statuses: [], timers },
   )
 
   // Instead of throwing any build failure right away, we wait for `onError`,
@@ -120,7 +125,13 @@ const runCommands = async function ({
     throw errorA
   }
 
-  return { commandsCount, statuses: statusesB, failedPlugins: failedPluginsA, timers: timersC }
+  return {
+    commandsCount,
+    netlifyConfig: netlifyConfigC,
+    statuses: statusesB,
+    failedPlugins: failedPluginsA,
+    timers: timersC,
+  }
 }
 
 module.exports = { runCommands }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -57,7 +57,15 @@ const build = async function (flags = {}) {
   const errorParams = { errorMonitor, mode, logs, debug, testOpts }
 
   try {
-    const { pluginsOptions, siteInfo, userNodeVersion, commandsCount, timers, durationNs } = await execBuild({
+    const {
+      pluginsOptions,
+      netlifyConfig: netlifyConfigA,
+      siteInfo,
+      userNodeVersion,
+      commandsCount,
+      timers,
+      durationNs,
+    } = await execBuild({
       ...flagsA,
       dry,
       errorMonitor,
@@ -87,7 +95,7 @@ const build = async function (flags = {}) {
       testOpts,
       errorParams,
     })
-    return { success, severityCode, logs }
+    return { success, severityCode, netlifyConfig: netlifyConfigA, logs }
   } catch (error) {
     const { severity } = await handleBuildError(error, errorParams)
     const { pluginsOptions, siteInfo, userNodeVersion } = errorParams
@@ -194,6 +202,7 @@ const tExecBuild = async function ({
 
   const {
     pluginsOptions: pluginsOptionsA,
+    netlifyConfig: netlifyConfigA,
     commandsCount,
     timers: timersB,
   } = await runAndReportBuild({
@@ -221,7 +230,14 @@ const tExecBuild = async function ({
     buildbotServerSocket,
     constants,
   })
-  return { pluginsOptions: pluginsOptionsA, siteInfo, userNodeVersion, commandsCount, timers: timersB }
+  return {
+    pluginsOptions: pluginsOptionsA,
+    netlifyConfig: netlifyConfigA,
+    siteInfo,
+    userNodeVersion,
+    commandsCount,
+    timers: timersB,
+  }
 }
 
 const execBuild = measureDuration(tExecBuild, 'total', { parentTag: 'build_site' })
@@ -255,6 +271,7 @@ const runAndReportBuild = async function ({
   try {
     const {
       commandsCount,
+      netlifyConfig: netlifyConfigA,
       statuses,
       pluginsOptions: pluginsOptionsA,
       failedPlugins,
@@ -291,7 +308,7 @@ const runAndReportBuild = async function ({
         api,
         mode,
         pluginsOptions: pluginsOptionsA,
-        netlifyConfig,
+        netlifyConfig: netlifyConfigA,
         errorMonitor,
         deployId,
         logs,
@@ -306,7 +323,7 @@ const runAndReportBuild = async function ({
         siteInfo,
         childEnv,
         mode,
-        netlifyConfig,
+        netlifyConfig: netlifyConfigA,
         errorMonitor,
         logs,
         debug,
@@ -315,7 +332,7 @@ const runAndReportBuild = async function ({
       }),
     ])
 
-    return { pluginsOptions: pluginsOptionsA, commandsCount, timers: timersA }
+    return { pluginsOptions: pluginsOptionsA, netlifyConfig: netlifyConfigA, commandsCount, timers: timersA }
   } catch (error) {
     const [{ statuses }] = getErrorInfo(error)
     await reportStatuses({
@@ -393,6 +410,7 @@ const initAndRunBuild = async function ({
   try {
     const {
       commandsCount,
+      netlifyConfig: netlifyConfigA,
       statuses,
       failedPlugins,
       timers: timersC,
@@ -413,6 +431,7 @@ const initAndRunBuild = async function ({
       api,
       errorMonitor,
       deployId,
+      errorParams,
       logs,
       debug,
       timers: timersB,
@@ -421,7 +440,14 @@ const initAndRunBuild = async function ({
 
     await warnOnLingeringProcesses({ mode, logs, testOpts })
 
-    return { commandsCount, statuses, pluginsOptions: pluginsOptionsA, failedPlugins, timers: timersC }
+    return {
+      commandsCount,
+      netlifyConfig: netlifyConfigA,
+      statuses,
+      pluginsOptions: pluginsOptionsA,
+      failedPlugins,
+      timers: timersC,
+    }
   } finally {
     stopPlugins(childProcesses)
   }
@@ -446,6 +472,7 @@ const runBuild = async function ({
   api,
   errorMonitor,
   deployId,
+  errorParams,
   logs,
   debug,
   timers,
@@ -463,11 +490,12 @@ const runBuild = async function ({
 
   if (dry) {
     doDryRun({ commands, constants, featureFlags, buildbotServerSocket, logs })
-    return {}
+    return { netlifyConfig }
   }
 
   const {
     commandsCount,
+    netlifyConfig: netlifyConfigA,
     statuses,
     failedPlugins,
     timers: timersB,
@@ -485,13 +513,14 @@ const runBuild = async function ({
     api,
     errorMonitor,
     deployId,
+    errorParams,
     netlifyConfig,
     logs,
     debug,
     timers: timersA,
     testOpts,
   })
-  return { commandsCount, statuses, failedPlugins, timers: timersB }
+  return { commandsCount, netlifyConfig: netlifyConfigA, statuses, failedPlugins, timers: timersB }
 }
 
 // Logs and reports that a build successfully ended

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -19,7 +19,7 @@ const run = async function (
   const envBefore = setEnvChanges(envChanges)
   await method(runOptions)
   const newEnvChanges = getNewEnvChanges(envBefore)
-  return { ...runState, newEnvChanges }
+  return { ...runState, newEnvChanges, netlifyConfig: netlifyConfigA }
 }
 
 module.exports = { run }


### PR DESCRIPTION
Part of #1193.

This PR propagates any mutation on `netlifyConfig` to: 
  - The next handlers of the same plugin
  - The next plugins
  - The return value of `@netlify/build` so it can be used by the `netlify build` and `netlify deploy --build` CLI commands

This cannot be tested yet (except for ensuring the current tests are still passing) since all `netlifyConfig` properties are currently read-only.