### PR TITLE
chore: add `p-filter` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -86,6 +86,10 @@
       "allowedVersions": "<4"
     },
     {
+      "matchPackageNames": ["p-filter"],
+      "allowedVersions": "<3"
+    },
+    {
       "matchPackageNames": ["string-width"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
`p-filter@3` requires ESM and Node 12.