### PR TITLE
feat: add `buildbot_nft_transpile_esm` feature flag

### DIFF
--- a/packages/build/src/plugins_core/functions/feature_flags.js
+++ b/packages/build/src/plugins_core/functions/feature_flags.js
@@ -3,7 +3,7 @@
 const getZisiFeatureFlags = (featureFlags) => ({
   buildGoSource: featureFlags.buildbot_build_go_functions,
   defaultEsModulesToEsbuild: featureFlags.buildbot_es_modules_esbuild,
-  nftTranspile: featureFlags.buildbot_zisi_trace_nft,
+  nftTranspile: featureFlags.buildbot_nft_transpile_esm || featureFlags.buildbot_zisi_trace_nft,
   parseWithEsbuild: featureFlags.buildbot_zisi_esbuild_parser,
   traceWithNft: featureFlags.buildbot_zisi_trace_nft,
 })

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -376,6 +376,10 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
     flags: { featureFlags: { buildbot_scheduled_functions: true } },
     snapshot: false,
   })
+  await runFixture(t, 'schedule', {
+    flags: { featureFlags: { buildbot_nft_transpile_esm: true } },
+    snapshot: false,
+  })
 
   stub.restore()
 
@@ -391,6 +395,8 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
   t.true(mockZipFunctions.getCall(1).args[2].featureFlags.nftTranspile)
   t.true(mockZipFunctions.getCall(2).args[2].featureFlags.buildGoSource)
   t.true(mockZipFunctions.getCall(3).args[2].featureFlags.parseWithEsbuild)
+  // eslint-disable-next-line no-magic-numbers
+  t.true(mockZipFunctions.getCall(4).args[2].featureFlags.nftTranspile)
 
   t.is(mockZipFunctions.getCall(0).args[2].config.test.schedule, undefined)
   // eslint-disable-next-line no-magic-numbers

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -396,7 +396,7 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
   t.true(mockZipFunctions.getCall(2).args[2].featureFlags.buildGoSource)
   t.true(mockZipFunctions.getCall(3).args[2].featureFlags.parseWithEsbuild)
   // eslint-disable-next-line no-magic-numbers
-  t.true(mockZipFunctions.getCall(4).args[2].featureFlags.nftTranspile)
+  t.true(mockZipFunctions.getCall(5).args[2].featureFlags.nftTranspile)
 
   t.is(mockZipFunctions.getCall(0).args[2].config.test.schedule, undefined)
   // eslint-disable-next-line no-magic-numbers

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -384,7 +384,7 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
   stub.restore()
 
   // eslint-disable-next-line no-magic-numbers
-  t.is(mockZipFunctions.callCount, 5)
+  t.is(mockZipFunctions.callCount, 6)
 
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.traceWithNft)
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.buildGoSource)


### PR DESCRIPTION
#### Summary

Set the `nftTranspile` zip-it-and-ship-it flag when the `buildbot_nft_transpile_esm` LaunchDarkly flag is set.