### PR TITLE
chore(ci): make the update lockfile step for releases its own workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,13 @@ workflows:
           filters:
             branches:
               only: [main]
+
+  # Workflow responsible for correctly updating the root lockfile for the release-please PR
+  # See: https://github.com/googleapis/release-please/issues/1101
+  release-pull-request:
+    jobs:
       - update-lockfile:
           context: [shared-secrets]
-          requires:
-            - release-please
           filters:
             branches:
               only: [release-please--branches--main]


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

See https://github.com/netlify/build/commit/3914825b496f287e5b8ebe0ece819dc903134518#r90127545 and https://netlify.slack.com/archives/C02T8ASK2E9/p1668618894172729?thread_ts=1668604366.231059&cid=C02T8ASK2E9. The lockfile update job in CircleCI needs to take place as its own workflow since it's separate from the overall `release-please` workflow.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
