### PR TITLE
fix: do not print warning messages for plugins from the directory

### DIFF
--- a/packages/build/src/plugins/node_version.js
+++ b/packages/build/src/plugins/node_version.js
@@ -15,7 +15,6 @@ const { logPluginNodeVersionWarning } = require('../log/messages/plugins')
 // Other plugins use `@netlify/build` Node.js version.
 const addPluginsNodeVersion = function ({ pluginsOptions, mode, nodePath, userNodeVersion, logs }) {
   const currentNodeVersion = cleanVersion(currentVersion)
-  checkForOldNodeVersions({ pluginsOptions, userNodeVersion, currentNodeVersion, logs, mode })
   return pluginsOptions.map((pluginOptions) =>
     addPluginNodeVersion({ pluginOptions, currentNodeVersion, userNodeVersion, mode, nodePath, logs }),
   )
@@ -25,7 +24,7 @@ const addPluginsNodeVersion = function ({ pluginsOptions, mode, nodePath, userNo
 // versions are lower than the system version we're currently relying (v12). This is part of our effort to decouple
 // the Node.js versions our build system supports and the Node.js versions @netlify/build supports -
 // https://github.com/netlify/pod-workflow/issues/219
-const checkForOldNodeVersions = function ({ pluginsOptions, userNodeVersion, currentNodeVersion, logs, mode }) {
+const checkForOldNodeVersions = function ({ pluginsOptions, userNodeVersion, logs, mode }) {
   if (mode !== 'buildbot' || satisfies(userNodeVersion, '>=12')) return
 
   const affectedPlugins = pluginsOptions
@@ -39,6 +38,7 @@ const checkForOldNodeVersions = function ({ pluginsOptions, userNodeVersion, cur
 
   if (affectedPlugins.length === 0) return
 
+  const currentNodeVersion = cleanVersion(currentVersion)
   logPluginNodeVersionWarning({ logs, pluginNames: affectedPlugins, userNodeVersion, currentNodeVersion })
 }
 
@@ -90,4 +90,4 @@ const throwUserError = function (message) {
   throw error
 }
 
-module.exports = { addPluginsNodeVersion, checkNodeVersion }
+module.exports = { addPluginsNodeVersion, checkForOldNodeVersions, checkNodeVersion }

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -5,7 +5,7 @@ const { installMissingPlugins } = require('../install/missing')
 const { resolvePath, tryResolvePath } = require('../utils/resolve')
 
 const { addExpectedVersions } = require('./expected_version')
-const { addPluginsNodeVersion } = require('./node_version')
+const { addPluginsNodeVersion, checkForOldNodeVersions } = require('./node_version')
 const { addPinnedVersions } = require('./pinned_version')
 
 // Try to find plugins in four places, by priority order:
@@ -48,6 +48,7 @@ const resolvePluginsPath = async function ({
     buildDir,
     testOpts,
   })
+  checkForOldNodeVersions({ pluginsOptions: pluginsOptionsD, mode, userNodeVersion, logs })
   const pluginsOptionsE = await handleMissingPlugins({
     pluginsOptions: pluginsOptionsD,
     autoPluginsDir,


### PR DESCRIPTION
The Node.js warning message logic uses `expectedVersion`. However, that variable is set later in the code logic. This fixes it.