### PR TITLE
feat: add `buildbot_zisi_trace_nft` feature flag

### DIFF
--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -17,6 +17,7 @@ const getFeatureFlag = function (name) {
 const DEFAULT_FEATURE_FLAGS = {
   buildbot_build_go_functions: false,
   buildbot_es_modules_esbuild: false,
+  buildbot_zisi_trace_nft: false,
   buildbot_zisi_esbuild_parser: false,
 }
 

--- a/packages/build/src/plugins_core/functions/feature_flags.js
+++ b/packages/build/src/plugins_core/functions/feature_flags.js
@@ -4,6 +4,7 @@ const getZisiFeatureFlags = (featureFlags) => ({
   buildGoSource: featureFlags.buildbot_build_go_functions,
   defaultEsModulesToEsbuild: featureFlags.buildbot_es_modules_esbuild,
   parseWithEsbuild: featureFlags.buildbot_zisi_esbuild_parser,
+  traceWithNft: featureFlags.buildbot_zisi_trace_nft,
 })
 
 module.exports = { getZisiFeatureFlags }

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -334,40 +334,6 @@ test.serial(`Doesn't fail build for ES module function if feature flag is off`, 
   t.false(callArgs[2].featureFlags.defaultEsModulesToEsbuild)
 })
 
-test.serial('Passes `parseWithEsbuild` feature flag to zip-it-and-ship-it', async (t) => {
-  const mockZipFunctions = sinon.stub().resolves()
-  const stub = sinon.stub(zipItAndShipIt, 'zipFunctions').get(() => mockZipFunctions)
-
-  await runFixture(t, 'core', { snapshot: false })
-  await runFixture(t, 'core', {
-    flags: { featureFlags: { buildbot_zisi_esbuild_parser: true } },
-    snapshot: false,
-  })
-
-  stub.restore()
-
-  t.is(mockZipFunctions.callCount, 2)
-  t.false(mockZipFunctions.firstCall.args[2].featureFlags.parseWithEsbuild)
-  t.true(mockZipFunctions.secondCall.args[2].featureFlags.parseWithEsbuild)
-})
-
-test.serial('Passes `buildGoSource` feature flag to zip-it-and-ship-it', async (t) => {
-  const mockZipFunctions = sinon.stub().resolves()
-  const stub = sinon.stub(zipItAndShipIt, 'zipFunctions').get(() => mockZipFunctions)
-
-  await runFixture(t, 'core', { snapshot: false })
-  await runFixture(t, 'core', {
-    flags: { featureFlags: { buildbot_build_go_functions: true } },
-    snapshot: false,
-  })
-
-  stub.restore()
-
-  t.is(mockZipFunctions.callCount, 2)
-  t.false(mockZipFunctions.firstCall.args[2].featureFlags.buildGoSource)
-  t.true(mockZipFunctions.secondCall.args[2].featureFlags.buildGoSource)
-})
-
 test.serial('Passes the right base path properties to zip-it-and-ship-it', async (t) => {
   const mockZipFunctions = sinon.stub().resolves()
   const stub = sinon.stub(zipItAndShipIt, 'zipFunctions').get(() => mockZipFunctions)
@@ -386,6 +352,38 @@ test.serial('Passes the right base path properties to zip-it-and-ship-it', async
   t.is(basePath, fixtureDir)
   t.is(config['*'].includedFilesBasePath, fixtureDir)
   t.is(repositoryRoot, fixtureDir)
+})
+
+test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) => {
+  const mockZipFunctions = sinon.stub().resolves()
+  const stub = sinon.stub(zipItAndShipIt, 'zipFunctions').get(() => mockZipFunctions)
+
+  await runFixture(t, 'core', { snapshot: false })
+  await runFixture(t, 'core', {
+    flags: { featureFlags: { buildbot_zisi_trace_nft: true } },
+    snapshot: false,
+  })
+  await runFixture(t, 'core', {
+    flags: { featureFlags: { buildbot_build_go_functions: true } },
+    snapshot: false,
+  })
+  await runFixture(t, 'core', {
+    flags: { featureFlags: { buildbot_zisi_esbuild_parser: true } },
+    snapshot: false,
+  })
+
+  stub.restore()
+
+  // eslint-disable-next-line no-magic-numbers
+  t.is(mockZipFunctions.callCount, 4)
+
+  t.false(mockZipFunctions.getCall(0).args[2].featureFlags.traceWithNft)
+  t.false(mockZipFunctions.getCall(0).args[2].featureFlags.buildGoSource)
+  t.false(mockZipFunctions.getCall(0).args[2].featureFlags.parseWithEsbuild)
+
+  t.true(mockZipFunctions.getCall(1).args[2].featureFlags.traceWithNft)
+  t.true(mockZipFunctions.getCall(2).args[2].featureFlags.buildGoSource)
+  t.true(mockZipFunctions.getCall(3).args[2].featureFlags.parseWithEsbuild)
 })
 
 test('Print warning on lingering processes', async (t) => {


### PR DESCRIPTION
#### Summary

Adds a `buildbot_zisi_trace_nft` feature flag and passes it to zip-it-and-ship-it as `traceWithNft` (see https://github.com/netlify/zip-it-and-ship-it/pull/769).

It also concentrates all feature flag assertions via sinon into one test. These tests have to run with `.serial`, so the fewer we have, the better.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
