### PR TITLE
fix: use static imports with `@netlify/config`

### DIFF
--- a/packages/config/src/api/client.js
+++ b/packages/config/src/api/client.js
@@ -1,17 +1,15 @@
+import { NetlifyAPI } from 'netlify'
+
 import { removeUndefined } from '../utils/remove_falsy.js'
 
-// TODO: use static `import` after migrating `@netlify/config` to pure ES modules
-const jsClient = import('netlify')
-
 // Retrieve Netlify API client, if an access token was passed
-export const getApiClient = async function ({ token, offline, testOpts = {}, host, scheme, pathPrefix }) {
+export const getApiClient = function ({ token, offline, testOpts = {}, host, scheme, pathPrefix }) {
   if (!token || offline) {
     return
   }
 
   // TODO: find less intrusive way to mock HTTP requests
   const parameters = removeUndefined({ scheme: testOpts.scheme || scheme, host: testOpts.host || host, pathPrefix })
-  const { NetlifyAPI } = await jsClient
   const api = new NetlifyAPI(token, parameters)
   return api
 }

--- a/packages/config/src/headers.js
+++ b/packages/config/src/headers.js
@@ -1,9 +1,8 @@
 import { resolve } from 'path'
 
-import { warnHeadersParsing, warnHeadersCaseSensitivity } from './log/messages.js'
+import { parseAllHeaders } from 'netlify-headers-parser'
 
-// TODO: use static `import` after migrating this repository to pure ES modules
-const netlifyHeadersParser = import('netlify-headers-parser')
+import { warnHeadersParsing, warnHeadersCaseSensitivity } from './log/messages.js'
 
 // Retrieve path to `_headers` file (even if it does not exist yet)
 export const getHeadersPath = function ({ build: { publish } }) {
@@ -14,7 +13,6 @@ const HEADERS_FILENAME = '_headers'
 
 // Add `config.headers`
 export const addHeaders = async function ({ headers: configHeaders, ...config }, headersPath, logs) {
-  const { parseAllHeaders } = await netlifyHeadersParser
   const { headers, errors } = await parseAllHeaders({
     headersFiles: [headersPath],
     configHeaders,

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -31,7 +31,7 @@ export const resolveConfig = async function (opts) {
   const { cachedConfig, cachedConfigPath, host, scheme, pathPrefix, testOpts, token, offline, ...optsA } =
     addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
-  const api = await getApiClient({ token, offline, host, scheme, pathPrefix, testOpts })
+  const api = getApiClient({ token, offline, host, scheme, pathPrefix, testOpts })
 
   const parsedCachedConfig = await getCachedConfig({ cachedConfig, cachedConfigPath, token, api })
   if (parsedCachedConfig !== undefined) {

--- a/packages/config/src/redirects.js
+++ b/packages/config/src/redirects.js
@@ -1,9 +1,8 @@
 import { resolve } from 'path'
 
-import { warnRedirectsParsing } from './log/messages.js'
+import { parseAllRedirects } from 'netlify-redirect-parser'
 
-// TODO: use static `import` after migrating this repository to pure ES modules
-const netlifyRedirectParser = import('netlify-redirect-parser')
+import { warnRedirectsParsing } from './log/messages.js'
 
 // Retrieve path to `_redirects` file (even if it does not exist yet)
 export const getRedirectsPath = function ({ build: { publish } }) {
@@ -14,7 +13,6 @@ const REDIRECTS_FILENAME = '_redirects'
 
 // Add `config.redirects`
 export const addRedirects = async function ({ redirects: configRedirects, ...config }, redirectsPath, logs) {
-  const { parseAllRedirects } = await netlifyRedirectParser
   const { redirects, errors } = await parseAllRedirects({
     redirectsFiles: [redirectsPath],
     configRedirects,


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/3742

Now that `@netlify/config` uses ES modules, we can change some dynamic imports into static ones.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅