### PR TITLE
feat: allow adding new properties to `compatibility`

### DIFF
--- a/packages/build/src/plugins/compatibility.js
+++ b/packages/build/src/plugins/compatibility.js
@@ -128,4 +128,4 @@ const CONDITIONS = {
   siteDependencies: { test: siteDependenciesTest, warning: siteDependenciesWarning },
 }
 
-module.exports = { getExpectedVersion }
+module.exports = { getExpectedVersion, CONDITIONS }

--- a/packages/build/src/plugins/list.js
+++ b/packages/build/src/plugins/list.js
@@ -9,6 +9,8 @@ const isPlainObj = require('is-plain-obj')
 const { logPluginsList } = require('../log/messages/plugins')
 const { logPluginsFetchError } = require('../log/messages/plugins')
 
+const { CONDITIONS } = require('./compatibility')
+
 // Retrieve the list of plugins officially vetted by us and displayed in our
 // plugins directory UI.
 // We fetch this list during each build (no caching) because we want new
@@ -76,9 +78,13 @@ const normalizePluginItem = function ({ package: packageName, version, compatibi
   return [packageName, versionsA]
 }
 
-const normalizeCompatVersion = function ({ version, migrationGuide, ...conditions }) {
-  const normalizedConditions = Object.entries(conditions).map(normalizeCondition)
-  return { version, migrationGuide, conditions: normalizedConditions }
+const normalizeCompatVersion = function ({ version, migrationGuide, ...otherProperties }) {
+  const conditions = Object.entries(otherProperties).filter(isCondition).map(normalizeCondition)
+  return { version, migrationGuide, conditions }
+}
+
+const isCondition = function ([type]) {
+  return type in CONDITIONS
 }
 
 const normalizeCondition = function ([type, condition]) {


### PR DESCRIPTION
Part of https://github.com/netlify/pod-workflow/issues/260

This allows adding new properties to `compatibility`.

The fix is only partial until https://github.com/netlify/pod-workflow/issues/157 is fixed too.