### PR TITLE
chore: allow instantiating event handlers types with only input types

### DIFF
--- a/packages/build/types/netlify_event.d.ts
+++ b/packages/build/types/netlify_event.d.ts
@@ -1,5 +1,9 @@
+import { PluginInputs } from './config/inputs'
 import { NetlifyPluginOptions } from './netlify_plugin_options'
 
-export interface NetlifyEvent<PluginOptions extends NetlifyPluginOptions = NetlifyPluginOptions> {
-  (options: PluginOptions): void | Promise<void>
+export interface NetlifyEvent<
+  TInputs extends PluginInputs = PluginInputs,
+  TPluginOptions extends NetlifyPluginOptions = NetlifyPluginOptions<TInputs>,
+> {
+  (options: TPluginOptions): void | Promise<void>
 }

--- a/packages/build/types/netlify_plugin.d.ts
+++ b/packages/build/types/netlify_plugin.d.ts
@@ -2,29 +2,32 @@ import { PluginInputs } from './config/inputs'
 import { NetlifyEvent } from './netlify_event'
 import { NetlifyPluginOptions } from './netlify_plugin_options'
 
-export interface NetlifyPlugin<TInputs extends PluginInputs = PluginInputs> {
+export interface NetlifyPlugin<
+  TInputs extends PluginInputs = PluginInputs,
+  TPluginOptions extends NetlifyPluginOptions = NetlifyPluginOptions<TInputs>,
+> {
   /**
    * Runs before the build command is executed.
    */
-  onPreBuild?: NetlifyEvent<NetlifyPluginOptions<TInputs>>
+  onPreBuild?: NetlifyEvent<TInputs, TPluginOptions>
   /**
    * runs directly after the build command is executed and before Functions? bundling and Edge Handlers bundling.
    */
-  onBuild?: NetlifyEvent<NetlifyPluginOptions<TInputs>>
+  onBuild?: NetlifyEvent<TInputs, TPluginOptions>
   /**
    * runs after the build command completes; after onBuild? tasks, Functions? bundling, and Edge Handlers bundling are executed; and before the deploy stage. Can be used to prevent a build from being deployed.
    */
-  onPostBuild?: NetlifyEvent<NetlifyPluginOptions<TInputs>>
+  onPostBuild?: NetlifyEvent<TInputs, TPluginOptions>
   /**
    * runs when an error occurs in the build or deploy stage, failing the build. Can’t be used to prevent a build from being deployed.
    */
-  onError?: NetlifyEvent<NetlifyPluginOptions<TInputs> & { error: Error }>
+  onError?: NetlifyEvent<TInputs, TPluginOptions & { error: Error }>
   /**
    * runs when the deploy succeeds. Can’t be used to prevent a build from being deployed.
    */
-  onSuccess?: NetlifyEvent<NetlifyPluginOptions<TInputs>>
+  onSuccess?: NetlifyEvent<TInputs, TPluginOptions>
   /**
    * runs after completion of the deploy stage, regardless of build error or success; is useful for resources cleanup. Can’t be used to prevent a build from being deployed.
    */
-  onEnd?: NetlifyEvent<NetlifyPluginOptions<TInputs> & { error?: Error }>
+  onEnd?: NetlifyEvent<TInputs, TPluginOptions & { error?: Error }>
 }


### PR DESCRIPTION
Part of netlify/pod-marketplace-and-integrations#3

This PR allows TypeScript users to instantiate plugin event handlers with just `<InputType>` instead of `<NetlifyPluginOptions<InputType>>`, which is a little simpler.

@bengry What do you think?

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅