### PR TITLE
fix(deps): bump clean-stack to 3.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20551,7 +20551,7 @@
         "ansi-escapes": "^4.3.2",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^4.1.2",
-        "clean-stack": "^2.2.0",
+        "clean-stack": "^3.0.1",
         "execa": "^3.3.0",
         "figures": "^3.2.0",
         "filter-obj": "^2.0.1",
@@ -20637,6 +20637,20 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "packages/build/node_modules/clean-stack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
+      "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+      "dependencies": {
+        "escape-string-regexp": "4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/build/node_modules/cliui": {
@@ -23735,7 +23749,7 @@
         "atob": "^2.1.2",
         "ava": "^3.15.0",
         "chalk": "^4.1.2",
-        "clean-stack": "^2.2.0",
+        "clean-stack": "^3.0.1",
         "cp-file": "^9.1.0",
         "cpy": "^8.1.0",
         "del": "^6.0.0",
@@ -23802,6 +23816,14 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "clean-stack": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
+          "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+          "requires": {
+            "escape-string-regexp": "4.0.0"
+          }
         },
         "cliui": {
           "version": "6.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -65,7 +65,7 @@
     "ansi-escapes": "^4.3.2",
     "array-flat-polyfill": "^1.0.1",
     "chalk": "^4.1.2",
-    "clean-stack": "^2.2.0",
+    "clean-stack": "^3.0.1",
     "execa": "^3.3.0",
     "figures": "^3.2.0",
     "filter-obj": "^2.0.1",

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,7 +8,6 @@
     {
       packageNames: [
         // Those cannot be upgraded to a major version until we drop support for Node 8
-        'clean-stack',
         'execa',
         'find-up',
         'get-stream',
@@ -30,6 +29,7 @@
         'yargs',
         'dot-prop',
         // Those cannot be upgraded to a major version until we drop support for Node 10
+        'clean-stack',
         'get-node',
         'get-bin-path',
         'p-reduce',


### PR DESCRIPTION
**Which problem is this pull request solving?**

Follow up of #3321, we can now bump clean-stack to 3.x. see - https://github.com/sindresorhus/clean-stack/releases

**Checklist**

Please add a `x` inside each checkbox:

- [ x I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
