### PR TITLE
fix: ensure edge functions dist directory exists

### DIFF
--- a/packages/build/src/plugins_core/edge_functions/index.js
+++ b/packages/build/src/plugins_core/edge_functions/index.js
@@ -1,3 +1,4 @@
+import { promises as fs } from 'fs'
 import { dirname, join, resolve } from 'path'
 
 import { bundle, find } from '@netlify/edge-bundler'
@@ -40,6 +41,9 @@ const coreStep = async function ({
   // Deno cache dir to a directory that is persisted between builds.
   const cacheDirectory =
     !isRunningLocally && featureFlags.edge_functions_cache_cli ? resolve(buildDir, DENO_CLI_CACHE_DIRECTORY) : undefined
+
+  // Edge Bundler expects the dist directory to exist.
+  await fs.mkdir(distPath, { recursive: true })
 
   await bundle(sourcePaths, distPath, declarations, {
     cacheDirectory,


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

When the bootstrap layer writes the stage 2 ESZIP, it expects the dist directory (i.e. `.netlify/edge-functions-dist`) to exist (see https://github.com/netlify/edge-functions-bootstrap/blob/main/src/bundler/stage2.ts#L85), and it'll fail if it doesn't.

Edge Bundler is [ensuring that the directory exists when the format is JavaScript](https://github.com/netlify/edge-bundler/blob/main/src/formats/javascript.ts#L82-L83), but it's not doing the same for ESZIP. Since merging https://github.com/netlify/edge-bundler/pull/50, this has become a problem because no one is creating the directory.

(cc @EwanValentine)