### PR TITLE
fix: update check determining if runtime is being used

### DIFF
--- a/packages/build/src/log/messages/compatibility.js
+++ b/packages/build/src/log/messages/compatibility.js
@@ -10,7 +10,7 @@ export const logRuntime = (logs, pluginOptions) => {
   const runtimes = pluginOptions.filter(isRuntime)
 
   // Once we have more runtimes, this hardcoded check should be removed
-  if (runtimes.length > 1) {
+  if (runtimes.length !== 0) {
     const [nextRuntime] = runtimes
 
     logSubHeader(logs, `Using Next.js Runtime - v${nextRuntime.pluginPackageJson.version}`)

--- a/packages/build/src/utils/runtime.js
+++ b/packages/build/src/utils/runtime.js
@@ -1,4 +1,5 @@
-export const isRuntime = function (packageName) {
+export const isRuntime = function (pluginOption) {
+  const { packageName } = pluginOption
   // Make this a bit more robust in the future
   return ['@netlify/next-runtime', '@netlify/plugin-nextjs'].includes(packageName)
 }


### PR DESCRIPTION
#### Summary

The method determining if a runtime is being used was not destructuring the `packageName` property from the object and as a result, was failing every time. 

We also previously checked to see if the number of runtimes was greater than 1 which resulted in an off-by-one error when the desired behaviour was to log a message when at least 1 one runtime is detected.

Example of build with fix: https://app.netlify.com/sites/ep-next-test/deploys/6318f20604dafa1efdf86829

Previous to this change we would log that we were logging/installing plugins when installing the runtime.