### PR TITLE
feat: reduce verbose logs when changing `netlifyConfig`

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -124,7 +124,7 @@ const logConfigInfo = function ({ logs, configPath, buildDir, netlifyConfig, con
 // are still propagated though and assigned to the specific plugin or core
 // command which changed the configuration.
 const resolveUpdatedConfig = async function (configOpts, priorityConfig) {
-  const { config } = await resolveConfig({ ...configOpts, priorityConfig, buffer: false })
+  const { config } = await resolveConfig({ ...configOpts, priorityConfig, buffer: true })
   return config
 }
 


### PR DESCRIPTION
Part of #1193.

When `netlifyConfig` is modified, we print the updated value when in debug mode. Therefore, `@netlify/config` should not print any logs, to avoid duplicated logs. Also, this will prevent config warnings from being logged several times.

Automated tests always use `buffer: true`, which is why this does not show up in test snapshots.