### PR TITLE
feat: add support for experimental ZISI v2 handler

### DIFF
--- a/packages/build/src/commands/core_command.js
+++ b/packages/build/src/commands/core_command.js
@@ -17,6 +17,7 @@ const fireCoreCommand = async function ({
   childEnv,
   envChanges,
   netlifyConfig,
+  featureFlags,
 }) {
   try {
     const childEnvA = setEnvChanges(envChanges, { ...childEnv })
@@ -30,6 +31,7 @@ const fireCoreCommand = async function ({
       childEnv: childEnvA,
       netlifyConfig,
       nodePath,
+      featureFlags,
     })
   } catch (newError) {
     if (!isBuildError(newError)) {

--- a/packages/build/src/commands/run_command.js
+++ b/packages/build/src/commands/run_command.js
@@ -45,6 +45,7 @@ const runCommand = async function ({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   const constantsA = await addMutableConstants({ constants, buildDir, netlifyConfig })
 
@@ -96,6 +97,7 @@ const runCommand = async function ({
     timers,
     errorParams,
     netlifyConfig,
+    featureFlags,
   })
 
   const newValues = await getCommandReturn({
@@ -208,6 +210,7 @@ const tFireCommand = function ({
   logs,
   errorParams,
   netlifyConfig,
+  featureFlags,
 }) {
   if (coreCommand !== undefined) {
     return fireCoreCommand({
@@ -223,6 +226,7 @@ const tFireCommand = function ({
       childEnv,
       envChanges,
       netlifyConfig,
+      featureFlags,
     })
   }
 

--- a/packages/build/src/commands/run_commands.js
+++ b/packages/build/src/commands/run_commands.js
@@ -31,6 +31,7 @@ const runCommands = async function ({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   const {
     index: commandsCount,
@@ -99,6 +100,7 @@ const runCommands = async function ({
         debug,
         timers: timersA,
         testOpts,
+        featureFlags,
       })
       const statusesA = addStatus({ newStatus, statuses, event, packageName, pluginPackageJson })
       return {

--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { env } = require('process')
+
 // From `--featureFlags=a,b,c` to `{ a: true, b: true, c: true }`
 const normalizeFeatureFlags = function ({ featureFlags = '', ...rawFlags }) {
   const normalizedFeatureFlags = Object.assign({}, ...featureFlags.split(',').filter(isNotEmpty).map(getFeatureFlag))
@@ -15,6 +17,8 @@ const getFeatureFlag = function (name) {
 }
 
 // Default values for feature flags
-const DEFAULT_FEATURE_FLAGS = {}
+const DEFAULT_FEATURE_FLAGS = {
+  zisiHandlerV2: env.NETLIFY_EXPERIMENTAL_FUNCTION_HANDLER_V2 === 'true',
+}
 
 module.exports = { normalizeFeatureFlags, DEFAULT_FEATURE_FLAGS }

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -148,6 +148,7 @@ const tExecBuild = async function ({
   timers,
   buildbotServerSocket,
   sendStatus,
+  featureFlags,
 }) {
   const {
     netlifyConfig,
@@ -227,6 +228,7 @@ const tExecBuild = async function ({
     testOpts,
     buildbotServerSocket,
     constants,
+    featureFlags,
   })
   return {
     pluginsOptions: pluginsOptionsA,
@@ -264,6 +266,7 @@ const runAndReportBuild = async function ({
   timers,
   sendStatus,
   testOpts,
+  featureFlags,
 }) {
   try {
     const {
@@ -296,6 +299,7 @@ const runAndReportBuild = async function ({
       testOpts,
       buildbotServerSocket,
       constants,
+      featureFlags,
     })
     await Promise.all([
       reportStatuses({
@@ -373,6 +377,7 @@ const initAndRunBuild = async function ({
   testOpts,
   buildbotServerSocket,
   constants,
+  featureFlags,
 }) {
   const { pluginsOptions: pluginsOptionsA, timers: timersA } = await getPluginsOptions({
     pluginsOptions,
@@ -430,6 +435,7 @@ const initAndRunBuild = async function ({
       debug,
       timers: timersB,
       testOpts,
+      featureFlags,
     })
 
     await warnOnLingeringProcesses({ mode, logs, testOpts })
@@ -470,6 +476,7 @@ const runBuild = async function ({
   debug,
   timers,
   testOpts,
+  featureFlags,
 }) {
   const { pluginsCommands, timers: timersA } = await loadPlugins({
     pluginsOptions,
@@ -511,6 +518,7 @@ const runBuild = async function ({
     debug,
     timers: timersA,
     testOpts,
+    featureFlags,
   })
   return { commandsCount, netlifyConfig: netlifyConfigA, statuses, failedPlugins, timers: timersB }
 }


### PR DESCRIPTION
This PR enables the zip-it-and-ship-it configuration properties for the experimental handler changes introduced in https://github.com/netlify/zip-it-and-ship-it/pull/474. These properties will be enabled when a `NETLIFY_EXPERIMENTAL_FUNCTION_HANDLER_V2` environment variable is set to `true`. We may be replacing this with a LD feature flag in a subsequent PR.

As part of this work, the `featureFlags` object is being passed down the chain so that it reaches core commands.