### PR TITLE
fix: check for functionsSrc in "module not found" error

### DIFF
--- a/packages/build/src/plugins_core/functions/error.js
+++ b/packages/build/src/plugins_core/functions/error.js
@@ -108,6 +108,7 @@ const getModuleNameFromZISIError = function (error) {
 // Netlify Functions has a `package.json` but no `node_modules`
 const lacksNodeModules = async function (functionsSrc) {
   return (
+    functionsSrc !== undefined &&
     (await hasFunctionRootFile('package.json', functionsSrc)) &&
     !(await hasFunctionRootFile('node_modules', functionsSrc))
   )


### PR DESCRIPTION
**Which problem is this pull request solving?**

When a function references a Node module that cannot be found in the project, we process that error and attempt to provide a more useful message to the user. As part of this logic, we check for `functionsSrc` without asserting whether it's defined, which can happen when using the internal functions directory.

This PR addresses that.

**List other issues or pull requests related to this problem**

Closes https://github.com/netlify/build/issues/3533.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
