### PR TITLE
fix(cache-utils): don't cache junk files nor list them as cached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19789,6 +19789,7 @@
         "del": "^5.1.0",
         "get-stream": "^6.0.0",
         "globby": "^10.0.2",
+        "junk": "^3.1.0",
         "locate-path": "^6.0.0",
         "make-dir": "^3.1.0",
         "move-file": "^2.0.0",
@@ -19876,7 +19877,7 @@
     },
     "packages/config": {
       "name": "@netlify/config",
-      "version": "15.3.6",
+      "version": "15.3.7",
       "license": "MIT",
       "dependencies": {
         "@ungap/from-entries": "^0.2.1",
@@ -22969,6 +22970,7 @@
         "del": "^5.1.0",
         "get-stream": "^6.0.0",
         "globby": "^10.0.2",
+        "junk": "^3.1.0",
         "locate-path": "^6.0.0",
         "make-dir": "^3.1.0",
         "move-file": "^2.0.0",

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -48,6 +48,7 @@
     "del": "^5.1.0",
     "get-stream": "^6.0.0",
     "globby": "^10.0.2",
+    "junk": "^3.1.0",
     "locate-path": "^6.0.0",
     "make-dir": "^3.1.0",
     "move-file": "^2.0.0",

--- a/packages/cache-utils/src/fs.js
+++ b/packages/cache-utils/src/fs.js
@@ -6,6 +6,7 @@ const { promisify } = require('util')
 
 const cpy = require('cpy')
 const globby = require('globby')
+const junk = require('junk')
 const moveFile = require('move-file')
 
 const pStat = promisify(stat)
@@ -33,8 +34,9 @@ const isEmptyDir = async function ({ srcGlob, cwd, isDir }) {
     return false
   }
 
-  const files = await globby(srcGlob, { cwd, ignoreJunk: true })
-  return files.length === 0
+  const files = await globby(srcGlob, { cwd })
+  const filteredFiles = files.filter((file) => junk.not(basename(file)))
+  return filteredFiles.length === 0
 }
 
 // Get globbing pattern with files to move/copy

--- a/packages/cache-utils/tests/has.js
+++ b/packages/cache-utils/tests/has.js
@@ -4,7 +4,7 @@ const test = require('ava')
 
 const cacheUtils = require('..')
 
-const { createTmpDir, createTmpFile, removeFiles } = require('./helpers/main')
+const { createTmpDir, createTmpFile, createTmpFiles, removeFiles } = require('./helpers/main')
 
 test('Should allow checking if one file is cached', async (t) => {
   const [cacheDir, [srcFile, srcDir]] = await Promise.all([createTmpDir(), createTmpFile()])
@@ -29,6 +29,42 @@ test('Should allow checking if several files are cached', async (t) => {
     t.true(await cacheUtils.has([srcFile, otherSrcFile], { cacheDir }))
   } finally {
     await removeFiles([cacheDir, srcDir, otherSrcDir])
+  }
+})
+
+test('Should not list junk files as cached nor cache them', async (t) => {
+  const [cacheDir, [[junkFile, srcFile, otherSrcFile], srcFilesDir]] = await Promise.all([
+    createTmpDir(),
+    // Create 3 files under the same temporary dir, including a .DS_Store junk file
+    createTmpFiles([{ name: '.DS_Store' }, {}, {}]),
+  ])
+  try {
+    t.false(await cacheUtils.has(junkFile, { cacheDir }))
+    t.true(await cacheUtils.save(srcFilesDir, { cacheDir }))
+    t.false(await cacheUtils.has(junkFile, { cacheDir }))
+    t.true(await cacheUtils.has(srcFile, { cacheDir }))
+    t.true(await cacheUtils.has(otherSrcFile, { cacheDir }))
+  } finally {
+    await removeFiles([cacheDir, srcFilesDir])
+  }
+})
+
+test('Should not list empty directories as cached nor cache them', async (t) => {
+  const [cacheDir, [junkFile, junkFileDir], emptyDir] = await Promise.all([
+    createTmpDir(),
+    // Create a directory with a junk .DS_Store file
+    createTmpFile({ name: '.DS_Store' }),
+    // Create an empty directory
+    createTmpDir(),
+  ])
+  try {
+    t.false(await cacheUtils.has(junkFile, { cacheDir }))
+    t.false(await cacheUtils.save(junkFileDir, { cacheDir }))
+    t.false(await cacheUtils.has(junkFile, { cacheDir }))
+    t.false(await cacheUtils.save(emptyDir, { cacheDir }))
+    t.false(await cacheUtils.has(emptyDir, { cacheDir }))
+  } finally {
+    await removeFiles([cacheDir, junkFileDir, emptyDir])
   }
 })
 

--- a/packages/cache-utils/tests/helpers/main.js
+++ b/packages/cache-utils/tests/helpers/main.js
@@ -18,12 +18,27 @@ const createTmpDir = async function (opts) {
   return path
 }
 
-const createTmpFile = async function (opts) {
+const createTmpFile = async function ({ name, ...opts } = {}) {
   const tmpDir = await createTmpDir(opts)
-  const filename = basename(await tmpName())
+  const filename = name || basename(await tmpName())
   const tmpFile = join(tmpDir, filename)
   await pWriteFile(tmpFile, '')
   return [tmpFile, tmpDir]
+}
+
+// Create multiple temporary files with a particular or random name, i.e.
+// createTmpFiles([{name: 'test'}, {} {}]) => creates 3 files, one of them named test, under the same temporary dir
+const createTmpFiles = async function (files, opts) {
+  const tmpDir = await createTmpDir(opts)
+  const tmpFiles = await Promise.all(
+    files.map(async ({ name }) => {
+      const filename = name || basename(await tmpName())
+      const tmpFile = join(tmpDir, filename)
+      await pWriteFile(tmpFile, '')
+      return tmpFile
+    }),
+  )
+  return [tmpFiles, tmpDir]
 }
 
 const PREFIX = 'test-cache-utils-'
@@ -39,5 +54,6 @@ module.exports = {
   pReaddir,
   createTmpDir,
   createTmpFile,
+  createTmpFiles,
   removeFiles,
 }

--- a/packages/cache-utils/tests/helpers/main.js
+++ b/packages/cache-utils/tests/helpers/main.js
@@ -18,11 +18,9 @@ const createTmpDir = async function (opts) {
   return path
 }
 
+// Utility method to create a single temporary file and directory
 const createTmpFile = async function ({ name, ...opts } = {}) {
-  const tmpDir = await createTmpDir(opts)
-  const filename = name || basename(await tmpName())
-  const tmpFile = join(tmpDir, filename)
-  await pWriteFile(tmpFile, '')
+  const [[tmpFile], tmpDir] = await createTmpFiles([{ name }], opts)
   return [tmpFile, tmpDir]
 }
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -66,6 +66,10 @@
 
     // Cannot be upgraded until we use ES modules natively (requires Node >=12.20.0)
     {
+      "matchPackageNames": ["junk"],
+      "allowedVersions": "<4"
+    },
+    {
       "matchPackageNames": ["ansi-escapes"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
**Which problem is this pull request solving?**

This PR is a consequence of #3487. After chatting with @ehmicky seems like we've been misusing the `ignoreJunk` property on `globby` (which doesn't exist) as a way to reproduce part of the logic from `cpy`, where junk files are disregarded. This PR attempts to fix that logic and add test cases to validate that we don't store nor list junk files and empty dirs as saved.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
