### PR TITLE
chore: add `os-name` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -86,6 +86,10 @@
       "allowedVersions": "<4"
     },
     {
+      "matchPackageNames": ["os-name"],
+      "allowedVersions": "<5"
+    },
+    {
       "matchPackageNames": ["string-width"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
`os-name@5` requires ESM and Node 12.