### PR TITLE
fix: `@netlify/config` user errors

### DIFF
--- a/packages/build/src/error/info.js
+++ b/packages/build/src/error/info.js
@@ -27,6 +27,14 @@ const getErrorInfo = function (error) {
   return [errorInfo, errorA]
 }
 
+// Change error type from one to another
+const changeErrorType = function (error, oldType, newType) {
+  const [{ type }] = getErrorInfo(error)
+  if (type === oldType) {
+    addErrorInfo(error, { type: newType })
+  }
+}
+
 const isBuildError = function (error) {
   return canHaveErrorInfo(error) && error[CUSTOM_ERROR_KEY] !== undefined
 }
@@ -39,4 +47,4 @@ const canHaveErrorInfo = function (error) {
 
 const CUSTOM_ERROR_KEY = 'customErrorInfo'
 
-module.exports = { addDefaultErrorInfo, addErrorInfo, getErrorInfo, isBuildError, CUSTOM_ERROR_KEY }
+module.exports = { addDefaultErrorInfo, addErrorInfo, getErrorInfo, changeErrorType, isBuildError, CUSTOM_ERROR_KEY }

--- a/packages/build/tests/error/fixtures/config_validation/netlify.toml
+++ b/packages/build/tests/error/fixtures/config_validation/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-command = "echo"
+command = false

--- a/packages/config/src/error.js
+++ b/packages/config/src/error.js
@@ -1,10 +1,10 @@
 'use strict'
 
 // We distinguish between errors thrown intentionally and uncaught exceptions
-// (such as bugs) with a `type` property.
+// (such as bugs) with a `customErrorInfo.type` property.
 const throwUserError = function (messageOrError, error) {
   const errorA = getError(messageOrError, error)
-  errorA.type = USER_ERROR_TYPE
+  errorA[CUSTOM_ERROR_KEY] = { type: USER_ERROR_TYPE }
   throw errorA
 }
 
@@ -22,11 +22,19 @@ const getError = function (messageOrError, error) {
   return error
 }
 
-// Check `error.type`
 const isUserError = function (error) {
-  return error instanceof Error && error.type === USER_ERROR_TYPE
+  return (
+    canHaveErrorInfo(error) && error[CUSTOM_ERROR_KEY] !== undefined && error[CUSTOM_ERROR_KEY].type === USER_ERROR_TYPE
+  )
 }
 
-const USER_ERROR_TYPE = 'userError'
+// Exceptions that are not objects (including `Error` instances) cannot have an
+// `CUSTOM_ERROR_KEY` property
+const canHaveErrorInfo = function (error) {
+  return error != null
+}
+
+const CUSTOM_ERROR_KEY = 'customErrorInfo'
+const USER_ERROR_TYPE = 'resolveConfig'
 
 module.exports = { throwUserError, isUserError }


### PR DESCRIPTION
Fixes https://github.com/netlify/build/issues/3695

This improves how `@netlify/config` is handling errors (see issue above for more details).