### PR TITLE
chore: update package dependency graph in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,7 @@ Linting and tests will automatically run before publish.
 Packages dependencies graph:
 
 ```
-@netlify/zip-it-and-ship-it -> js-client
-                            -> @netlify/function-utils
+@netlify/zip-it-and-ship-it -> @netlify/function-utils
                             -> @netlify/build
                             -> netlify-cli
 js-client                   -> @netlify/config


### PR DESCRIPTION
With https://github.com/netlify/js-client/releases/tag/v7.0.0, `zip-it-and-ship-it` is no longer a dependency of `js-client`. 🎉 