### PR TITLE
fix: enforce yargs version 17.6.0 as prior version do not support ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25514,7 +25514,7 @@
     },
     "packages/build": {
       "name": "@netlify/build",
-      "version": "28.0.1",
+      "version": "28.1.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
@@ -25570,7 +25570,7 @@
         "typescript": "^4.5.4",
         "update-notifier": "^5.0.0",
         "uuid": "^8.0.0",
-        "yargs": "^17.3.1"
+        "yargs": "^17.6.0"
       },
       "bin": {
         "netlify-build": "bin.js"
@@ -25611,8 +25611,8 @@
       "dependencies": {
         "@netlify/framework-info": "^9.3.0",
         "@npmcli/map-workspaces": "^2.0.0",
-        "read-pkg": "^7.0.0",
-        "yargs": "^17.0.0"
+        "read-pkg": "^7.1.0",
+        "yargs": "^17.6.0"
       },
       "bin": {
         "build-info": "bin.js"
@@ -25741,7 +25741,7 @@
         "toml": "^3.0.0",
         "tomlify-j0.4": "^3.0.0",
         "validate-npm-package-name": "^4.0.0",
-        "yargs": "^17.3.1"
+        "yargs": "^17.6.0"
       },
       "bin": {
         "netlify-config": "bin.js"
@@ -31167,7 +31167,7 @@
         "typescript": "^4.8.4",
         "update-notifier": "^5.0.0",
         "uuid": "^8.0.0",
-        "yargs": "^17.3.1",
+        "yargs": "^17.6.0",
         "yarn": "^1.22.4"
       },
       "dependencies": {
@@ -31195,10 +31195,10 @@
         "@types/node": "^14.18.31",
         "@vitest/coverage-c8": "^0.24.1",
         "execa": "^6.0.0",
-        "read-pkg": "^7.0.0",
+        "read-pkg": "^7.1.0",
         "typescript": "^4.8.4",
         "vitest": "^0.24.1",
-        "yargs": "^17.0.0"
+        "yargs": "^17.6.0"
       },
       "dependencies": {
         "@types/node": {
@@ -31285,7 +31285,7 @@
         "tomlify-j0.4": "^3.0.0",
         "typescript": "^4.8.4",
         "validate-npm-package-name": "^4.0.0",
-        "yargs": "^17.3.1"
+        "yargs": "^17.6.0"
       },
       "dependencies": {
         "@types/node": {

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@netlify/framework-info": "^9.3.0",
     "@npmcli/map-workspaces": "^2.0.0",
-    "read-pkg": "^7.0.0",
-    "yargs": "^17.0.0"
+    "read-pkg": "^7.1.0",
+    "yargs": "^17.6.0"
   },
   "devDependencies": {
     "@types/node": "^14.18.31",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -116,7 +116,7 @@
     "typescript": "^4.5.4",
     "update-notifier": "^5.0.0",
     "uuid": "^8.0.0",
-    "yargs": "^17.3.1"
+    "yargs": "^17.6.0"
   },
   "devDependencies": {
     "@netlify/nock-udp": "^3.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -80,7 +80,7 @@
     "toml": "^3.0.0",
     "tomlify-j0.4": "^3.0.0",
     "validate-npm-package-name": "^4.0.0",
-    "yargs": "^17.3.1"
+    "yargs": "^17.6.0"
   },
   "devDependencies": {
     "@types/node": "^14.18.31",


### PR DESCRIPTION
#### Summary

buildbot has an older version of yargs in its package-lock. Older versions do not play nice with ESM and produce this error:

https://github.com/yargs/yargs/pull/2151

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
