### PR TITLE
fix: break builds if expected plugin version is not met as set in manifest

### DIFF
--- a/packages/build/src/core/build.ts
+++ b/packages/build/src/core/build.ts
@@ -395,6 +395,7 @@ const initAndRunBuild = async function ({
     logs,
     debug,
     timers: timersA,
+    featureFlags,
   })
 
   try {

--- a/packages/build/src/core/feature_flags.js
+++ b/packages/build/src/core/feature_flags.js
@@ -19,4 +19,5 @@ export const DEFAULT_FEATURE_FLAGS = {
   edge_functions_cache_cli: false,
   edge_functions_produce_eszip: false,
   edge_functions_system_logger: false,
+  plugins_break_builds_with_unsupported_plugin_versions: false,
 }

--- a/packages/build/src/error/type.js
+++ b/packages/build/src/error/type.js
@@ -70,6 +70,13 @@ const TYPES = {
     severity: 'info',
   },
 
+  // User package.json sets an unsupported plugin version
+  pluginUnsupportedVersion: {
+    title: 'Unsupported plugin version(s) detected',
+    stackType: 'none',
+    severity: 'info',
+  },
+
   // `build.command` non-0 exit code
   buildCommand: {
     title: '"build.command" failed',

--- a/packages/build/src/log/messages/compatibility.js
+++ b/packages/build/src/log/messages/compatibility.js
@@ -119,19 +119,43 @@ const getOutdatedPlugin = function ({
   return `${THEME.warningHighlightWords(packageName)}${versionedPackage}: ${outdatedDescription}`
 }
 
-const getOutdatedDescription = function ({ latestVersion, migrationGuide, loadedFrom, origin, excludedVersionsRange }) {
-  const upgradeInstruction = getUpgradeInstruction(loadedFrom, origin, excludedVersionsRange, latestVersion)
-  if (migrationGuide === undefined) {
+const getOutdatedDescription = function ({
+  latestVersion,
+  migrationGuide,
+  loadedFrom,
+  origin,
+  excludedVersionsRange,
+  version,
+  packageName,
+}) {
+  const upgradeInstruction = getUpgradeInstruction(
+    loadedFrom,
+    origin,
+    excludedVersionsRange,
+    latestVersion,
+    version,
+    packageName,
+  )
+  if (excludedVersionsRange !== undefined || migrationGuide === undefined) {
     return `latest version is ${latestVersion}\n${upgradeInstruction}`
   }
 
   return `latest version is ${latestVersion}\nMigration guide: ${migrationGuide}\n${upgradeInstruction}`
 }
 
-const getUpgradeInstruction = function (loadedFrom, origin, excludedVersionsRange, latestVersion) {
+const getUpgradeInstruction = function (
+  loadedFrom,
+  origin,
+  excludedVersionsRange,
+  latestVersion,
+  version,
+  packageName,
+) {
   if (excludedVersionsRange !== undefined) {
-    return `Current plugin version is not supported. To upgrade this plugin,
-please update its version in "package.json" to a version outside of the range: ${excludedVersionsRange} and below ${latestVersion}`
+    return `We have blocked this build due to likely failure of this version of nextjs-runtime: ${packageName}${version}.
+Versions greater than 4.26.0 are recommended. To upgrade this plugin, please update its version in "package.json"
+to the latest version: ${latestVersion} or version above 4.26.0. If you cannot use a more recent version,
+please contact support at https://www.netlify.com/support for guidance.`
   }
 
   if (loadedFrom === 'package.json') {
@@ -231,6 +255,8 @@ const getExcludedVersion = function ({
     loadedFrom,
     origin,
     excludedVersionsRange,
+    version,
+    packageName,
   })
   return `${THEME.errorHighlightWords(packageName)}${versionedPackage} ${outdatedDescription}`
 }

--- a/packages/build/src/log/messages/compatibility.js
+++ b/packages/build/src/log/messages/compatibility.js
@@ -235,7 +235,7 @@ const hasUnsupportedVersion = function ({ pluginPackageJson: { version }, manife
   // excludedVersionsRange is a range of versions that are not supported e.g 4.0.0 - 4.25.0
   // semver hyphen range is inclusive 4.0.0 - 4.25.0 is same as >= 4.0.0 || < 4.26.0;
   return (
-    version !== undefined && excludedVersionsRange !== undefined && semver.satisfies(version, excludedVersionsRange)
+    version !== undefined && excludedVersionsRange !== undefined && semver.satisfies(version, excludedVersionsRange, { includePrerelease: true })
   )
 }
 

--- a/packages/build/src/log/messages/compatibility.js
+++ b/packages/build/src/log/messages/compatibility.js
@@ -154,7 +154,7 @@ const getUpgradeInstruction = function (
   if (excludedVersionsRange !== undefined) {
     return `We have blocked this build due to likely failure of this version of nextjs-runtime: ${packageName}${version}.
 Versions greater than 4.26.0 are recommended. To upgrade this plugin, please update its version in "package.json"
-to the latest version: ${latestVersion} or version above 4.26.0. If you cannot use a more recent version,
+to the latest version: ${latestVersion} or a version above 4.26.0. If you cannot use a more recent version,
 please contact support at https://www.netlify.com/support for guidance.`
   }
 

--- a/packages/build/src/plugins/manifest/validate.js
+++ b/packages/build/src/plugins/manifest/validate.js
@@ -9,6 +9,7 @@ export const validateManifest = function (manifest, rawManifest) {
     validateUnknownProps(manifest)
     validateName(manifest)
     validateInputs(manifest)
+    validateExcludedVersionsRange(manifest)
   } catch (error) {
     error.message = `Plugin's "manifest.yml" ${error.message}
 
@@ -31,7 +32,7 @@ const validateUnknownProps = function (manifest) {
   }
 }
 
-const VALID_PROPS = new Set(['name', 'inputs'])
+const VALID_PROPS = new Set(['name', 'inputs', 'excludedVersionsRange'])
 
 const validateName = function ({ name }) {
   if (name === undefined) {
@@ -53,6 +54,15 @@ const validateInputs = function ({ inputs }) {
   }
 
   inputs.forEach(validateInput)
+}
+
+const validateExcludedVersionsRange = function ({ excludedVersionsRange }) {
+  if (excludedVersionsRange === undefined) {
+    return
+  }
+  if (typeof excludedVersionsRange !== 'string') {
+    throw new TypeError('"excludedVersionsRange" property must be a string')
+  }
 }
 
 const isArrayOfObjects = function (objects) {

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -23,10 +23,11 @@ const CHILD_MAIN_FILE = fileURLToPath(new URL('child/main.js', import.meta.url))
 //    (for both security and safety reasons)
 //  - logs can be buffered which allows manipulating them for log shipping,
 //    transforming and parallel plugins
-const tStartPlugins = async function ({ pluginsOptions, buildDir, childEnv, logs, debug }) {
+const tStartPlugins = async function ({ pluginsOptions, buildDir, childEnv, logs, debug, featureFlags }) {
   logRuntime(logs, pluginsOptions)
   logLoadingPlugins(logs, pluginsOptions, debug)
-  logUnsupportedPluginVersions(logs, pluginsOptions)
+  if (featureFlags.plugins_break_builds_with_unsupported_plugin_versions)
+    logUnsupportedPluginVersions(logs, pluginsOptions)
   logOutdatedPlugins(logs, pluginsOptions)
   logIncompatiblePlugins(logs, pluginsOptions)
 

--- a/packages/build/src/plugins/spawn.js
+++ b/packages/build/src/plugins/spawn.js
@@ -8,6 +8,7 @@ import {
   logLoadingPlugins,
   logOutdatedPlugins,
   logIncompatiblePlugins,
+  logUnsupportedPluginVersions,
 } from '../log/messages/compatibility.js'
 import { measureDuration } from '../time/main.js'
 
@@ -25,6 +26,7 @@ const CHILD_MAIN_FILE = fileURLToPath(new URL('child/main.js', import.meta.url))
 const tStartPlugins = async function ({ pluginsOptions, buildDir, childEnv, logs, debug }) {
   logRuntime(logs, pluginsOptions)
   logLoadingPlugins(logs, pluginsOptions, debug)
+  logUnsupportedPluginVersions(logs, pluginsOptions)
   logOutdatedPlugins(logs, pluginsOptions)
   logIncompatiblePlugins(logs, pluginsOptions)
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Allows plugins to set a range of excluded versions and breaks builds if found (initially set up for plugin-nextjs)
<img width="853" alt="exclude-from-manifest" src="https://user-images.githubusercontent.com/16131515/199699027-4e9d46f3-c350-40c7-95cc-67b1e1d6381e.png">


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
