### PR TITLE
chore: switch to manifest releaser

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,10 +7,6 @@ on:
 jobs:
   release-package:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [build, cache-utils, config, functions-utils, git-utils, run-utils]
-      fail-fast: false
     steps:
       - uses: navikt/github-app-token-generator@2d70c12368d1958155af4d283f9f21c9a2a8cb98
         id: get-token
@@ -21,10 +17,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.get-token.outputs.token }}
-          release-type: node
-          package-name: '@netlify/${{ matrix.package }}'
-          monorepo-tags: true
-          path: packages/${{ matrix.package }}
+          command: manifest
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -38,7 +31,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish packages/${{ matrix.package }}/
-        if: ${{ steps.release.outputs.release_created }}
+      # Publish new releases in order of dependencies
+      - run: npm publish packages/git-utils/
+        if: ${{ steps.release.outputs['packages/git-utils--version'] }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish packages/run-utils/
+        if: ${{ steps.release.outputs['packages/run-utils--version'] }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish packages/function-utils/
+        if: ${{ steps.release.outputs['packages/function-utils--version'] }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish packages/cache-utils/
+        if: ${{ steps.release.outputs['packages/cache-utils--version'] }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish packages/config/
+        if: ${{ steps.release.outputs['packages/config--version'] }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm publish packages/build/
+        if: ${{ steps.release.outputs['packages/build--version'] }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,8 +19,6 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
           command: manifest
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,8 @@
+{
+  "packages/build": "17.1.1",
+  "packages/cache-utils": "2.0.0",
+  "packages/config": "14.0.0",
+  "packages/functions-utils": "2.0.2",
+  "packages/git-utils": "2.0.0",
+  "packages/run-utils": "2.0.0"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,12 @@ After submitting the pull request, please make sure the Continuous Integration c
 
 ## Releasing
 
-To release a specific simply package merge the relevant package release PR created by `release-please`
-
-Linting and tests will automatically run before publish.
+`release-please` creates an aggregated release PR that contains all packages that were changed from the last release.
+When you merge this PR, it will automatically publish the relevant packages to `npm` in the correct order.
 
 Packages dependencies graph:
 
-```
+```sh
 @netlify/zip-it-and-ship-it -> @netlify/function-utils
                             -> @netlify/build
                             -> netlify-cli

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly:checkout": "run-local \"git checkout main\"",
     "prepublishOnly:pull": "run-local \"git pull\"",
     "prepublishOnly:install": "run-local \"npm ci\"",
-    "prepublishOnly:test": "npm test"
+    "prepublishOnly:test": "run-local \"npm test\""
   },
   "config": {
     "eslint": "--ignore-path .gitignore --ignore-pattern \"packages/*/tests/**/snapshots/*.md\" --cache --format=codeframe --max-warnings=0 \"{packages,.github}/**/*.{js,md,html}\" \"*.{js,md,html}\" \".*.{js,md,html}\"",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,11 @@
+{
+  "bootstrap-sha": "13ed0b0053b77a11333203c537de08b7d97f0fd4",
+  "packages": {
+    "packages/build": {},
+    "packages/cache-utils": {},
+    "packages/config": {},
+    "packages/functions-utils": {},
+    "packages/git-utils": {},
+    "packages/run-utils": {}
+  }
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

More information [here](https://github.com/googleapis/release-please/blob/b452f2a7929f67142664883894182fa892ef0dd7/docs/manifest-releaser.md).

Instead of a PR per package, this should aggregate all releases into a single PR and publish the relevant ones in the correct order.

**List other issues or pull requests related to this problem**

Fixes https://github.com/netlify/team-dev/issues/28

**Describe the solution you've chosen**

`release-please` manifest driven release

**Describe alternatives you've considered**

Keep using a release PR per package

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
