### PR TITLE
chore: improve `functionsDistDir` test

### DIFF
--- a/packages/build/tests/helpers/temp.js
+++ b/packages/build/tests/helpers/temp.js
@@ -26,4 +26,4 @@ const getTempName = async function () {
   return tempName
 }
 
-module.exports = { getTempDir }
+module.exports = { getTempDir, getTempName }


### PR DESCRIPTION
This is a small improvement of the integration test for the `--functionsDistDir` flag.
The current test only check that the flag can be passed and is being logged.
This adds:
  - Ensuring the directory is created
  - Ensuring the directory is used for bundling