### PR TITLE
chore(ci-release): use v2 of release please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
           app-id: ${{ secrets.TOKENS_APP_ID }}
-      - uses: GoogleCloudPlatform/release-please-action@cac03337f2ee29fd77292e84ae9a5b9c994d4c71
+      - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
           token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
This PR reverts https://github.com/netlify/build/pull/3994 which inadvertently updated the release please action from v2 to v3.

v3 has some breaking changes to `manifest` releaser (which we are using in this monorepo), so we'll need to update manually.  