### PR TITLE
fix: clear edge functions dist directory before build

### DIFF
--- a/packages/build/src/plugins_core/edge_functions/index.js
+++ b/packages/build/src/plugins_core/edge_functions/index.js
@@ -43,7 +43,11 @@ const coreStep = async function ({
 
   // Cleaning up the dist directory, in case it has any artifacts from previous
   // builds.
-  await fs.rm(distPath, { recursive: true })
+  try {
+    await fs.rm(distPath, { recursive: true })
+  } catch {
+    // no-op
+  }
 
   // Ensuring the dist directory actually exists before letting Edge Bundler
   // write to it.

--- a/packages/build/src/plugins_core/edge_functions/index.js
+++ b/packages/build/src/plugins_core/edge_functions/index.js
@@ -41,7 +41,12 @@ const coreStep = async function ({
   const cacheDirectory =
     !isRunningLocally && featureFlags.edge_functions_cache_cli ? resolve(buildDir, DENO_CLI_CACHE_DIRECTORY) : undefined
 
-  // Edge Bundler expects the dist directory to exist.
+  // Cleaning up the dist directory, in case it has any artifacts from previous
+  // builds.
+  await fs.rm(distPath, { recursive: true })
+
+  // Ensuring the dist directory actually exists before letting Edge Bundler
+  // write to it.
   await fs.mkdir(distPath, { recursive: true })
 
   try {


### PR DESCRIPTION
#### Summary

When bundling edge functions, we upload the contents of the `.netlify/edge-functions-dist` directory. For CI builds, this directory will be created fresh each time, but for local deploys it may actually contain files left over from a previous build. In those situations, we might be unnecessarily uploading old bundles.

This PR wipes that directory before we start the bundling process.