### PR TITLE
Allow the functions directory to be a symbolic link.

### DIFF
--- a/packages/build/src/plugins_core/functions/utils.js
+++ b/packages/build/src/plugins_core/functions/utils.js
@@ -47,7 +47,7 @@ const validateFunctionsSrc = async function ({ functionsSrc, relativeFunctionsSr
   try {
     const stats = await pLstat(functionsSrc)
 
-    if (stats.isDirectory()) {
+    if (stats.isDirectory() || stats.isSymbolicLink()) {
       return true
     }
 


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Please make sure the title is clear and descriptive.

If you are fixing a typo or documentation, please skip these instructions.

Otherwise please fill in the sections below.

**Which problem is this pull request solving?**

We previously supported the functions directory being a symbolic link. This PR restores that functionality.

**List other issues or pull requests related to this problem**

This fixes https://github.com/netlify/build/issues/3324

**Describe the solution you've chosen**

The test now passes for symlinks as well.

Avocado toast.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
