### PR TITLE
docs: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 .github/CODEOWNERS    @netlify/netlify-dev
-docs/                 @netlify/docs
-docs.js               @netlify/docs


### PR DESCRIPTION
Removing the docs team from codeowners for this repo, as we don't actually maintain docs within the repo and therefore don't need to get requested as reviewers.