### PR TITLE
chore!: use pure ES modules with `run-utils`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,14 @@ module.exports = {
     strict: 2,
 
     // eslint-plugin-ava needs to know where test files are located
-    'ava/no-ignored-test-files': [2, { files: ['tests/**/*.js', '!tests/{helpers,fixtures}/**/*.{js,json}'] }],
-    'ava/no-import-test-files': [2, { files: ['tests/**/*.js', '!tests/{helpers,fixtures}/**/*.{js,json}'] }],
+    'ava/no-ignored-test-files': [
+      2,
+      { files: ['tests/**/*.{cjs,mjs,js}', '!tests/{helpers,fixtures}/**/*.{cjs,mjs,js,json}'] },
+    ],
+    'ava/no-import-test-files': [
+      2,
+      { files: ['tests/**/*.{cjs,mjs,js}', '!tests/{helpers,fixtures}/**/*.{cjs,mjs,js,json}'] },
+    ],
 
     // Avoid state mutation except for some known state variables
     'fp/no-mutating-methods': [
@@ -52,7 +58,7 @@ module.exports = {
   overrides: [
     ...overrides,
     {
-      files: ['**/fixtures/**/*.js'],
+      files: ['**/fixtures/**/*.{cjs,mjs,js}'],
       rules: {
         'import/no-unresolved': 0,
       },
@@ -64,6 +70,7 @@ module.exports = {
       },
       rules: {
         'node/no-unsupported-features/es-syntax': 0,
+        'ava/no-import-test-files': 0,
       },
     },
 
@@ -71,7 +78,7 @@ module.exports = {
     // many parameters, such as `runStep` in `src/steps/run_step.js`.
     // We should discuss whether we want to keep this rule or discontinue it.
     {
-      files: ['packages/build/**/*.js'],
+      files: ['packages/build/**/*.{cjs,mjs,js}'],
       rules: {
         'max-lines-per-function': 'off',
       },
@@ -87,9 +94,20 @@ module.exports = {
       },
     },
     {
-      files: ['packages/*/tests/**/*.js'],
+      files: ['packages/*/tests/**/*.{cjs,mjs,js}'],
       rules: {
         'no-magic-numbers': 'off',
+      },
+    },
+
+    // Those packages are using pure ES modules
+    {
+      files: ['packages/run-utils/**/*.{cjs,mjs,js}'],
+      parserOptions: {
+        sourceType: 'module',
+      },
+      rules: {
+        'import/extensions': [2, 'ignorePackages'],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "prepublishOnly:test": "run-local \"npm test\""
   },
   "config": {
-    "eslint": "--ignore-path .gitignore --ignore-pattern \"packages/*/tests/**/snapshots/*.md\" --cache --format=codeframe --max-warnings=0 \"{packages,.github}/**/*.{js,md,html}\" \"*.{js,md,html}\" \".*.{js,md,html}\"",
-    "prettier": "--ignore-path .gitignore --loglevel=warn \"{packages,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\" \".*.{js,yml,json,html}\" \"!**/package-lock.json\" \"!**/CHANGELOG.md\" \"!package-lock.json\" \"!.release-please-manifest.json\" \"!.github/**/*.md\""
+    "eslint": "--ignore-path .gitignore --ignore-pattern \"packages/*/tests/**/snapshots/*.md\" --cache --format=codeframe --max-warnings=0 \"{packages,.github}/**/*.{cjs,mjs,js,md,html}\" \"*.{cjs,mjs,js,md,html}\" \".*.{cjs,mjs,js,md,html}\"",
+    "prettier": "--ignore-path .gitignore --loglevel=warn \"{packages,.github}/**/*.{cjs,mjs,js,md,yml,json,html}\" \"*.{cjs,mjs,js,yml,json,html}\" \".*.{cjs,mjs,js,yml,json,html}\" \"!**/package-lock.json\" \"!**/CHANGELOG.md\" \"!package-lock.json\" \"!.release-please-manifest.json\" \"!.github/**/*.md\""
   },
   "workspaces": [
     "packages/*"
   ],
   "ava": {
     "files": [
-      "packages/**/tests/*.js",
-      "packages/**/tests/**/tests.js"
+      "packages/**/tests/*.{cjs,mjs,js}",
+      "packages/**/tests/**/tests.{cjs,mjs,js}"
     ],
     "verbose": true,
     "timeout": "120s",

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -13,7 +13,7 @@ const run = async function (
 ) {
   const method = methods[event]
   const runState = {}
-  const utils = getUtils({ event, constants, runState })
+  const utils = await getUtils({ event, constants, runState })
   const netlifyConfigCopy = cloneNetlifyConfig(netlifyConfig)
   const runOptions = { utils, constants, inputs, netlifyConfig: netlifyConfigCopy, packageJson, error }
 

--- a/packages/build/src/plugins/child/utils.js
+++ b/packages/build/src/plugins/child/utils.js
@@ -3,7 +3,6 @@
 const { bindOpts: cacheBindOpts } = require('@netlify/cache-utils')
 const { add: functionsAdd, list: functionsList, listAll: functionsListAll } = require('@netlify/functions-utils')
 const getGitUtils = require('@netlify/git-utils')
-const run = require('@netlify/run-utils')
 
 const { failBuild, failPlugin, cancelBuild, failPluginWithWarning } = require('../error')
 const { isSoftFailEvent } = require('../events')
@@ -11,8 +10,14 @@ const { isSoftFailEvent } = require('../events')
 const { addLazyProp } = require('./lazy')
 const { show } = require('./status')
 
+const runUtilsPromise = import('@netlify/run-utils')
+
 // Retrieve the `utils` argument.
-const getUtils = function ({ event, constants: { FUNCTIONS_SRC, INTERNAL_FUNCTIONS_SRC, CACHE_DIR }, runState }) {
+const getUtils = async function ({ event, constants: { FUNCTIONS_SRC, INTERNAL_FUNCTIONS_SRC, CACHE_DIR }, runState }) {
+  const { run, runCommand } = await runUtilsPromise
+  // eslint-disable-next-line fp/no-mutation
+  run.command = runCommand
+
   const build = getBuildUtils(event)
   const cache = getCacheUtils(CACHE_DIR)
   const functions = getFunctionsUtils(FUNCTIONS_SRC, INTERNAL_FUNCTIONS_SRC)

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -2,7 +2,9 @@
   "name": "@netlify/run-utils",
   "version": "3.0.0",
   "description": "Utility for running commands inside Netlify Build",
-  "main": "src/main.js",
+  "type": "module",
+  "exports": "./src/main.js",
+  "main": "./src/main.js",
   "files": [
     "src/**/*.js"
   ],

--- a/packages/run-utils/src/main.js
+++ b/packages/run-utils/src/main.js
@@ -1,11 +1,9 @@
-'use strict'
+import process from 'process'
 
-const process = require('process')
-
-const execa = require('execa')
+import execa from 'execa'
 
 // Run a command, with arguments being an array
-const run = function (file, args, options) {
+export const run = function (file, args, options) {
   const [argsA, optionsA] = parseArgs(args, options)
   const optionsB = { ...DEFAULT_OPTIONS, ...optionsA }
   const childProcess = execa(file, argsA, optionsB)
@@ -14,7 +12,7 @@ const run = function (file, args, options) {
 }
 
 // Run a command, with file + arguments being a single string
-const runCommand = function (command, options) {
+export const runCommand = function (command, options) {
   const optionsA = { ...DEFAULT_OPTIONS, ...options }
   const childProcess = execa.command(command, optionsA)
   redirectOutput(childProcess, optionsA)
@@ -46,9 +44,3 @@ const redirectOutput = function (childProcess, { stdio, stdout, stderr }) {
   childProcess.stdout.pipe(process.stdout)
   childProcess.stderr.pipe(process.stderr)
 }
-
-// Needed to add a property to the function
-// eslint-disable-next-line fp/no-mutation
-run.command = runCommand
-
-module.exports = run

--- a/packages/run-utils/tests/fixtures/run.js
+++ b/packages/run-utils/tests/fixtures/run.js
@@ -1,10 +1,7 @@
-'use strict'
+import { argv } from 'process'
 
-const {
-  argv: [, , command, options],
-} = require('process')
+import { runCommand } from '../../src/main.js'
 
-const run = require('../..')
-
+const [, , command, options] = argv
 const optionsA = options === undefined ? options : JSON.parse(options)
-run.command(command, optionsA)
+runCommand(command, optionsA)

--- a/packages/run-utils/tests/main.mjs
+++ b/packages/run-utils/tests/main.mjs
@@ -1,14 +1,13 @@
-'use strict'
+import { platform } from 'process'
+import { fileURLToPath } from 'url'
 
-const { platform } = require('process')
+import test from 'ava'
+import execa from 'execa'
+import semver from 'semver'
 
-const test = require('ava')
-const execa = require('execa')
-const { valid: validVersion } = require('semver')
+import { run, runCommand } from '../src/main.js'
 
-const run = require('..')
-
-const FIXTURES_DIR = `${__dirname}/fixtures`
+const FIXTURES_DIR = fileURLToPath(new URL('fixtures', import.meta.url))
 const RUN_FILE = `${FIXTURES_DIR}/run.js`
 
 const runInChildProcess = function (command, options) {
@@ -18,12 +17,12 @@ const runInChildProcess = function (command, options) {
 
 test('Should expose several methods', (t) => {
   t.is(typeof run, 'function')
-  t.is(typeof run.command, 'function')
+  t.is(typeof runCommand, 'function')
 })
 
 test('Can run a command as a single string', async (t) => {
-  const { stdout } = await run.command('ava --version', { stdio: 'pipe' })
-  t.truthy(validVersion(stdout))
+  const { stdout } = await runCommand('ava --version', { stdio: 'pipe' })
+  t.truthy(semver.valid(stdout))
 })
 
 // `echo` in `cmd.exe` is different from Unix
@@ -41,12 +40,12 @@ if (platform !== 'win32') {
 
 test('Can run local binaries', async (t) => {
   const { stdout } = await run('ava', ['--version'], { stdio: 'pipe' })
-  t.truthy(validVersion(stdout))
+  t.truthy(semver.valid(stdout))
 })
 
 test('Should redirect stdout/stderr to parent', async (t) => {
   const { stdout } = await runInChildProcess('ava --version')
-  t.truthy(validVersion(stdout))
+  t.truthy(semver.valid(stdout))
 })
 
 test('Should not redirect stdout/stderr to parent when using "stdio" option', async (t) => {


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/3742

This switches `run-utils` from CommonJS to pure ES modules.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅