### PR TITLE
feat: refactor some logic related to the `base` directory

### DIFF
--- a/packages/config/src/base.js
+++ b/packages/config/src/base.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { resolvePath } = require('./files')
+
 // Retrieve the first `base` directory used to load the first config file.
 const getInitialBase = function ({
   defaultConfig: { build: { base: defaultBase } = {} },
@@ -8,4 +10,17 @@ const getInitialBase = function ({
   return initialBase
 }
 
-module.exports = { getInitialBase }
+// Retrieve the final `base` directory used:
+//  - To load the second config file
+//  - As the `buildDir`
+//  - To resolve file paths
+// If the second file has a `base` property, it is ignored, i.e. it is not
+// recursive.
+// Also add it to `config.build.base`.
+const addBase = function (repositoryRoot, config) {
+  const base = resolvePath(repositoryRoot, config.build.base)
+  const configA = { ...config, build: { ...config.build, base } }
+  return { base, config: configA }
+}
+
+module.exports = { getInitialBase, addBase }

--- a/packages/config/src/base.js
+++ b/packages/config/src/base.js
@@ -10,7 +10,12 @@ const getInitialBase = function ({
   return initialBase
 }
 
-// Retrieve the final `base` directory used:
+// Two config files can be used:
+//  - The first one, using the `config` property or doing a default lookup
+//    of `netlify.toml`
+//  - If the first one has a `base` property pointing to a directory with
+//    another `netlify.toml`, that second config file is used instead.
+// This retrieves the final `base` directory used:
 //  - To load the second config file
 //  - As the `buildDir`
 //  - To resolve file paths

--- a/packages/config/src/build_dir.js
+++ b/packages/config/src/build_dir.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { resolve } = require('path')
-
 const { isDirectory } = require('path-type')
 
 const { throwError } = require('./error')
@@ -12,17 +10,9 @@ const { warnBaseWithoutPublish } = require('./log/messages')
 //  - `build.base`
 //  - `--repositoryRoot`
 //  - the current directory (default value of `--repositoryRoot`)
-const getBuildDir = async function ({
-  config: {
-    build,
-    build: { base },
-  },
-  repositoryRoot,
-  logs,
-  featureFlags,
-}) {
+const getBuildDir = async function ({ config: { build }, repositoryRoot, base, logs, featureFlags }) {
   warnBaseWithoutPublish({ logs, repositoryRoot, base, build, featureFlags })
-  const buildDir = base === undefined ? repositoryRoot : resolve(repositoryRoot, base)
+  const buildDir = base === undefined ? repositoryRoot : base
   await checkBuildDir(buildDir, repositoryRoot)
   return buildDir
 }

--- a/packages/config/src/files.js
+++ b/packages/config/src/files.js
@@ -10,19 +10,16 @@ const { mergeConfigs } = require('./utils/merge')
 
 // Make configuration paths relative to `buildDir` and converts them to
 // absolute paths
-const resolveConfigPaths = async function ({ config, repositoryRoot, baseRelDir, logs, featureFlags }) {
-  const configA = resolvePaths(config, REPOSITORY_RELATIVE_PROPS, repositoryRoot)
-  const buildDir = await getBuildDir({ config: configA, repositoryRoot, logs, featureFlags })
+const resolveConfigPaths = async function ({ config, repositoryRoot, baseRelDir, base, logs, featureFlags }) {
+  const buildDir = await getBuildDir({ config, repositoryRoot, base, logs, featureFlags })
   const baseRel = baseRelDir ? buildDir : repositoryRoot
-  const configB = resolvePaths(configA, FILE_PATH_CONFIG_PROPS, baseRel)
+  const configB = resolvePaths(config, FILE_PATH_CONFIG_PROPS, baseRel)
   const configC = await addDefaultPaths(configB, baseRel)
   return { config: configC, buildDir }
 }
 
-// All file paths in the configuration file.
-// Most are relative to `buildDir` (if `baseRelDir` is `true`). But `build.base`
-// itself is never relative to `buildDir` since it is contained in it.
-const REPOSITORY_RELATIVE_PROPS = ['build.base']
+// All file paths in the configuration file are are relative to `buildDir`
+// (if `baseRelDir` is `true`).
 const FILE_PATH_CONFIG_PROPS = ['functionsDirectory', 'build.publish', 'build.edge_handlers']
 
 const resolvePaths = function (config, propNames, baseRel) {

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -5,7 +5,7 @@ require('./utils/polyfills')
 
 const { getApiClient } = require('./api/client')
 const { getSiteInfo } = require('./api/site_info')
-const { getInitialBase } = require('./base')
+const { getInitialBase, addBase } = require('./base')
 const { mergeContext } = require('./context')
 const { parseDefaultConfig } = require('./default')
 const { getEnv } = require('./env/main')
@@ -23,6 +23,7 @@ const { mergeConfigs } = require('./utils/merge')
 // Load the configuration file.
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
+// eslint-disable-next-line max-statements
 const resolveConfig = async function (opts) {
   const { cachedConfig, host, scheme, pathPrefix, testOpts, token, offline, ...optsA } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
@@ -83,17 +84,19 @@ const resolveConfig = async function (opts) {
     featureFlags,
   })
 
-  const { config: configA, buildDir } = await resolveConfigPaths({
-    config,
+  const { base: baseA, config: configA } = await addBase(repositoryRoot, config)
+  const { config: configB, buildDir } = await resolveConfigPaths({
+    config: configA,
     repositoryRoot,
     baseRelDir: baseRelDirA,
+    base: baseA,
     logs,
     featureFlags,
   })
 
   const env = await getEnv({
     mode,
-    config: configA,
+    config: configB,
     siteInfo,
     accounts,
     addons,
@@ -104,7 +107,7 @@ const resolveConfig = async function (opts) {
   })
 
   // @todo Remove in the next major version.
-  const configB = addLegacyFunctionsDirectory(configA)
+  const configC = addLegacyFunctionsDirectory(configB)
 
   const result = {
     siteInfo,
@@ -112,7 +115,7 @@ const resolveConfig = async function (opts) {
     configPath,
     buildDir,
     repositoryRoot,
-    config: configB,
+    config: configC,
     context,
     branch,
     token,


### PR DESCRIPTION
Part of #1193.

This refactors some logic related to the `base` directory. This does not change any behavior.
This is needed for an upcoming PR related to `netlifyConfig.redirects`.