### PR TITLE
chore: split files

### DIFF
--- a/packages/build/src/commands/update_config.js
+++ b/packages/build/src/commands/update_config.js
@@ -7,7 +7,8 @@ const pathExists = require('path-exists')
 
 const { resolveUpdatedConfig } = require('../core/config')
 const { addErrorInfo } = require('../error/info')
-const { logConfigMutations, logConfigOnUpdate } = require('../log/messages/config')
+const { logConfigOnUpdate } = require('../log/messages/config')
+const { logConfigMutations } = require('../log/messages/mutations')
 
 // If `netlifyConfig` was updated or `_redirects` was created, the configuration
 // is updated by calling `@netlify/config` again.

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -8,15 +8,8 @@ const mapObj = require('map-obj')
 const { getChildEnv } = require('../env/main')
 const { addApiErrorHandlers } = require('../error/api')
 const { addErrorInfo } = require('../error/info')
-const {
-  logBuildDir,
-  logConfigPath,
-  logConfig,
-  logContext,
-  logConfigOnUpload,
-  logHeadersOnUpload,
-  logRedirectsOnUpload,
-} = require('../log/messages/config')
+const { logBuildDir, logConfigPath, logConfig, logContext } = require('../log/messages/config')
+const { logConfigOnUpload, logHeadersOnUpload, logRedirectsOnUpload } = require('../log/messages/mutations')
 const { measureDuration } = require('../time/main')
 const { getPackageJson } = require('../utils/package')
 

--- a/packages/build/src/log/messages/config.js
+++ b/packages/build/src/log/messages/config.js
@@ -1,18 +1,11 @@
-/* eslint-disable max-lines */
 'use strict'
 
-const { readFile } = require('fs')
-const { inspect, promisify } = require('util')
-
 const { cleanupConfig } = require('@netlify/config')
-const pathExists = require('path-exists')
 
 const { DEFAULT_FEATURE_FLAGS } = require('../../core/feature_flags')
 const { omit } = require('../../utils/omit')
-const { log, logMessage, logObject, logSubHeader } = require('../logger')
+const { logMessage, logObject, logSubHeader } = require('../logger')
 const { THEME } = require('../theme')
-
-const pReadFile = promisify(readFile)
 
 const logFlags = function (logs, flags, { debug }) {
   const flagsA = cleanFeatureFlags(flags)
@@ -113,71 +106,6 @@ const logContext = function (logs, context) {
   logMessage(logs, context)
 }
 
-const logConfigMutations = function (logs, newConfigMutations) {
-  newConfigMutations.forEach(({ keysString, value }) => {
-    logConfigMutation(logs, keysString, value)
-  })
-}
-
-const logConfigMutation = function (logs, keysString, value) {
-  const newValue = shouldHideConfigValue(keysString) ? '' : ` to ${inspect(value, { colors: false })}`
-  log(logs, `Netlify configuration property "${keysString}" value changed${newValue}.`)
-}
-
-const shouldHideConfigValue = function (keysString) {
-  return SECRET_PROPS.some((secretProp) => keysString.startsWith(secretProp))
-}
-
-const SECRET_PROPS = ['build.environment']
-
-const logConfigOnUpload = async function ({ logs, configPath, debug }) {
-  if (!debug) {
-    return
-  }
-
-  logSubHeader(logs, 'Uploaded config')
-
-  if (!(await pathExists(configPath))) {
-    logMessage(logs, 'No netlify.toml')
-    return
-  }
-
-  const configContents = await pReadFile(configPath, 'utf8')
-  logMessage(logs, configContents.trim())
-}
-
-const logHeadersOnUpload = async function ({ logs, headersPath, debug }) {
-  if (!debug) {
-    return
-  }
-
-  logSubHeader(logs, 'Uploaded headers')
-
-  if (!(await pathExists(headersPath))) {
-    logMessage(logs, 'No headers')
-    return
-  }
-
-  const headersContents = await pReadFile(headersPath, 'utf8')
-  logMessage(logs, headersContents.trim())
-}
-
-const logRedirectsOnUpload = async function ({ logs, redirectsPath, debug }) {
-  if (!debug) {
-    return
-  }
-
-  logSubHeader(logs, 'Uploaded redirects')
-
-  if (!(await pathExists(redirectsPath))) {
-    logMessage(logs, 'No redirects\n')
-    return
-  }
-
-  const redirectsContents = await pReadFile(redirectsPath, 'utf8')
-  logMessage(logs, `${redirectsContents.trim()}\n`)
-}
-
 module.exports = {
   logFlags,
   logBuildDir,
@@ -186,9 +114,4 @@ module.exports = {
   logConfigOnUpdate,
   logConfigOnError,
   logContext,
-  logConfigMutations,
-  logConfigOnUpload,
-  logHeadersOnUpload,
-  logRedirectsOnUpload,
 }
-/* eslint-enable max-lines */

--- a/packages/build/src/log/messages/mutations.js
+++ b/packages/build/src/log/messages/mutations.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const { readFile } = require('fs')
+const { inspect, promisify } = require('util')
+
+const pathExists = require('path-exists')
+
+const { log, logMessage, logSubHeader } = require('../logger')
+
+const pReadFile = promisify(readFile)
+
+const logConfigMutations = function (logs, newConfigMutations) {
+  newConfigMutations.forEach(({ keysString, value }) => {
+    logConfigMutation(logs, keysString, value)
+  })
+}
+
+const logConfigMutation = function (logs, keysString, value) {
+  const newValue = shouldHideConfigValue(keysString) ? '' : ` to ${inspect(value, { colors: false })}`
+  log(logs, `Netlify configuration property "${keysString}" value changed${newValue}.`)
+}
+
+const shouldHideConfigValue = function (keysString) {
+  return SECRET_PROPS.some((secretProp) => keysString.startsWith(secretProp))
+}
+
+const SECRET_PROPS = ['build.environment']
+
+const logConfigOnUpload = async function ({ logs, configPath, debug }) {
+  if (!debug) {
+    return
+  }
+
+  logSubHeader(logs, 'Uploaded config')
+
+  if (!(await pathExists(configPath))) {
+    logMessage(logs, 'No netlify.toml')
+    return
+  }
+
+  const configContents = await pReadFile(configPath, 'utf8')
+  logMessage(logs, configContents.trim())
+}
+
+const logHeadersOnUpload = async function ({ logs, headersPath, debug }) {
+  if (!debug) {
+    return
+  }
+
+  logSubHeader(logs, 'Uploaded headers')
+
+  if (!(await pathExists(headersPath))) {
+    logMessage(logs, 'No headers')
+    return
+  }
+
+  const headersContents = await pReadFile(headersPath, 'utf8')
+  logMessage(logs, headersContents.trim())
+}
+
+const logRedirectsOnUpload = async function ({ logs, redirectsPath, debug }) {
+  if (!debug) {
+    return
+  }
+
+  logSubHeader(logs, 'Uploaded redirects')
+
+  if (!(await pathExists(redirectsPath))) {
+    logMessage(logs, 'No redirects\n')
+    return
+  }
+
+  const redirectsContents = await pReadFile(redirectsPath, 'utf8')
+  logMessage(logs, `${redirectsContents.trim()}\n`)
+}
+
+module.exports = {
+  logConfigMutations,
+  logConfigOnUpload,
+  logHeadersOnUpload,
+  logRedirectsOnUpload,
+}


### PR DESCRIPTION
This splits a file into two, and remove an ESLint warning.