### PR TITLE
chore: fix codecov GitHub action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,3 +61,4 @@ jobs:
         with:
           file: coverage/coverage-final.json
           flags: ${{ steps.test-coverage-flags.outputs.os }},${{ steps.test-coverage-flags.outputs.node }}
+        continue-on-error: true


### PR DESCRIPTION
This prevents Codecov outages from making our CI pipeline fail.