### PR TITLE
fix: updates to plugin options types

### DIFF
--- a/packages/build/test-d/config/functions.ts
+++ b/packages/build/test-d/config/functions.ts
@@ -12,7 +12,6 @@ const testNetlifyConfigFunctions: onPreBuild = function ({
 
   if (functions.node_bundler === 'esbuild') {
     expectType<string[] | undefined>(functions.external_node_modules)
-    expectType<string[] | undefined>(functions.included_files)
     expectType<string[] | undefined>(functions.ignored_node_modules)
   } else {
     expectError(functions.external_node_modules)

--- a/packages/build/test-d/config/functions.ts
+++ b/packages/build/test-d/config/functions.ts
@@ -7,16 +7,15 @@ const testNetlifyConfigFunctions: onPreBuild = function ({
     functions: { '*': functions },
   },
 }) {
-  expectType<string>(functions.directory)
-  expectAssignable<string>(functions.node_bundler)
+  expectAssignable<string | undefined>(functions.node_bundler)
+  expectType<string[] | undefined>(functions.included_files)
 
   if (functions.node_bundler === 'esbuild') {
-    expectType<string[]>(functions.external_node_modules)
-    expectType<string[]>(functions.included_files)
-    expectType<string[]>(functions.ignored_node_modules)
+    expectType<string[] | undefined>(functions.external_node_modules)
+    expectType<string[] | undefined>(functions.included_files)
+    expectType<string[] | undefined>(functions.ignored_node_modules)
   } else {
     expectError(functions.external_node_modules)
-    expectError(functions.included_files)
     expectError(functions.ignored_node_modules)
   }
 }

--- a/packages/build/types/config/functions.d.ts
+++ b/packages/build/types/config/functions.d.ts
@@ -3,36 +3,34 @@ type GlobPattern = string
 /* eslint-disable camelcase -- some properties are named in snake case in this API */
 type FunctionsObject = {
   /**
-   * string that includes the path to a site's [functions directory](https://docs.netlify.com/functions/configure-and-deploy/#configure-the-functions-folder)
+   * a list of additional paths to include in the function bundle. Although our build system includes statically referenced files (like `require("./some-file.js")`) by default, `included_files` lets you specify additional files or directories and reference them dynamically in function code. You can use `*` to match any character or prefix an entry with `!` to exclude files. Paths are relative to the [base directory](https://docs.netlify.com/configure-builds/get-started/#definitions-1).
    */
-  directory: string
+  included_files?: string[]
 } & (
   | {
       /**
        * the function bundling method used in [`@netlify/zip-it-and-ship-it`](https://github.com/netlify/zip-it-and-ship-it).
        */
-      node_bundler: 'zisi'
+      node_bundler?: 'zisi' | 'nft'
     }
   | {
       /**
        * the function bundling method used in [`@netlify/zip-it-and-ship-it`](https://github.com/netlify/zip-it-and-ship-it).
        */
-      node_bundler: 'esbuild'
+      node_bundler?: 'esbuild'
 
       /**
        * a list of Node.js modules that are copied to the bundled artifact without adjusting their source or references during the bundling process.
        * This property helps handle dependencies that can’t be inlined, such as modules with native add-ons.
        */
-      external_node_modules: string[]
+      external_node_modules?: string[]
 
-      /**
-       * a list of additional paths to include in the function bundle. Although our build system includes statically referenced files (like `require("./some-file.js")`) by default, `included_files` lets you specify additional files or directories and reference them dynamically in function code. You can use `*` to match any character or prefix an entry with `!` to exclude files. Paths are relative to the [base directory](https://docs.netlify.com/configure-builds/get-started/#definitions-1).
-       */
-      included_files: string[]
-
-      ignored_node_modules: string[]
+      ignored_node_modules?: string[]
     }
 )
 /* eslint-enable camelcase */
 
-export type Functions = Record<GlobPattern, FunctionsObject>
+export type Functions = {
+  '*': FunctionsObject
+  [pattern: GlobPattern]: FunctionsObject
+}

--- a/packages/build/types/options/netlify_plugin_build_util.d.ts
+++ b/packages/build/types/options/netlify_plugin_build_util.d.ts
@@ -3,5 +3,5 @@
  */
 export type NetlifyPluginBuildUtil = Record<
   'failBuild' | 'failPlugin' | 'cancelBuild',
-  (message: string, options?: { error?: Error }) => void
+  (message: string, options?: { error?: Error }) => never
 >


### PR DESCRIPTION
#### Summary

Corrects the types for `netlifyConfig.functions` and `utils.failBuild` etc. 

`directory` is not included in the functions config, and `included_files` applies to all bundlers. `nft` is another valid bundler name.

The `failBuild` etc functions throw, so should return `never`

