### PR TITLE
chore: Pin nodejs version for windows tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: ['*']
+        node-version: ['16.15.0']
         install-command: ['npm ci']
         machine: ['0', '1', '2', '3']
         include:


### PR DESCRIPTION
The tests on windows are failing because nodejs version 16.15.1 updated to npm 8.11 which introduced a deprecation warning for `--global`, for some reason this was again reverted in version 8.12.1 of npm. 

https://github.com/netlify/build/runs/6817828686

There is currently no newer nodejs version so for now I would stick with nodejs version 16.15.0 and revert this change as soon as there is a new nodejs version with fixed npm version.
