### PR TITLE
fix: `utils.git` crashes when commit messages or authors have uncommon characters

### DIFF
--- a/packages/git-utils/src/commits.js
+++ b/packages/git-utils/src/commits.js
@@ -5,17 +5,33 @@ const { git } = require('./exec')
 // Return information on each commit since the `base` commit, such as SHA,
 // parent commits, author, committer and commit message
 const getCommits = function (base, head, cwd) {
-  const stdout = git(['log', `--pretty=format:${JSON.stringify(FORMAT_JSON)}`, `${base}...${head}`], cwd)
-  const commits = JSON.parse(`[${stdout.split('\n').join(',')}]`)
+  const stdout = git(['log', `--pretty=${GIT_PRETTY_FORMAT}`, `${base}...${head}`], cwd)
+  const commits = stdout.split('\n').map(getCommit)
   return commits
 }
 
-const FORMAT_JSON = {
-  sha: '%H',
-  parents: '%p',
-  author: { name: '%an', email: '%ae', date: '%ai' },
-  committer: { name: '%cn', email: '%ce', date: '%ci' },
-  message: '%f',
+// Parse the commit output from a string to a JavaScript object
+const getCommit = function (line) {
+  const [sha, parents, authorName, authorEmail, authorDate, committerName, committerEmail, committerDate, message] =
+    line.split(GIT_PRETTY_SEPARATOR)
+  return {
+    sha,
+    parents,
+    author: { name: authorName, email: authorEmail, date: authorDate },
+    committer: { name: committerName, email: committerEmail, date: committerDate },
+    message,
+  }
 }
+
+// `git log --pretty` does not have any way of separating tokens, except for
+// commits being separated by newlines. Since some tokens (like the commit
+// message or the committer name) might contain a wide range of characters, we
+// need a specific separator.
+// We choose RS (Record separator) which is a rarely used control character
+// intended for this very purpose: separating records. It is used by some
+// formats such as JSON text sequences (RFC 7464).
+const GIT_PRETTY_SEPARATOR = '\u001E'
+// List of commit fields we want to retrieve
+const GIT_PRETTY_FORMAT = ['%H', '%p', '%an', '%ae', '%ai', '%cn', '%ce', '%ci', '%f'].join(GIT_PRETTY_SEPARATOR)
 
 module.exports = { getCommits }


### PR DESCRIPTION
Fixes https://github.com/netlify/build/issues/3622

`utils.git` retrieves all previous commits and returns information about them as an array of objects. It does this by using `git log --pretty` and parsing its output. 

The current implementation is quite naive and does not properly handle unescaped characters. This PR fixes this.

Please note `utils.git`'s code is only executed when a site uses a plugin that uses `utils.git`, thanks to [some lazy loading code](https://github.com/netlify/build/blob/main/packages/build/src/plugins/child/lazy.js) we have. This should dramatically reduce the risk associated with this PR, considering almost no plugins uses `utils.git`.