### PR TITLE
test(snapshots): normalize prerelease

### DIFF
--- a/packages/build/tests/helpers/normalize.js
+++ b/packages/build/tests/helpers/normalize.js
@@ -113,7 +113,7 @@ const NORMALIZE_REGEXPS = [
   // Package versions
   [/([@v])[\d.]+/g, '$11.0.0'],
   // Semantic versions
-  [/\d+\.\d+\.\d+(-\d+)?/g, '1.0.0'],
+  [/\d+\.\d+\.\d+(-\w+)?/g, '1.0.0'],
   // npm install logs
   [/added \d+ package.*/g, 'added packages'],
   // npm install logs look different on Node 8.3.0

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -24,7 +24,7 @@ const normalizeText = function (text) {
   return text.replace(STACK_TRACE_REGEXP, '').replace(WHITESPACE_REGEXP, ' ').trim()
 }
 
-const VERSION_REGEXP = /\d+\.\d+\.\d+/g
+const VERSION_REGEXP = /\d+\.\d+\.\d+(-\w+)?/g
 const STACK_TRACE_REGEXP = /^\s+at .*/gm
 const WHITESPACE_REGEXP = /\s+/g
 


### PR DESCRIPTION
This PR adds snapshots normalization for prereleases.

This should fix the prerelease flow for `netlify/build` see https://github.com/netlify/build/runs/3075585703?check_suite_focus=true