### PR TITLE
feat: remove headers/redirects duplicate filtering

### DIFF
--- a/packages/config/src/headers.js
+++ b/packages/config/src/headers.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { resolve } = require('path')
-const { isDeepStrictEqual } = require('util')
 
 const { parseFileHeaders, mergeHeaders, normalizeHeaders } = require('netlify-headers-parser')
 
@@ -21,8 +20,7 @@ const addConfigHeaders = async function ({ headers: configHeaders = [], ...confi
     const normalizedConfigHeaders = normalizeHeaders(configHeaders)
     const normalizedFileHeaders = await getFileHeaders(headersPath)
     const headers = mergeHeaders({ fileHeaders: normalizedFileHeaders, configHeaders: normalizedConfigHeaders })
-    const uniqueHeaders = headers.filter(isUniqueHeader)
-    return { ...config, headers: uniqueHeaders }
+    return { ...config, headers }
     // @todo remove this failsafe once the code is stable
   } catch (error) {
     warnHeadersParsing(logs, error.message)
@@ -34,15 +32,6 @@ const getFileHeaders = async function (headersPath) {
   const fileHeaders = await parseFileHeaders(headersPath)
   const normalizedFileHeaders = normalizeHeaders(fileHeaders)
   return normalizedFileHeaders
-}
-
-// `configHeaders` might contain the content of `_headers` already.
-// This happens when a plugin appends to `netlifyConfig.headers` which already
-// contains `_headers` rules and is transformed to an `inlineConfig` object,
-// which is itself parsed as `configHeaders`. In that case, we do not want
-// duplicates.
-const isUniqueHeader = function (header, index, headers) {
-  return !headers.slice(index + 1).some((otherHeader) => isDeepStrictEqual(header, otherHeader))
 }
 
 module.exports = { addHeaders, addConfigHeaders }

--- a/packages/config/src/redirects.js
+++ b/packages/config/src/redirects.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { resolve } = require('path')
-const { isDeepStrictEqual } = require('util')
 
 const { parseFileRedirects, mergeRedirects, normalizeRedirects } = require('netlify-redirect-parser')
 
@@ -24,8 +23,7 @@ const addConfigRedirects = async function ({ redirects: configRedirects = [], ..
       fileRedirects: normalizedFileRedirects,
       configRedirects: normalizedConfigRedirects,
     })
-    const uniqueRedirects = redirects.filter(isUniqueRedirects)
-    return { ...config, redirects: uniqueRedirects }
+    return { ...config, redirects }
     // @todo remove this failsafe once the code is stable
   } catch (error) {
     warnRedirectsParsing(logs, error.message)
@@ -41,15 +39,6 @@ const getFileRedirects = async function (redirectsPath) {
 
 const normalizeAllRedirects = function (redirects) {
   return normalizeRedirects(redirects, { minimal: true })
-}
-
-// `configRedirects` might contain the content of `_redirects` already.
-// This happens when a plugin appends to `netlifyConfig.redirects` which already
-// contains `_redirects` rules and is transformed to an `inlineConfig` object,
-// which is itself parsed as `configRedirects`. In that case, we do not want
-// duplicates.
-const isUniqueRedirects = function (redirect, index, redirects) {
-  return !redirects.slice(index + 1).some((otherRedirect) => isDeepStrictEqual(redirect, otherRedirect))
 }
 
 module.exports = { addRedirects, addConfigRedirects }


### PR DESCRIPTION
This removes the headers/redirects duplicate filtering introduced by #3424 now that it has been moved to:
  - `netlify-headers-parser` (https://github.com/netlify/netlify-headers-parser/pull/8, https://github.com/netlify/build/pull/3435)
  - `netlify-redirect-parser` (https://github.com/netlify/netlify-redirect-parser/pull/312, https://github.com/netlify/build/pull/3436)