### PR TITLE
test: fix tests that timeouts due to ts-node

### DIFF
--- a/packages/build-info/test/__snapshots__/bin.test.ts.snap
+++ b/packages/build-info/test/__snapshots__/bin.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`CLI --help flag 1`] = `
-"bin.ts [OPTIONS...] [PROJECT_DIRECTORY]
+"bin.js [OPTIONS...] [PROJECT_DIRECTORY]
 
 Print relevant build information from a project.
 

--- a/packages/build-info/vitest.config.ts
+++ b/packages/build-info/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     restoreMocks: true,
     environment: 'node',
+    testTimeout: 10000,
     onConsoleLog: (log, type) => {
       process[type].write(log)
     },


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes a test that timed out due to ts-node loader taking longer to compile on ci.

Tried to use `ts-node-esm` binary directly same result.
The only significant improvement was to run directly the compiled code.

Big downside – you need to run build first.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
