### PR TITLE
fix: remove `array-flat-polyfill`

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -64,7 +64,6 @@
     "@netlify/zip-it-and-ship-it": "^5.0.0",
     "@sindresorhus/slugify": "^1.1.0",
     "ansi-escapes": "^4.3.2",
-    "array-flat-polyfill": "^1.0.1",
     "chalk": "^4.1.2",
     "clean-stack": "^3.0.1",
     "execa": "^5.1.1",

--- a/packages/build/src/core/bin.js
+++ b/packages/build/src/core/bin.js
@@ -6,8 +6,6 @@ const process = require('process')
 const filterObj = require('filter-obj')
 const yargs = require('yargs')
 
-require('../utils/polyfills')
-
 const { normalizeCliFeatureFlags } = require('./feature_flags')
 const { FLAGS } = require('./flags')
 const build = require('./main')

--- a/packages/build/src/core/main.js
+++ b/packages/build/src/core/main.js
@@ -1,8 +1,6 @@
 'use strict'
 
 /* eslint-disable max-lines, import/max-dependencies */
-require('../utils/polyfills')
-
 const { handleBuildError } = require('../error/handle')
 const { getErrorInfo } = require('../error/info')
 const { startErrorMonitor } = require('../error/monitor/start')

--- a/packages/build/src/plugins/child/main.js
+++ b/packages/build/src/plugins/child/main.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('../../utils/polyfills')
-
 const { setInspectColors } = require('../../log/colors')
 const { sendEventToParent, getEventsFromParent } = require('../ipc')
 

--- a/packages/build/src/utils/polyfills.js
+++ b/packages/build/src/utils/polyfills.js
@@ -1,5 +1,0 @@
-'use strict'
-
-// Patches `Array.flat()` and `Array.flatMap()`
-// TODO: remove after dropping Node <12 support
-require('array-flat-polyfill')

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -43,7 +43,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "array-flat-polyfill": "^1.0.1",
     "cpy": "^8.1.0",
     "del": "^5.1.0",
     "get-stream": "^6.0.0",

--- a/packages/cache-utils/src/main.js
+++ b/packages/cache-utils/src/main.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('./utils/polyfills')
-
 const del = require('del')
 
 const { getCacheDir } = require('./dir')

--- a/packages/cache-utils/src/utils/polyfills.js
+++ b/packages/cache-utils/src/utils/polyfills.js
@@ -1,5 +1,0 @@
-'use strict'
-
-// Patches `Array.flat()` and `Array.flatMap()`
-// TODO: remove after dropping Node <12 support
-require('array-flat-polyfill')

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -49,7 +49,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "array-flat-polyfill": "^1.0.1",
     "chalk": "^4.1.2",
     "cron-parser": "^4.1.0",
     "deepmerge": "^4.2.2",

--- a/packages/config/src/bin/main.js
+++ b/packages/config/src/bin/main.js
@@ -10,8 +10,6 @@ const { stableStringify } = require('fast-safe-stringify')
 const makeDir = require('make-dir')
 const omit = require('omit.js').default
 
-require('../utils/polyfills')
-
 const { isUserError } = require('../error')
 const resolveConfig = require('../main')
 

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -1,8 +1,6 @@
 /* eslint-disable max-lines */
 'use strict'
 
-require('./utils/polyfills')
-
 const { getApiClient } = require('./api/client')
 const { getSiteInfo } = require('./api/site_info')
 const { getInitialBase, getBase, addBase } = require('./base')

--- a/packages/config/src/utils/polyfills.js
+++ b/packages/config/src/utils/polyfills.js
@@ -1,5 +1,0 @@
-'use strict'
-
-// Patches `Array.flat()` and `Array.flatMap()`
-// TODO: remove after dropping Node <12 support
-require('array-flat-polyfill')


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/3741

Now that Node.js 10 support has been dropped, we can remove the `array.flat()` polyfill (`array-flat-polyfill`).

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅