### PR TITLE
fix: persist `build.environment` changes to `netlify.toml`

### DIFF
--- a/packages/config/src/simplify.js
+++ b/packages/config/src/simplify.js
@@ -16,7 +16,7 @@ const simplifyConfig = function ({
 }) {
   const buildA = {
     ...build,
-    ...removeEmptyArray(environment, 'environment'),
+    ...simplifyEnvironment(environment),
     ...removeEmptyObject(
       {
         ...processing,
@@ -37,6 +37,12 @@ const simplifyConfig = function ({
     ...removeEmptyArray(simplifyRedirects(redirects), 'redirects'),
     ...removeEmptyObject(simplifyContexts(context), 'context'),
   })
+}
+
+const simplifyEnvironment = function (environment) {
+  return Array.isArray(environment)
+    ? removeEmptyArray(environment, 'environment')
+    : removeEmptyObject(environment, 'environment')
 }
 
 const simplifyContexts = function (contextProps) {


### PR DESCRIPTION
`build.environment` is a plain object. However, when logged, it is converted to an array of keys, for security reasons.
This PR fixes some function which should assume that property to be either a plain object or an array. Otherwise, changing `build.environment` is not persisted to `netlify.toml` at the end of the build.