### PR TITLE
fix: avoid debug mode to be too verbose

### DIFF
--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -136,11 +136,13 @@ const logConfigInfo = function ({ logs, configPath, buildDir, netlifyConfig, con
 // Retrieve the configuration after it's been changed.
 // This ensures any configuration changes done by plugins is validated and
 // normalized.
+// We use `debug: false` to avoid any debug logs. Otherwise every configuration
+// change would create debug logs which would be too verbose.
 // Errors are propagated and assigned to the specific plugin or core command
 // which changed the configuration.
 const resolveUpdatedConfig = async function (configOpts, configMutations) {
   try {
-    return await resolveConfig({ ...configOpts, configMutations })
+    return await resolveConfig({ ...configOpts, configMutations, debug: false })
   } catch (error) {
     if (error.type === 'configMutation') {
       // We need to mutate the `error` directly to preserve its `name`, `stack`, etc.


### PR DESCRIPTION
Follow-up on #3426 

When either modifying `netlifyConfig` in plugins or creating a `_headers`/`_redirects` in the build command or in plugins, `@netlify/config` is called again. #3426 ensured that warning messages from `@netlify/config` were logged then. However, we should not print debug logs on each `@netlify/config` call because it becomes _very_ verbose and not very useful since the resolved configuration is already printed. This PR fixes this.