### PR TITLE
chore(renovate): move/remove dependency update locks on renovate's config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,50 +5,97 @@
   dependencyDashboard: true,
   automerge: true,
   packageRules: [
+    // Cannot be upgraded to a major version until we drop support for Node 10
     {
-      packageNames: [
-        // Those cannot be upgraded to a major version until we drop support for Node 8
-        'execa',
-        'find-up',
-        'get-stream',
-        'globby',
-        'got',
-        'is-plain-obj',
-        'lerna',
-        'locate-path',
-        'log-process-errors',
-        'move-file',
-        'os-name',
-        'p-locate',
-        'pkg-dir',
-        'pretty-ms',
-        'ps-list',
-        'semver',
-        'supports-color',
-        'update-notifier',
-        'yargs',
-        'dot-prop',
-        // Those cannot be upgraded to a major version until we drop support for Node 10
-        'clean-stack',
-        'get-node',
-        'get-bin-path',
-        'p-reduce',
-        'path-key',
-        'path-type',
-        'read-pkg-up',
-        // Those cannot be upgraded until we use ES modules natively (requires Node >=12.20.0)
-        'ansi-escapes',
-        'figures',
-        'has-ansi',
-        'indent-string',
-        'keep-func-props',
-        'string-width',
-        'strip-ansi',
-        '@sindresorhus/slugify',
-      ],
-      major: {
-        enabled: false,
-      },
+      "matchPackageNames": ["clean-stack"],
+      "allowedVersions": "<4"
+    },
+    {
+      "matchPackageNames": ["get-node"],
+      "allowedVersions": "<12"
+    },
+    {
+      "matchPackageNames": ["get-bin-path"],
+      "allowedVersions": "<6"
+    },
+    {
+      "matchPackageNames": ["globby"],
+      "allowedVersions": "<12"
+    },
+    {
+      "matchPackageNames": ["got"],
+      "allowedVersions": "<11"
+    },
+    {
+      "matchPackageNames": ["is-plain-obj"],
+      "allowedVersions": "<4"
+    },
+    {
+      "matchPackageNames": ["log-process-errors"],
+      "allowedVersions": "<7"
+    },
+    {
+      "matchPackageNames": ["move-file"],
+      "allowedVersions": "<3"
+    },
+    {
+      "matchPackageNames": ["supports-color"],
+      "allowedVersions": "<9"
+    },
+    {
+      "matchPackageNames": ["p-reduce"],
+      "allowedVersions": "<3"
+    },
+    {
+      "matchPackageNames": ["path-key"],
+      "allowedVersions": "<4"
+    },
+    {
+      "matchPackageNames": ["path-type"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["read-pkg-up"],
+      "allowedVersions": "<8"
+    },
+    {
+      "matchPackageNames": ["yargs"],
+      "allowedVersions": "<17"
+    },
+
+
+    // Cannot be upgraded until we use ES modules natively (requires Node >=12.20.0)
+    {
+      "matchPackageNames": ["ansi-escapes"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["figures"],
+      "allowedVersions": "<4"
+    },
+    {
+      "matchPackageNames": ["has-ansi"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["indent-string"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["keep-func-props"],
+      "allowedVersions": "<4"
+    },
+    {
+      "matchPackageNames": ["string-width"],
+      "allowedVersions": "<5"
+    },
+    {
+      "matchPackageNames": ["strip-ansi"],
+      "allowedVersions": "<7"
+    },
+    {
+      "matchPackageNames": ["@sindresorhus/slugify"],
+      "allowedVersions": "<2"
     },
   ],
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Follow up from #3321. This follows a similar approach to the one we're using in - https://github.com/netlify/renovate-config/blob/351b228622126c6713272544cfa3303f572b6ba6/default.json#L28 - where instead of blocking major updates from renovate we specifically list the major versions we won't support (making it easier for our future selves to change this file).

I've went through each dependency changelog and I believe this should be correct. That being said renovate/our tests will tell us if we're wrong 👀 

The idea will be to keep track of which PRs from renovate fail and follow up with the required changes.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
