### PR TITLE
fix: `deployDir` parameter sent to buildbot during deploys

### DIFF
--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -40,7 +40,7 @@ const coreCommand = async function ({
       debug,
       saveConfig,
     })
-    await deploySiteWithBuildbotClient(client, events, constants)
+    await deploySiteWithBuildbotClient({ client, events, buildDir, repositoryRoot, constants })
     await restoreUpdatedConfig({
       buildDir,
       repositoryRoot,

--- a/packages/build/tests/plugins/fixtures/deploy_dir_path/base/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/deploy_dir_path/base/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+publish = "publish"

--- a/packages/build/tests/plugins/fixtures/deploy_dir_path/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/deploy_dir_path/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+base = "base"

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { writeFile } = require('fs')
+const { normalize } = require('path')
 const { platform, version } = require('process')
 const { promisify } = require('util')
 
@@ -633,6 +634,18 @@ test('Deploy plugin succeeds', async (t) => {
   }
 
   t.true(requests.every(isValidDeployReponse))
+})
+
+test('Deploy plugin sends deployDir as a path relative to repositoryRoot', async (t) => {
+  const { address, requests, stopServer } = await startDeployServer()
+  try {
+    await runFixture(t, 'deploy_dir_path', { flags: { buildbotServerSocket: address }, snapshot: false })
+  } finally {
+    await stopServer()
+  }
+
+  const [{ deployDir }] = requests
+  t.is(deployDir, normalize('base/publish'))
 })
 
 test('Deploy plugin is not run unless --buildbotServerSocket is passed', async (t) => {


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/1445

This fixes the `deployDir` parameter sent to the buildbot during deploys.
At the moment, it is a path relative to the build directory. It should be relative to the repository root instead for consistency with the other file paths in the buildbot.