### PR TITLE
feat: add support for edge functions import maps with ESZIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ packages/*/package-lock.json
 !**/fixtures/**/plugins_cache*/.netlify
 !**/fixtures/**/pin_*/.netlify
 !**/fixtures/**/functions_*/.netlify
+!**/fixtures/**/functions_*/.netlify
+!**/fixtures/**/functions_*/.netlify/edge-functions/manifest.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "typescript": "^4.5.4"
-      },
       "devDependencies": {
         "@netlify/eslint-config-node": "^6.0.0",
         "ava": "^4.1.0",
@@ -1206,6 +1203,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@import-maps/resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA=="
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1390,10 +1392,11 @@
       "link": true
     },
     "node_modules/@netlify/edge-bundler": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-1.14.1.tgz",
-      "integrity": "sha512-0FJSvK5kZlf093aaWyvcULRzeUImypHn63oVsC+t8xvR08bhA9LebrYHPgQ/0GhFA8yDY+tz25xrNJ6JKKDWEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-2.0.1.tgz",
+      "integrity": "sha512-BMe99dnrmhf6qzY4ppym8SjT3s7SxgGPA1O9LW0+4hzssOQZJlJOQ78xhyGzZHuZTrDTccRom5hNmsBrWAd2nw==",
       "dependencies": {
+        "@import-maps/resolve": "^1.0.1",
         "common-path-prefix": "^3.0.0",
         "del": "^6.0.0",
         "env-paths": "^3.0.0",
@@ -15645,7 +15648,7 @@
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^4.0.0",
         "@netlify/config": "^18.2.3",
-        "@netlify/edge-bundler": "^1.14.1",
+        "@netlify/edge-bundler": "^2.0.1",
         "@netlify/functions-utils": "^4.2.8",
         "@netlify/git-utils": "^4.0.0",
         "@netlify/plugins-list": "^6.44.0",
@@ -16768,6 +16771,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@import-maps/resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA=="
+    },
     "@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -16899,7 +16907,7 @@
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^4.0.0",
         "@netlify/config": "^18.2.3",
-        "@netlify/edge-bundler": "^1.14.1",
+        "@netlify/edge-bundler": "^2.0.1",
         "@netlify/functions-utils": "^4.2.8",
         "@netlify/git-utils": "^4.0.0",
         "@netlify/nock-udp": "^1.0.0",
@@ -17037,10 +17045,11 @@
       }
     },
     "@netlify/edge-bundler": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-1.14.1.tgz",
-      "integrity": "sha512-0FJSvK5kZlf093aaWyvcULRzeUImypHn63oVsC+t8xvR08bhA9LebrYHPgQ/0GhFA8yDY+tz25xrNJ6JKKDWEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-2.0.1.tgz",
+      "integrity": "sha512-BMe99dnrmhf6qzY4ppym8SjT3s7SxgGPA1O9LW0+4hzssOQZJlJOQ78xhyGzZHuZTrDTccRom5hNmsBrWAd2nw==",
       "requires": {
+        "@import-maps/resolve": "^1.0.1",
         "common-path-prefix": "^3.0.0",
         "del": "^6.0.0",
         "env-paths": "^3.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/js": "^7.0.0",
-    "@netlify/edge-bundler": "^1.14.1",
+    "@netlify/edge-bundler": "^2.0.1",
     "@netlify/cache-utils": "^4.0.0",
     "@netlify/config": "^18.2.3",
     "@netlify/functions-utils": "^4.2.8",

--- a/packages/build/src/plugins_core/edge_functions/index.js
+++ b/packages/build/src/plugins_core/edge_functions/index.js
@@ -38,7 +38,7 @@ const coreStep = async function ({
 
   logFunctions({ internalSrcDirectory, internalSrcPath, logs, srcDirectory, srcPath })
 
-  const { declarations: internalDeclarations, importMap } = await parseManifest(internalSrcPath)
+  const { declarations: internalDeclarations, importMap } = await parseManifest(internalSrcPath, systemLog)
   const declarations = [...configDeclarations, ...internalDeclarations]
 
   // If we're running in buildbot and the feature flag is enabled, we set the

--- a/packages/build/src/plugins_core/edge_functions/lib/internal_manifest.js
+++ b/packages/build/src/plugins_core/edge_functions/lib/internal_manifest.js
@@ -1,7 +1,8 @@
 import { promises as fs } from 'fs'
 import { dirname, join, resolve } from 'path'
+import { pathToFileURL } from 'url'
 
-const parseManifest = async (internalSourceDirectory) => {
+const parseManifest = async (internalSourceDirectory, systemLog) => {
   const manifestPath = join(internalSourceDirectory, 'manifest.json')
 
   try {
@@ -22,13 +23,18 @@ const parseManifest = async (internalSourceDirectory) => {
 
       return {
         ...result,
-        importMap,
+        importMap: {
+          baseURL: pathToFileURL(importMapPath),
+          ...importMap,
+        },
       }
     }
 
     return result
-  } catch {
-    // no-op
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      systemLog('Error while parsing internal edge functions manifest:', error)
+    }
   }
 
   return {

--- a/packages/build/tests/edge_functions/fixtures/functions_internal/.netlify/edge-functions/function-1.ts
+++ b/packages/build/tests/edge_functions/fixtures/functions_internal/.netlify/edge-functions/function-1.ts
@@ -1,1 +1,3 @@
-export default async () => new Response('Hello world')
+import { foo } from 'alias:util'
+
+export default async () => new Response(foo && 'Hello world')

--- a/packages/build/tests/edge_functions/fixtures/functions_internal/.netlify/edge-functions/manifest.json
+++ b/packages/build/tests/edge_functions/fixtures/functions_internal/.netlify/edge-functions/manifest.json
@@ -1,0 +1,10 @@
+{
+  "functions": [
+    {
+      "function": "function-1",
+      "path": "/*"
+    }
+  ],
+  "import_map": "../../import-map.json",
+  "version": 1
+}

--- a/packages/build/tests/edge_functions/fixtures/functions_internal/import-map.json
+++ b/packages/build/tests/edge_functions/fixtures/functions_internal/import-map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "alias:util": "./util.ts"
+  }
+}

--- a/packages/build/tests/edge_functions/fixtures/functions_internal/util.ts
+++ b/packages/build/tests/edge_functions/fixtures/functions_internal/util.ts
@@ -1,0 +1,1 @@
+export const foo = true

--- a/packages/build/tests/edge_functions/tests.js
+++ b/packages/build/tests/edge_functions/tests.js
@@ -70,7 +70,9 @@ test.serial('builds Edge Functions from the user-defined directory', async (t) =
 test.serial('builds Edge Functions from the internal directory', async (t) => {
   const fixtureName = 'functions_internal'
 
-  await runFixture(t, 'functions_internal', { flags: { debug: false, mode: 'buildbot' } })
+  await runFixture(t, 'functions_internal', {
+    flags: { debug: false, featureFlags: { edge_functions_produce_eszip: true }, mode: 'buildbot' },
+  })
   await assertManifest(t, fixtureName)
 })
 


### PR DESCRIPTION
This PR makes use of https://github.com/netlify/edge-bundler/pull/109 to add support for import maps in edge functions when generating ESZIP bundles.

It sets the `baseURL` property of each import map to the path of the import map file.

Supersedes https://github.com/netlify/build/pull/4507.