### PR TITLE
feat: remove `buildbot_scheduled_functions` feature flag

### DIFF
--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -18,6 +18,5 @@ export const DEFAULT_FEATURE_FLAGS = {
   buildbot_es_modules_esbuild: false,
   buildbot_zisi_trace_nft: false,
   buildbot_zisi_esbuild_parser: false,
-  buildbot_scheduled_functions: false,
   zisi_parse_isc: false,
 }

--- a/packages/build/src/plugins_core/functions/index.js
+++ b/packages/build/src/plugins_core/functions/index.js
@@ -19,7 +19,7 @@ const isUsingEsbuild = (functionsConfig = {}) =>
 // The function configuration keys returned by @netlify/config are not an exact
 // match to the properties that @netlify/zip-it-and-ship-it expects. We do that
 // translation here.
-const normalizeFunctionConfig = ({ buildDir, featureFlags, functionConfig = {}, isRunningLocally }) => ({
+const normalizeFunctionConfig = ({ buildDir, functionConfig = {}, isRunningLocally }) => ({
   externalNodeModules: functionConfig.external_node_modules,
   includedFiles: functionConfig.included_files,
   includedFilesBasePath: buildDir,
@@ -37,7 +37,7 @@ const normalizeFunctionConfig = ({ buildDir, featureFlags, functionConfig = {}, 
   // build process.
   rustTargetDirectory: isRunningLocally ? undefined : resolve(buildDir, '.netlify', 'rust-functions-cache', '[name]'),
 
-  schedule: featureFlags.buildbot_scheduled_functions ? functionConfig.schedule : undefined,
+  schedule: functionConfig.schedule,
 })
 
 const getZisiParameters = ({

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -379,10 +379,6 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
     snapshot: false,
   })
   await runFixture(t, 'schedule', {
-    flags: { featureFlags: { buildbot_scheduled_functions: true } },
-    snapshot: false,
-  })
-  await runFixture(t, 'schedule', {
     flags: { featureFlags: { buildbot_nft_transpile_esm: true } },
     snapshot: false,
   })
@@ -397,12 +393,12 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
 
   stub.restore()
 
-  t.is(mockZipFunctions.callCount, 8)
+  t.is(mockZipFunctions.callCount, 7)
 
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.traceWithNft)
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.buildGoSource)
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.parseWithEsbuild)
-  t.is(mockZipFunctions.getCall(0).args[2].config.test.schedule, undefined)
+  t.is(mockZipFunctions.getCall(0).args[2].config.test.schedule, '@daily')
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.nftTranspile)
   t.false(mockZipFunctions.getCall(0).args[2].featureFlags.parseISC)
   t.is(mockZipFunctions.getCall(0).args[2].featureFlags.this_is_a_mock_flag, undefined)
@@ -412,11 +408,10 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
   t.true(mockZipFunctions.getCall(1).args[2].featureFlags.nftTranspile)
   t.true(mockZipFunctions.getCall(2).args[2].featureFlags.buildGoSource)
   t.true(mockZipFunctions.getCall(3).args[2].featureFlags.parseWithEsbuild)
-  t.is(mockZipFunctions.getCall(4).args[2].config.test.schedule, '@daily')
-  t.true(mockZipFunctions.getCall(5).args[2].featureFlags.nftTranspile)
-  t.true(mockZipFunctions.getCall(6).args[2].featureFlags.parseISC)
-  t.true(mockZipFunctions.getCall(7).args[2].featureFlags.this_is_a_mock_flag)
-  t.true(mockZipFunctions.getCall(7).args[2].featureFlags.and_another_one)
+  t.true(mockZipFunctions.getCall(4).args[2].featureFlags.nftTranspile)
+  t.true(mockZipFunctions.getCall(5).args[2].featureFlags.parseISC)
+  t.true(mockZipFunctions.getCall(6).args[2].featureFlags.this_is_a_mock_flag)
+  t.true(mockZipFunctions.getCall(6).args[2].featureFlags.and_another_one)
 })
 /* eslint-enable max-statements, no-magic-numbers */
 


### PR DESCRIPTION
#### Summary

Removes the `buildbot_scheduled_functions` feature flag.

**A picture of a cute animal (not mandatory, but encouraged)**

![53f92680adca46bf8f6285d1ebf6f75b](https://user-images.githubusercontent.com/4162329/147929243-bbea291a-dc99-430c-9d28-f3fe9bf3f84a.png)

