### PR TITLE
chore: add test to ensure framework detection works correctly

### DIFF
--- a/packages/build-info/tests/fixtures/next-project/package.json
+++ b/packages/build-info/tests/fixtures/next-project/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "next": "^13.0.6"
+  }
+}

--- a/packages/build-info/tests/get-build-info.test.ts
+++ b/packages/build-info/tests/get-build-info.test.ts
@@ -125,4 +125,24 @@ describe('Frameworks', () => {
     })
     expect(frameworks).toEqual([])
   })
+
+  test('framework detection works correctly for npm pkg detected framework', async () => {
+    const fixture = await createFixture('next-project')
+    cleanup = fixture.cleanup
+    const { frameworks } = await getBuildInfo({
+      projectDir: fixture.cwd,
+    })
+    expect(frameworks).toHaveLength(1)
+    expect(frameworks).toEqual([expect.objectContaining({ id: 'next' })])
+  })
+
+  test('framework detection works correctly for static file detected framework', async () => {
+    const fixture = await createFixture('jekyll-project')
+    cleanup = fixture.cleanup
+    const { frameworks } = await getBuildInfo({
+      projectDir: fixture.cwd,
+    })
+    expect(frameworks).toHaveLength(1)
+    expect(frameworks).toEqual([expect.objectContaining({ id: 'jekyll' })])
+  })
 })


### PR DESCRIPTION
#### Summary

Fixes #4679 

Simple tests to ensure framework detection works correctly, with 9.4.0 they do fail:

```diff
- Expected  - 3
+ Received  + 1
  
  Array [
-   ObjectContaining {
-     "id": "next",
-   },
+   undefined,
  ]
```

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
