### PR TITLE
chore: use releases_created instead of release_created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,16 +19,16 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
           command: manifest
       - uses: actions/checkout@v2
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - uses: actions/setup-node@v2
         with:
           node-version: '*'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - name: Install dependencies
         run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       # Publish new releases in order of dependencies
       - run: npm publish packages/git-utils/
         if: ${{ steps.release.outputs['packages/git-utils--version'] }}


### PR DESCRIPTION
Follow up on https://github.com/netlify/build/pull/3352

See https://github.com/netlify/local-functions-proxy/pull/46 and https://github.com/google-github-actions/release-please-action/issues/317

It seems there's a single case where `release_created` is set to `true`, but we should use `releases_created`:
https://github.com/google-github-actions/release-please-action/blob/d3d5b411d22e25052bb20e73a0ec1b156d67d944/index.js#L48