### PR TITLE
fix: non-writable `error.message` inside plugins

### DIFF
--- a/packages/build/src/plugins/error.js
+++ b/packages/build/src/plugins/error.js
@@ -36,7 +36,10 @@ const normalizeError = function (type, func, message, { error } = {}) {
 
 const getError = function (error, message, func) {
   if (error instanceof Error) {
-    error.message = `${message}\n${error.message}`
+    // This might fail if `name` is a getter or is non-writable.
+    try {
+      error.message = `${message}\n${error.message}`
+    } catch {}
     return error
   }
 


### PR DESCRIPTION
Follow-up on https://github.com/netlify/build/pull/4227

This handles `error.name` when it is not writable.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅