### PR TITLE
fix: update `plugins.json` version

### DIFF
--- a/packages/build/src/plugins/list.js
+++ b/packages/build/src/plugins/list.js
@@ -50,7 +50,7 @@ const fetchPluginsList = async function ({ logs, pluginsListUrl }) {
   }
 }
 
-const PLUGINS_LIST_VERSION = 'v1'
+const PLUGINS_LIST_VERSION = 'list-v1'
 const PLUGINS_LIST_URL = `https://${PLUGINS_LIST_VERSION}--netlify-plugins.netlify.app/plugins.json`
 // 1 minute HTTP request timeout
 const PLUGINS_LIST_TIMEOUT = 6e4


### PR DESCRIPTION
Part of https://github.com/netlify/pod-workflow/issues/157

This updates the version of `plugins.json` to match the new URL format.