### PR TITLE
fix: simplify plugin's Node.js version in local builds

### DIFF
--- a/packages/build/src/plugins/node_version.js
+++ b/packages/build/src/plugins/node_version.js
@@ -11,12 +11,12 @@ const { addErrorInfo } = require('../error/info')
 
 // Local plugins and `package.json`-installed plugins use user's preferred Node.js version if higher than our minimum
 // supported version (Node v10). Else default to the system Node version.
-// Local builds use user's preferred Node.js version.
-// Other plugins use `@netlify/build` Node.js version.
-const addPluginsNodeVersion = function ({ pluginsOptions, mode, nodePath, userNodeVersion }) {
+// Local and programmatic builds use `@netlify/build` Node.js version, which is
+// usually the system's Node.js version.
+const addPluginsNodeVersion = function ({ pluginsOptions, nodePath, userNodeVersion }) {
   const currentNodeVersion = cleanVersion(currentVersion)
   return pluginsOptions.map((pluginOptions) =>
-    addPluginNodeVersion({ pluginOptions, currentNodeVersion, userNodeVersion, mode, nodePath }),
+    addPluginNodeVersion({ pluginOptions, currentNodeVersion, userNodeVersion, nodePath }),
   )
 }
 
@@ -25,14 +25,10 @@ const addPluginNodeVersion = function ({
   pluginOptions: { loadedFrom },
   currentNodeVersion,
   userNodeVersion,
-  mode,
   nodePath,
 }) {
   if (loadedFrom === 'local' || loadedFrom === 'package.json') {
     return nonUIPluginNodeVersion({ pluginOptions, currentNodeVersion, userNodeVersion, nodePath })
-  }
-  if (loadedFrom !== 'core' && mode !== 'buildbot') {
-    return { ...pluginOptions, nodePath, nodeVersion: userNodeVersion }
   }
 
   return { ...pluginOptions, nodePath: execPath, nodeVersion: currentNodeVersion }

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -34,7 +34,6 @@ const resolvePluginsPath = async function ({
   )
   const pluginsOptionsB = addPluginsNodeVersion({
     pluginsOptions: pluginsOptionsA,
-    mode,
     nodePath,
     userNodeVersion,
     logs,


### PR DESCRIPTION
Somewhat part of https://github.com/netlify/build/issues/3651

At the moment, plugins installed in the UI or `netlify.toml` (but not in `package.json`) usually use the same Node.js version as `@netlify/build`. In buildbot, this is `12.18.0`. In local or programmatic builds, this is the machine/system's Node.js version.

For local or programmatic builds, there is an exception: when the `--node-path` flag is passed, it is used instead. However, this is rather unnecessary considering the `--node-path` flag is not currently used in local builds.

Therefore, this PR makes all plugins (except local or installed in `package.json`) always use the same Node.js version as `@netlify/build`. This is in line with our overall goal towards simplifying the Node.js version run by plugins and fix native modules issues in plugins.