### PR TITLE
feat: move configMutations logging logic

### DIFF
--- a/packages/build/src/commands/update_config.js
+++ b/packages/build/src/commands/update_config.js
@@ -6,7 +6,7 @@ const pFilter = require('p-filter')
 const pathExists = require('path-exists')
 
 const { resolveUpdatedConfig } = require('../core/config')
-const { logConfigOnUpdate } = require('../log/messages/config')
+const { logConfigMutations, logConfigOnUpdate } = require('../log/messages/config')
 
 // If `netlifyConfig` was updated or `_redirects` was created, the configuration
 // is updated by calling `@netlify/config` again.
@@ -25,6 +25,7 @@ const updateNetlifyConfig = async function ({
     return { netlifyConfig, configMutations }
   }
 
+  logConfigMutations(logs, newConfigMutations)
   const configMutationsA = [...configMutations, ...newConfigMutations]
   const { config: netlifyConfigA, redirectsPath: redirectsPathA } = await resolveUpdatedConfig(
     configOpts,

--- a/packages/build/src/log/messages/config.js
+++ b/packages/build/src/log/messages/config.js
@@ -1,10 +1,12 @@
 'use strict'
 
+const { inspect } = require('util')
+
 const { cleanupConfig } = require('@netlify/config')
 
 const { DEFAULT_FEATURE_FLAGS } = require('../../core/feature_flags')
 const { omit } = require('../../utils/omit')
-const { logMessage, logObject, logSubHeader } = require('../logger')
+const { log, logMessage, logObject, logSubHeader } = require('../logger')
 const { THEME } = require('../theme')
 
 const logFlags = function (logs, flags, { debug }) {
@@ -105,6 +107,16 @@ const logContext = function (logs, context) {
   logMessage(logs, context)
 }
 
+const logConfigMutations = function (logs, newConfigMutations) {
+  newConfigMutations.forEach(({ keysString, value }) => {
+    logConfigMutation(logs, keysString, value)
+  })
+}
+
+const logConfigMutation = function (logs, keysString, value) {
+  log(logs, `Netlify configuration property "${keysString}" value changed to ${inspect(value, { colors: false })}.`)
+}
+
 module.exports = {
   logFlags,
   logBuildDir,
@@ -113,4 +125,5 @@ module.exports = {
   logConfigOnUpdate,
   logConfigOnError,
   logContext,
+  logConfigMutations,
 }

--- a/packages/build/src/log/messages/plugins.js
+++ b/packages/build/src/log/messages/plugins.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { inspect } = require('util')
-
 const { log, logArray, logWarning, logSubHeader } = require('../logger')
 
 const logPluginsFetchError = function (logs, message) {
@@ -51,19 +49,10 @@ const logDeploySuccess = function (logs) {
   log(logs, 'Site deploy was successfully initiated')
 }
 
-const logConfigMutation = function (keysString, value) {
-  const mutationText =
-    value === undefined
-      ? `Netlify configuration property "${keysString}" deleted.`
-      : `Netlify configuration property "${keysString}" value changed to ${inspect(value, { colors: false })}.`
-  log(undefined, mutationText)
-}
-
 module.exports = {
   logPluginsFetchError,
   logPluginsList,
   logFailPluginWarning,
   logDeploySuccess,
-  logConfigMutation,
   logPluginNodeVersionWarning,
 }

--- a/packages/build/src/plugins/child/track.js
+++ b/packages/build/src/plugins/child/track.js
@@ -4,7 +4,6 @@ const isPlainObj = require('is-plain-obj')
 const mapObj = require('map-obj')
 
 const { addErrorInfo } = require('../../error/info')
-const { logConfigMutation } = require('../../log/messages/plugins')
 
 // `netlifyConfig` is read-only except for specific properties.
 // This requires a `Proxy` to:
@@ -83,8 +82,7 @@ const trackDefineProperty = function ({ parentKeys, configMutations, event }, pr
     value: trackObjectMutations(value, keys, { configMutations, event }),
   }
   // eslint-disable-next-line fp/no-mutating-methods
-  configMutations.push({ keys: jsonKeys, value, event })
-  logConfigMutation(keysString, value)
+  configMutations.push({ keys: jsonKeys, keysString, value, event })
   return Reflect.defineProperty(proxy, key, proxyDescriptor)
 }
 


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/3166

This moves the logic which logs configuration mutations from the plugin child process to the parent process instead.