### PR TITLE
fix: handle non-writable `error.name`

### DIFF
--- a/packages/build/src/error/monitor/report.js
+++ b/packages/build/src/error/monitor/report.js
@@ -89,7 +89,10 @@ const getApp = function () {
 // But we change it back after Bugsnag is done reporting.
 const updateErrorName = function (error, type) {
   const { name } = error
-  error.name = type
+  // This might fail if `name` is a getter or is non-writable.
+  try {
+    error.name = type
+  } catch {}
   return name
 }
 


### PR DESCRIPTION
Fixes https://github.com/netlify/build/issues/4226

This handles `error.name` when it is not writable.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅