### PR TITLE
chore: add regression tests for sites with many redirects or headers

### DIFF
--- a/packages/build/tests/log/fixtures/truncate_headers/manifest.yml
+++ b/packages/build/tests/log/fixtures/truncate_headers/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/log/fixtures/truncate_headers/netlify.toml
+++ b/packages/build/tests/log/fixtures/truncate_headers/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin"

--- a/packages/build/tests/log/fixtures/truncate_headers/plugin.js
+++ b/packages/build/tests/log/fixtures/truncate_headers/plugin.js
@@ -1,0 +1,15 @@
+export const onPreBuild = function ({ netlifyConfig }) {
+  // eslint-disable-next-line no-param-reassign
+  netlifyConfig.headers = Array.from({ length: 1e3 }, (value, index) => ({
+    for: `/here/${index}`,
+    values: { TEST: `${index}` },
+  }))
+}
+
+export const onPostBuild = function ({
+  utils: {
+    build: { failBuild },
+  },
+}) {
+  failBuild('test')
+}

--- a/packages/build/tests/log/fixtures/truncate_redirects/manifest.yml
+++ b/packages/build/tests/log/fixtures/truncate_redirects/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/log/fixtures/truncate_redirects/netlify.toml
+++ b/packages/build/tests/log/fixtures/truncate_redirects/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin"

--- a/packages/build/tests/log/fixtures/truncate_redirects/plugin.js
+++ b/packages/build/tests/log/fixtures/truncate_redirects/plugin.js
@@ -1,0 +1,16 @@
+export const onPreBuild = function ({ netlifyConfig }) {
+  // eslint-disable-next-line no-param-reassign
+  netlifyConfig.redirects = Array.from({ length: 1e3 }, (value, index) => ({
+    from: `/here/${index}`,
+    to: '/there',
+    query: { test: index },
+  }))
+}
+
+export const onPostBuild = function ({
+  utils: {
+    build: { failBuild },
+  },
+}) {
+  failBuild('test')
+}

--- a/packages/build/tests/log/tests.js
+++ b/packages/build/tests/log/tests.js
@@ -58,3 +58,13 @@ test('The verbose flag enables verbosity', async (t) => {
 test('Verbosity works with plugin errors', async (t) => {
   await runFixture(t, 'verbose_error', { flags: { verbose: true } })
 })
+
+test.skip('Does not truncate long headers in logs', async (t) => {
+  const { returnValue } = await runFixture(t, 'truncate_headers', { snapshot: false })
+  t.false(returnValue.includes('999'))
+})
+
+test.skip('Does not truncate long redirects in logs', async (t) => {
+  const { returnValue } = await runFixture(t, 'truncate_redirects', { snapshot: false })
+  t.false(returnValue.includes('999'))
+})

--- a/packages/build/tests/mutate_save/fixtures/many_headers/manifest.yml
+++ b/packages/build/tests/mutate_save/fixtures/many_headers/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/mutate_save/fixtures/many_headers/netlify.toml
+++ b/packages/build/tests/mutate_save/fixtures/many_headers/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin"

--- a/packages/build/tests/mutate_save/fixtures/many_headers/plugin.js
+++ b/packages/build/tests/mutate_save/fixtures/many_headers/plugin.js
@@ -1,0 +1,11 @@
+export const onPreBuild = function ({ netlifyConfig }) {
+  // eslint-disable-next-line no-param-reassign
+  netlifyConfig.headers = Array.from({ length: 1e3 }, (value, index) => ({
+    for: `/here/${index}`,
+    values: { TEST: 'test' },
+  }))
+}
+
+export const onSuccess = function ({ netlifyConfig }) {
+  console.log(netlifyConfig.headers.length)
+}

--- a/packages/build/tests/mutate_save/fixtures/many_redirects/manifest.yml
+++ b/packages/build/tests/mutate_save/fixtures/many_redirects/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/mutate_save/fixtures/many_redirects/netlify.toml
+++ b/packages/build/tests/mutate_save/fixtures/many_redirects/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin"

--- a/packages/build/tests/mutate_save/fixtures/many_redirects/plugin.js
+++ b/packages/build/tests/mutate_save/fixtures/many_redirects/plugin.js
@@ -1,0 +1,11 @@
+export const onPreBuild = function ({ netlifyConfig }) {
+  // eslint-disable-next-line no-param-reassign
+  netlifyConfig.redirects = Array.from({ length: 1e3 }, (value, index) => ({
+    from: `/here/${index}`,
+    to: '/there',
+  }))
+}
+
+export const onSuccess = function ({ netlifyConfig }) {
+  console.log(netlifyConfig.redirects.length)
+}

--- a/packages/build/tests/mutate_save/tests.js
+++ b/packages/build/tests/mutate_save/tests.js
@@ -196,6 +196,60 @@ test('--saveConfig saves the configuration changes as netlify.toml', async (t) =
   }
 })
 
+test('--saveConfig does not truncate high amount of redirects', async (t) => {
+  const fixtureDir = `${FIXTURES_DIR}/many_redirects`
+  const fixtureConfigPath = `${fixtureDir}/netlify.toml`
+  const configPath = `${fixtureDir}/test_netlify.toml`
+  await fs.copyFile(fixtureConfigPath, configPath)
+  const { address, stopServer } = await startDeployServer({
+    async onRequest() {
+      const newConfigContents = await fs.readFile(configPath, 'utf8')
+      t.true(newConfigContents.includes('999'))
+    },
+  })
+  try {
+    await runFixture(t, 'many_redirects', {
+      flags: {
+        buildbotServerSocket: address,
+        config: configPath,
+        saveConfig: true,
+        context: 'production',
+        branch: 'main',
+      },
+      snapshot: false,
+    })
+  } finally {
+    await stopServer()
+  }
+})
+
+test('--saveConfig does not truncate high amount of headers', async (t) => {
+  const fixtureDir = `${FIXTURES_DIR}/many_headers`
+  const fixtureConfigPath = `${fixtureDir}/netlify.toml`
+  const configPath = `${fixtureDir}/test_netlify.toml`
+  await fs.copyFile(fixtureConfigPath, configPath)
+  const { address, stopServer } = await startDeployServer({
+    async onRequest() {
+      const newConfigContents = await fs.readFile(configPath, 'utf8')
+      t.true(newConfigContents.includes('999'))
+    },
+  })
+  try {
+    await runFixture(t, 'many_headers', {
+      flags: {
+        buildbotServerSocket: address,
+        config: configPath,
+        saveConfig: true,
+        context: 'production',
+        branch: 'main',
+      },
+      snapshot: false,
+    })
+  } finally {
+    await stopServer()
+  }
+})
+
 test('--saveConfig is required to save the configuration changes as netlify.toml', async (t) => {
   const fixtureDir = `${FIXTURES_DIR}/save_none`
   const fixtureConfigPath = `${fixtureDir}/netlify.toml`


### PR DESCRIPTION
Related to https://github.com/netlify/build/issues/4163 and Monday's incident.

This adds regression tests to ensure sites with many redirects or headers are not truncated before deploy.

This also adds some tests to ensure sites with many redirects or headers are truncated in logs (not deploys). Those tests are marked as `skip` for the moment since we have reverted truncating them in logs for the moment.

This PR only adds tests, it does not change any production logic.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅