### PR TITLE
chore: run npm install instead of ci for formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
     executor: node
     steps:
       - checkout
-      - npm-install-deps
+      - npm-install-deps:
+          command: npm install
       - run: npm run format:ci
       - run: npm run lint:ci


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

On release PRs the lockfile is out of sync so `npm ci` is failing there

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
