### PR TITLE
feat: fix the payload sent during deploy to the buildbot

### DIFF
--- a/packages/build/src/plugins_core/deploy/buildbot_client.js
+++ b/packages/build/src/plugins_core/deploy/buildbot_client.js
@@ -57,7 +57,7 @@ const getNextParsedResponsePromise = addAsyncErrorMessage(
 
 const deploySiteWithBuildbotClient = async function (client, events, { PUBLISH_DIR }) {
   const action = shouldWaitForPostProcessing(events) ? 'deploySiteAndAwaitLive' : 'deploySite'
-  const payload = { action, values: { deployDir: PUBLISH_DIR } }
+  const payload = { action, deployDir: PUBLISH_DIR }
 
   const [{ succeeded, values: { error, error_type: errorType } = {} }] = await Promise.all([
     getNextParsedResponsePromise(client),

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -584,7 +584,7 @@ const startDeployServer = function (opts = {}) {
   return startTcpServer({ useUnixSocket, response: { succeeded: true, ...opts.response }, ...opts })
 }
 
-const isValidDeployReponse = function ({ action, values: { deployDir } }) {
+const isValidDeployReponse = function ({ action, deployDir }) {
   return ['deploySite', 'deploySiteAndAwaitLive'].includes(action) && typeof deployDir === 'string' && deployDir !== ''
 }
 


### PR DESCRIPTION
This addresses the comment from @vbrown608 in https://github.com/netlify/buildbot/issues/1445#issuecomment-874426915

This moves the deploy payload property `values.deployDir` to a top-level `deployDir` property instead.