### PR TITLE
feat: pass `zipGo` property to ZISI

### DIFF
--- a/packages/build/src/plugins_core/functions/index.js
+++ b/packages/build/src/plugins_core/functions/index.js
@@ -24,6 +24,7 @@ const normalizeFunctionConfig = ({ buildDir, functionConfig = {}, isRunningLocal
   includedFiles: functionConfig.included_files,
   includedFilesBasePath: buildDir,
   ignoredNodeModules: functionConfig.ignored_node_modules,
+  schedule: functionConfig.schedule,
 
   // When the user selects esbuild as the Node bundler, we still want to use
   // the legacy ZISI bundler as a fallback. Rather than asking the user to
@@ -37,7 +38,9 @@ const normalizeFunctionConfig = ({ buildDir, functionConfig = {}, isRunningLocal
   // build process.
   rustTargetDirectory: isRunningLocally ? undefined : resolve(buildDir, '.netlify', 'rust-functions-cache', '[name]'),
 
-  schedule: functionConfig.schedule,
+  // Go functions should be zipped only when building locally. When running in
+  // buildbot, the Go API client will handle the zipping.
+  zipGo: isRunningLocally ? true : undefined,
 })
 
 const getZisiParameters = ({

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -334,7 +334,7 @@ test.serial(`Doesn't fail build for ES module function if feature flag is off`, 
   t.false(callArgs[2].featureFlags.defaultEsModulesToEsbuild)
 })
 
-test.serial('Passes the right base path properties to zip-it-and-ship-it', async (t) => {
+test.serial('Passes the right properties to zip-it-and-ship-it', async (t) => {
   // eslint-disable-next-line import/no-named-as-default-member
   const mockZipFunctions = sinon.stub().resolves()
   // eslint-disable-next-line import/no-named-as-default-member
@@ -343,17 +343,24 @@ test.serial('Passes the right base path properties to zip-it-and-ship-it', async
   const fixtureDir = join(FIXTURES_DIR, fixtureName)
 
   await runFixture(t, fixtureName, { snapshot: false })
+  await runFixture(t, fixtureName, { flags: { mode: 'buildbot' }, snapshot: false })
 
   stub.restore()
 
-  t.is(mockZipFunctions.callCount, 1)
+  t.is(mockZipFunctions.callCount, 2)
 
   // eslint-disable-next-line prefer-destructuring
-  const { basePath, config, repositoryRoot } = mockZipFunctions.firstCall.args[2]
+  const params1 = mockZipFunctions.firstCall.args[2]
 
-  t.is(basePath, fixtureDir)
-  t.is(config['*'].includedFilesBasePath, fixtureDir)
-  t.is(repositoryRoot, fixtureDir)
+  t.is(params1.basePath, fixtureDir)
+  t.true(params1.config['*'].zipGo)
+  t.is(params1.config['*'].includedFilesBasePath, fixtureDir)
+  t.is(params1.repositoryRoot, fixtureDir)
+
+  // eslint-disable-next-line prefer-destructuring
+  const params2 = mockZipFunctions.secondCall.args[2]
+
+  t.is(params2.config['*'].zipGo, undefined)
 })
 
 /* eslint-disable max-statements, no-magic-numbers */


### PR DESCRIPTION
#### Summary

Passes the `zipGo` configuration option to zip-it-and-ship-it (added in https://github.com/netlify/zip-it-and-ship-it/pull/955) when running locally.

**A picture of a cute animal (not mandatory, but encouraged)**

![vv95h](https://user-images.githubusercontent.com/4162329/150196471-88228ebb-036f-49d5-bd28-f60399684f8a.jpg)

