### PR TITLE
fix: refactor warning message related to monorepo `publish` default value

### DIFF
--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -12,8 +12,8 @@ const { mergeConfigs } = require('./utils/merge')
 // Make configuration paths relative to `buildDir` and converts them to
 // absolute paths
 const resolveConfigPaths = async function ({ config, repositoryRoot, baseRelDir, logs }) {
-  warnBaseWithoutPublish(logs, config)
   const configA = resolvePaths(config, REPOSITORY_RELATIVE_PROPS, repositoryRoot)
+  warnBaseWithoutPublish({ logs, repositoryRoot, config: configA })
   const buildDir = await getBuildDir({ repositoryRoot, config: configA })
   const baseRel = baseRelDir ? buildDir : repositoryRoot
   const configB = resolvePaths(configA, FILE_PATH_CONFIG_PROPS, baseRel)

--- a/packages/config/src/log/messages.js
+++ b/packages/config/src/log/messages.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { relative } = require('path')
+
 const { throwError } = require('../error')
 
 const { logWarning } = require('./logger')
@@ -47,17 +49,24 @@ To run "${packageName}" in all contexts, please remove the following section fro
 // At the moment, the publish directory defaults to the repository root
 // directory even when there is a base directory, which might confuse some users
 // See https://github.com/netlify/build/issues/2075
-const warnBaseWithoutPublish = function (logs, { build: { base, publish } }) {
-  if (!base || base === '/' || publish) {
+const warnBaseWithoutPublish = function ({
+  logs,
+  repositoryRoot,
+  config: {
+    build: { base, publish },
+  },
+}) {
+  if (!base || base === repositoryRoot || publish) {
     return
   }
 
+  const relativeBase = relative(repositoryRoot, base)
   logWarning(
     logs,
     `
 Warning: the "publish" directory was not set and will default to the repository root directory.
 To publish the root directory, please set the "publish" directory to "/"
-To publish the "base" directory instead, please set the "publish" directory to "${base}"
+To publish the "base" directory instead, please set the "publish" directory to "${relativeBase}"
 `,
   )
 }


### PR DESCRIPTION
Part of both #1193 and #2075

This refactors the logic related to the warning message printed in repositories with a `base` directory but no `publish` directory. This does not change behavior. This refactoring is needed due to some upcoming changes.