### PR TITLE
fix: load plugin utilities directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "packages/**/tests/**/tests.js"
     ],
     "verbose": true,
-    "timeout": "60s",
+    "timeout": "120s",
     "environmentVariables": {
       "FORCE_COLOR": "1"
     }


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/3742

Plugin utilities are currently loaded lazily. 

However, this has created some bugs in the past. More importantly, this does not work with pure ES modules. This is because `import()` is async while `require()` is not. Utilities are loaded on behalf of plugin authors which makes using async code difficult.

This PR switches to loading plugin `utils` like any other regular dependency, which solves those problems.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅