### PR TITLE
feat(build): return config mutations

### DIFF
--- a/packages/build/src/commands/run_commands.js
+++ b/packages/build/src/commands/run_commands.js
@@ -47,6 +47,7 @@ const runCommands = async function ({
     statuses: statusesB,
     failedPlugins: failedPluginsA,
     timers: timersC,
+    configMutations: configMutationsB,
   } = await pReduce(
     commands,
     async (
@@ -166,6 +167,7 @@ const runCommands = async function ({
     statuses: statusesB,
     failedPlugins: failedPluginsA,
     timers: timersC,
+    configMutations: configMutationsB,
   }
 }
 

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -65,6 +65,7 @@ const build = async function (flags = {}) {
       commandsCount,
       timers,
       durationNs,
+      configMutations,
     } = await execBuild({
       ...flagsA,
       dry,
@@ -96,7 +97,7 @@ const build = async function (flags = {}) {
       testOpts,
       errorParams,
     })
-    return { success, severityCode, netlifyConfig: netlifyConfigA, logs }
+    return { success, severityCode, netlifyConfig: netlifyConfigA, logs, configMutations }
   } catch (error) {
     const { severity } = await handleBuildError(error, errorParams)
     const { pluginsOptions, siteInfo, userNodeVersion } = errorParams
@@ -227,6 +228,7 @@ const tExecBuild = async function ({
     netlifyConfig: netlifyConfigA,
     commandsCount,
     timers: timersB,
+    configMutations,
   } = await runAndReportBuild({
     pluginsOptions,
     netlifyConfig,
@@ -265,6 +267,7 @@ const tExecBuild = async function ({
     userNodeVersion,
     commandsCount,
     timers: timersB,
+    configMutations,
   }
 }
 
@@ -310,6 +313,7 @@ const runAndReportBuild = async function ({
       pluginsOptions: pluginsOptionsA,
       failedPlugins,
       timers: timersA,
+      configMutations,
     } = await initAndRunBuild({
       pluginsOptions,
       netlifyConfig,
@@ -372,7 +376,13 @@ const runAndReportBuild = async function ({
       }),
     ])
 
-    return { pluginsOptions: pluginsOptionsA, netlifyConfig: netlifyConfigA, commandsCount, timers: timersA }
+    return {
+      pluginsOptions: pluginsOptionsA,
+      netlifyConfig: netlifyConfigA,
+      commandsCount,
+      timers: timersA,
+      configMutations,
+    }
   } catch (error) {
     const [{ statuses }] = getErrorInfo(error)
     await reportStatuses({
@@ -461,6 +471,7 @@ const initAndRunBuild = async function ({
       statuses,
       failedPlugins,
       timers: timersC,
+      configMutations,
     } = await runBuild({
       childProcesses,
       pluginsOptions: pluginsOptionsA,
@@ -500,6 +511,7 @@ const initAndRunBuild = async function ({
       pluginsOptions: pluginsOptionsA,
       failedPlugins,
       timers: timersC,
+      configMutations,
     }
   } finally {
     stopPlugins(childProcesses)
@@ -558,6 +570,7 @@ const runBuild = async function ({
     statuses,
     failedPlugins,
     timers: timersB,
+    configMutations,
   } = await runCommands({
     commands,
     buildbotServerSocket,
@@ -585,7 +598,8 @@ const runBuild = async function ({
     testOpts,
     featureFlags,
   })
-  return { commandsCount, netlifyConfig: netlifyConfigA, statuses, failedPlugins, timers: timersB }
+
+  return { commandsCount, netlifyConfig: netlifyConfigA, statuses, failedPlugins, timers: timersB, configMutations }
 }
 
 // Logs and reports that a build successfully ended

--- a/packages/build/tests/core/fixtures/plugin_mutations/manifest.yml
+++ b/packages/build/tests/core/fixtures/plugin_mutations/manifest.yml
@@ -1,0 +1,1 @@
+name: mutator

--- a/packages/build/tests/core/fixtures/plugin_mutations/netlify.toml
+++ b/packages/build/tests/core/fixtures/plugin_mutations/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin.js"

--- a/packages/build/tests/core/fixtures/plugin_mutations/plugin.js
+++ b/packages/build/tests/core/fixtures/plugin_mutations/plugin.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  onPreBuild({ netlifyConfig }) {
+    // eslint-disable-next-line no-param-reassign
+    netlifyConfig.redirects = [{ from: 'api/*', to: '.netlify/functions/:splat', status: 200 }]
+  },
+}

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -95,6 +95,21 @@ test('severityCode is 3 on plugin error', async (t) => {
   t.is(severityCode, 3)
 })
 
+test('returns config mutations', async (t) => {
+  const {
+    returnValue: { configMutations },
+  } = await runFixture(t, 'plugin_mutations', { programmatic: true, snapshot: false })
+
+  t.deepEqual(configMutations, [
+    {
+      keys: ['redirects'],
+      keysString: 'redirects',
+      value: [{ from: 'api/*', to: '.netlify/functions/:splat', status: 200 }],
+      event: 'onPreBuild',
+    },
+  ])
+})
+
 test('--cwd', async (t) => {
   await runFixture(t, '', { flags: { cwd: `${FIXTURES_DIR}/publish` } })
 })

--- a/packages/config/src/mutations/update.js
+++ b/packages/config/src/mutations/update.js
@@ -68,11 +68,9 @@ const deleteRedirectsFile = async function (redirectsPath, normalizedInlineConfi
 const backupConfig = async function ({ buildDir, configPath, redirectsPath }) {
   const tempDir = getTempDir(buildDir)
   await makeDir(tempDir)
-  // this makes sure we don't restore stale files
-  await Promise.all([deleteNoError(`${tempDir}/netlify.toml`), deleteNoError(`${tempDir}/_redirects`)])
   await Promise.all([
-    copyIfExists(configPath, `${tempDir}/netlify.toml`),
-    copyIfExists(redirectsPath, `${tempDir}/_redirects`),
+    backupFile(configPath, `${tempDir}/netlify.toml`),
+    backupFile(redirectsPath, `${tempDir}/_redirects`),
   ])
 }
 
@@ -88,12 +86,15 @@ const getTempDir = function (buildDir) {
   return `${buildDir}/.netlify/deploy`
 }
 
-const copyIfExists = async function (src, dest) {
-  if (!(await pathExists(src))) {
+const backupFile = async function (original, backup) {
+  // this makes sure we don't restore stale files
+  await deleteNoError(backup)
+
+  if (!(await pathExists(original))) {
     return
   }
 
-  await cpFile(src, dest)
+  await cpFile(original, backup)
 }
 
 const deleteNoError = async (path) => {

--- a/packages/config/src/mutations/update.js
+++ b/packages/config/src/mutations/update.js
@@ -67,7 +67,7 @@ const deleteRedirectsFile = async function (redirectsPath, normalizedInlineConfi
 // We do this by backing them up inside some sibling directory.
 const backupConfig = async function ({ buildDir, configPath, redirectsPath }) {
   const tempDir = getTempDir(buildDir)
-  await makeDir(tempDir, {})
+  await makeDir(tempDir)
   // this makes sure we don't restore stale files
   await Promise.all([deleteNoError(`${tempDir}/netlify.toml`), deleteNoError(`${tempDir}/_redirects`)])
   await Promise.all([

--- a/packages/config/tests/mutate/tests.js
+++ b/packages/config/tests/mutate/tests.js
@@ -13,8 +13,15 @@ const FIXTURES_DIR = `${__dirname}/fixtures`
 
 // Call the main function
 const runUpdateConfig = async function (fixtureName, { configMutations = [buildCommandMutation], ...opts } = {}) {
-  const { configPath, redirectsPath } = await initFixtureDir(fixtureName)
-  await updateConfig(configMutations, { configPath, redirectsPath, context: 'production', branch: 'main', ...opts })
+  const { configPath, redirectsPath, buildDir } = await initFixtureDir(fixtureName)
+  await updateConfig(configMutations, {
+    buildDir,
+    configPath,
+    redirectsPath,
+    context: 'production',
+    branch: 'main',
+    ...opts,
+  })
   return { configPath, redirectsPath }
 }
 
@@ -30,7 +37,7 @@ const initFixtureDir = async function (fixtureName) {
   const fixtureRedirectsPath = `${fixtureDir}/_redirects`
   const redirectsPath = `${fixtureDir}/test_redirects`
   await Promise.all([copyIfExists(fixtureConfigPath, configPath), copyIfExists(fixtureRedirectsPath, redirectsPath)])
-  return { configPath, redirectsPath }
+  return { configPath, redirectsPath, buildDir: fixtureDir }
 }
 
 // Create temporary copies of `netlify.toml` and `redirects` from the fixture


### PR DESCRIPTION
**Which problem is this pull request solving?**

Return `configMutations` when running `build` programmatically, so those can be used to sync the configuration before deploy.

**List other issues or pull requests related to this problem**

Related to https://github.com/netlify/cli/pull/2920

**Describe the solution you've chosen**

Return `configMutations` when calling `netlify/build` programmatically

**Describe alternatives you've considered**

Duplicating the code in `netlify/config`

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
