### PR TITLE
chore: fix some test to use a more recent Node.js version

### DIFF
--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -209,7 +209,7 @@ test('--dry with build.command but no netlify.toml', async (t) => {
   await runFixture(t, 'none', { flags: { dry: true, defaultConfig: { build: { command: 'echo' } } } })
 })
 
-const CHILD_NODE_VERSION = '8.3.0'
+const CHILD_NODE_VERSION = '10.17.0'
 const VERY_OLD_NODE_VERSION = '4.0.0'
 
 // Try `get-node` several times because it sometimes fails due to network failures


### PR DESCRIPTION
Some tests are failing due to some VSCode extensions not supporting Node.js 8. This PR fixes this.