### PR TITLE
fix: remove zisiEsbuildDynamicImports feature flag

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
           check-latest: true
       - name: Install dependencies
         run: npm run installOldNpm

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
           check-latest: true
       - name: Install dependencies
         run: npm run installOldNpm

--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { env } = require('process')
-
 // From CLI `--featureFlags=a,b,c` to programmatic `{ a: true, b: true, c: true }`
 const normalizeCliFeatureFlags = function (cliFeatureFlags) {
   return Object.assign({}, ...cliFeatureFlags.split(',').filter(isNotEmpty).map(getFeatureFlag))
@@ -17,7 +15,6 @@ const getFeatureFlag = function (name) {
 
 // Default values for feature flags
 const DEFAULT_FEATURE_FLAGS = {
-  zisiEsbuildDynamicImports: env.NETLIFY_EXPERIMENTAL_PROCESS_DYNAMIC_IMPORTS === 'true',
   buildbot_es_modules_esbuild: false,
 }
 

--- a/packages/build/src/plugins_core/functions/index.js
+++ b/packages/build/src/plugins_core/functions/index.js
@@ -25,7 +25,7 @@ const isUsingEsbuild = (functionsConfig = {}) =>
 // The function configuration keys returned by @netlify/config are not an exact
 // match to the properties that @netlify/zip-it-and-ship-it expects. We do that
 // translation here.
-const normalizeFunctionConfig = ({ buildDir, featureFlags, functionConfig = {}, isRunningLocally }) => ({
+const normalizeFunctionConfig = ({ buildDir, functionConfig = {}, isRunningLocally }) => ({
   externalNodeModules: functionConfig.external_node_modules,
   includedFiles: functionConfig.included_files,
   includedFilesBasePath: buildDir,
@@ -37,11 +37,6 @@ const normalizeFunctionConfig = ({ buildDir, featureFlags, functionConfig = {}, 
   // fallback behavior ourselves. We do this by transforming the value
   // `esbuild` into `esbuild_zisi`, which zip-it-and-ship-it understands.
   nodeBundler: functionConfig.node_bundler === 'esbuild' ? 'esbuild_zisi' : functionConfig.node_bundler,
-
-  // With the `zisiEsbuildDynamicImports` feature flag, zip-it-and-ship-it will
-  // resolve dynamic import expressions by injecting shim files to make the
-  // expressions resolve to the right paths at runtime.
-  processDynamicNodeImports: Boolean(featureFlags.zisiEsbuildDynamicImports),
 
   // If the build is running in buildbot, we set the Rust target directory to a
   // path that will get cached in between builds, allowing us to speed up the


### PR DESCRIPTION
**Which problem is this pull request solving?**

With https://github.com/netlify/zip-it-and-ship-it/pull/603, we want the value of the `processDynamicNodeImports` config property to be `true`. As it stands, the value will start to be `false` once we remove the `zisiEsbuildDynamicImports` LaunchDarkly flag.

This PR stops listening to the flag entirely and stops passing a `processDynamicNodeImports` configuration property to zip-it-and-ship-it.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
