### PR TITLE
feat: add `configMutations` internal variable

### DIFF
--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -13,7 +13,8 @@ const run = async function (
   const { method } = pluginCommands.find((pluginCommand) => pluginCommand.event === event)
   const runState = {}
   const utils = getUtils({ event, constants, runState })
-  const netlifyConfigA = preventConfigMutations(netlifyConfig, event)
+  const configMutations = []
+  const netlifyConfigA = preventConfigMutations(netlifyConfig, event, configMutations)
   const runOptions = { utils, constants, inputs, netlifyConfig: netlifyConfigA, packageJson, error }
 
   const envBefore = setEnvChanges(envChanges)


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/3051

This adds a `configMutations` internal variable which keeps track of all `netlifyConfig.*` mutations.