### PR TITLE
fix: return an empty object rather than throwing swallowed error in envelope fetch

### DIFF
--- a/packages/config/src/env/envelope.js
+++ b/packages/config/src/env/envelope.js
@@ -1,6 +1,3 @@
-import { throwUserError } from '../error.js'
-import { ERROR_CALL_TO_ACTION } from '../log/messages.js'
-
 export const getEnvelope = async function ({ api, accountId, siteId }) {
   if (accountId === undefined) {
     return {}
@@ -21,7 +18,7 @@ export const getEnvelope = async function ({ api, accountId, siteId }) {
         return acc
       }, {})
     return sortedEnvVarsFromDevContext
-  } catch (error) {
-    throwUserError(`Failed retrieving envelope for site ${siteId}: ${error.message}. ${ERROR_CALL_TO_ACTION}`)
+  } catch {
+    return {}
   }
 }


### PR DESCRIPTION
#### Summary
This PR fixes a bug introduced in #4329, which impacted any Collaborators on CLI 10.6.3 using sites that have opted in to the new environment variable experience. Collaborators aren't allowed to access a team's shared environment variables. When they ran commands like `netlify dev` or `netlify env:list`, the account-level fetch would 403 with the error swallowed. This prevented even the site-level fetch from returning, which made it look like the site had no environment variables set on the site level. 

Now, if something goes wrong (i.e. insufficient permissions) with the account-level (or even site-level) fetch, an empty object will be returned instead of throwing a user error (which ended up being swallowed and caused the command to silently fail). 

Fixes https://github.com/netlify/pillar-workflow/issues/720

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

<img width="648" alt="Screenshot 2022-06-29 at 17 50 38" src="https://user-images.githubusercontent.com/236451/176569651-a6d25fab-d64a-4bc7-a352-f6567628c864.png">

