### PR TITLE
fix: pin framework-info package to 9.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7023,21 +7023,25 @@
       }
     },
     "node_modules/@netlify/framework-info": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-9.3.0.tgz",
-      "integrity": "sha512-GfGG6DGHeVNpSN9yesKvgT0LTgrD0d0toV3kU86+E9j+yByKnRUdxVlGXocA454t/eVw0Vww/xeKY10oGUljEw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-9.4.0.tgz",
+      "integrity": "sha512-OlnEdp+xXjt+1xY3wnFMt/RdrvRcufkaTXvmlN2TvsJmfPsIFY0j88L86amqUQkxeDkS4zH1zdsHHazyHGM5Xw==",
       "dependencies": {
         "ajv": "^8.0.0",
         "filter-obj": "^3.0.0",
+        "find-up": "^6.3.0",
+        "fs-extra": "^10.1.0",
         "is-plain-obj": "^4.0.0",
         "locate-path": "^7.0.0",
         "p-filter": "^3.0.0",
         "p-locate": "^6.0.0",
+        "process": "^0.11.10",
         "read-pkg-up": "^9.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.3.4",
+        "url": "^0.11.0"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.0.0"
+        "node": "^14.14.0 || >=16.0.0"
       }
     },
     "node_modules/@netlify/framework-info/node_modules/semver": {
@@ -14883,7 +14887,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -17333,7 +17336,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -21770,6 +21772,14 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-exists/-/process-exists-5.0.0.tgz",
@@ -21933,6 +21943,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
@@ -24450,7 +24469,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -24672,6 +24690,15 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated"
     },
+    "node_modules/url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -24682,6 +24709,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -25594,12 +25626,12 @@
     },
     "packages/build": {
       "name": "@netlify/build",
-      "version": "28.1.4",
+      "version": "28.1.5",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^5.0.1",
-        "@netlify/config": "^19.1.0",
+        "@netlify/config": "^19.1.1",
         "@netlify/edge-bundler": "^3.0.1",
         "@netlify/functions-utils": "^5.0.1",
         "@netlify/git-utils": "^5.0.1",
@@ -25686,10 +25718,10 @@
     },
     "packages/build-info": {
       "name": "@netlify/build-info",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
-        "@netlify/framework-info": "^9.3.0",
+        "@netlify/framework-info": "^9.4.0",
         "@npmcli/map-workspaces": "^2.0.0",
         "find-up": "^6.3.0",
         "read-pkg": "^7.1.0",
@@ -25825,7 +25857,7 @@
     },
     "packages/config": {
       "name": "@netlify/config",
-      "version": "19.1.0",
+      "version": "19.1.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
@@ -25843,7 +25875,7 @@
         "map-obj": "^5.0.0",
         "netlify": "^13.0.1",
         "netlify-headers-parser": "^7.0.0",
-        "netlify-redirect-parser": "^14.0.0",
+        "netlify-redirect-parser": "^14.0.1",
         "omit.js": "^2.0.2",
         "p-locate": "^6.0.0",
         "path-exists": "^5.0.0",
@@ -26009,7 +26041,7 @@
     },
     "packages/redirect-parser": {
       "name": "netlify-redirect-parser",
-      "version": "14.0.0",
+      "version": "14.0.1",
       "license": "MIT",
       "dependencies": {
         "fast-safe-stringify": "^2.1.1",
@@ -31195,7 +31227,7 @@
       "requires": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^5.0.1",
-        "@netlify/config": "^19.1.0",
+        "@netlify/config": "^19.1.1",
         "@netlify/edge-bundler": "^3.0.1",
         "@netlify/functions-utils": "^5.0.1",
         "@netlify/git-utils": "^5.0.1",
@@ -31290,7 +31322,7 @@
     "@netlify/build-info": {
       "version": "file:packages/build-info",
       "requires": {
-        "@netlify/framework-info": "^9.3.0",
+        "@netlify/framework-info": "^9.4.0",
         "@npmcli/map-workspaces": "^2.0.0",
         "@types/node": "^14.18.31",
         "@types/semver": "^7.3.13",
@@ -31396,7 +31428,7 @@
         "map-obj": "^5.0.0",
         "netlify": "^13.0.1",
         "netlify-headers-parser": "^7.0.0",
-        "netlify-redirect-parser": "^14.0.0",
+        "netlify-redirect-parser": "^14.0.1",
         "omit.js": "^2.0.2",
         "p-locate": "^6.0.0",
         "path-exists": "^5.0.0",
@@ -31655,18 +31687,22 @@
       "optional": true
     },
     "@netlify/framework-info": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-9.3.0.tgz",
-      "integrity": "sha512-GfGG6DGHeVNpSN9yesKvgT0LTgrD0d0toV3kU86+E9j+yByKnRUdxVlGXocA454t/eVw0Vww/xeKY10oGUljEw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-9.4.0.tgz",
+      "integrity": "sha512-OlnEdp+xXjt+1xY3wnFMt/RdrvRcufkaTXvmlN2TvsJmfPsIFY0j88L86amqUQkxeDkS4zH1zdsHHazyHGM5Xw==",
       "requires": {
         "ajv": "^8.0.0",
         "filter-obj": "^3.0.0",
+        "find-up": "^6.3.0",
+        "fs-extra": "^10.1.0",
         "is-plain-obj": "^4.0.0",
         "locate-path": "^7.0.0",
         "p-filter": "^3.0.0",
         "p-locate": "^6.0.0",
+        "process": "^0.11.10",
         "read-pkg-up": "^9.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.3.4",
+        "url": "^0.11.0"
       },
       "dependencies": {
         "semver": {
@@ -37571,7 +37607,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -39361,7 +39396,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -42703,6 +42737,11 @@
       "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    },
     "process-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-exists/-/process-exists-5.0.0.tgz",
@@ -42826,6 +42865,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -44743,8 +44787,7 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unixify": {
       "version": "1.0.0",
@@ -44911,6 +44954,22 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+        }
+      }
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -30,7 +30,7 @@
   },
   "author": "Netlify Inc.",
   "dependencies": {
-    "@netlify/framework-info": "^9.3.0",
+    "@netlify/framework-info": "^9.4.0",
     "@npmcli/map-workspaces": "^2.0.0",
     "find-up": "^6.3.0",
     "read-pkg": "^7.1.0",


### PR DESCRIPTION
#### Summary

Pins the version of `framework-info` to 9.4.0

There's now a dependency on logic that exists within this version in `buildbot` and needs to be the new minimum version.

As a result of this not being the correct version, the following is what is being output in build logs for version detection:

<img width="703" alt="Screen Shot 2022-11-01 at 9 35 59 AM" src="https://user-images.githubusercontent.com/5655473/199246180-286d5632-c84c-46cb-a115-7064ae9eeb38.png">
