### PR TITLE
fix: separate detectBuildsystems and listFrameworks

### DIFF
--- a/packages/build-info/src/detect-build-system.ts
+++ b/packages/build-info/src/detect-build-system.ts
@@ -169,11 +169,11 @@ const lookFor = (
 }
 
 const getPkgJson = (configPath: string): PackageJson => {
-  let pkgJson: PackageJson
+  let pkgJson: PackageJson = {};
   try {
     pkgJson = JSON.parse(readFileSync(path.join(path.dirname(configPath), 'package.json'), 'utf-8'))
   } catch {
-    pkgJson = JSON.parse('{}')
+    // noop
   }
   return pkgJson
 }

--- a/packages/build-info/src/detect-build-system.ts
+++ b/packages/build-info/src/detect-build-system.ts
@@ -169,5 +169,11 @@ const lookFor = (
 }
 
 const getPkgJson = (configPath: string): PackageJson => {
-  return JSON.parse(readFileSync(path.join(path.dirname(configPath), 'package.json'), 'utf-8'))
+  let pkgJson: PackageJson
+  try {
+    pkgJson = JSON.parse(readFileSync(path.join(path.dirname(configPath), 'package.json'), 'utf-8'))
+  } catch {
+    pkgJson = JSON.parse('{}')
+  }
+  return pkgJson
 }

--- a/packages/build-info/src/detect-build-system.ts
+++ b/packages/build-info/src/detect-build-system.ts
@@ -169,7 +169,7 @@ const lookFor = (
 }
 
 const getPkgJson = (configPath: string): PackageJson => {
-  let pkgJson: PackageJson = {};
+  let pkgJson: PackageJson = {}
   try {
     pkgJson = JSON.parse(readFileSync(path.join(path.dirname(configPath), 'package.json'), 'utf-8'))
   } catch {

--- a/packages/build-info/src/get-build-info.ts
+++ b/packages/build-info/src/get-build-info.ts
@@ -15,10 +15,9 @@ export type Info = {
 export const getBuildInfo = async (opts: ContextOptions) => {
   const context = await getContext(opts)
   let frameworks: any[] = []
-  let buildSystems: BuildSystem[] = []
 
   try {
-    // if the framework or buildSystem detection is crashing we should not crash the build info and package-manager
+    // if the framework  detection is crashing we should not crash the build info and package-manager
     // detection
     frameworks = await listFrameworks({ projectDir: context.projectDir })
   } catch {
@@ -26,19 +25,12 @@ export const getBuildInfo = async (opts: ContextOptions) => {
     // noop
   }
 
-  try {
-    // if  buildSystem detection is crashing we should not crash the build info and package-manager
-    // detection
-    buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
-  } catch {
-    // noop
-  }
-
-  const info: Info = { frameworks, buildSystems }
+  const info: Info = { frameworks }
 
   // only if we find a root package.json we know this is a javascript workspace
   if (Object.keys(context.rootPackageJson).length > 0) {
     info.packageManager = await detectPackageManager(context.projectDir, context.rootDir)
+    info.buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
     const workspaceInfo = await getWorkspaceInfo(info.packageManager, context)
     if (workspaceInfo) {
       info.jsWorkspaces = workspaceInfo

--- a/packages/build-info/src/get-build-info.ts
+++ b/packages/build-info/src/get-build-info.ts
@@ -27,10 +27,11 @@ export const getBuildInfo = async (opts: ContextOptions) => {
 
   const info: Info = { frameworks }
 
+  info.buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
+
   // only if we find a root package.json we know this is a javascript workspace
   if (Object.keys(context.rootPackageJson).length > 0) {
     info.packageManager = await detectPackageManager(context.projectDir, context.rootDir)
-    info.buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
     const workspaceInfo = await getWorkspaceInfo(info.packageManager, context)
     if (workspaceInfo) {
       info.jsWorkspaces = workspaceInfo

--- a/packages/build-info/src/get-build-info.ts
+++ b/packages/build-info/src/get-build-info.ts
@@ -21,9 +21,14 @@ export const getBuildInfo = async (opts: ContextOptions) => {
     // if the framework or buildSystem detection is crashing we should not crash the build info and package-manager
     // detection
     frameworks = await listFrameworks({ projectDir: context.projectDir })
-    buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
   } catch {
     // TODO: build reporting to buildbot see: https://github.com/netlify/pillar-workflow/issues/1001
+    // noop
+  }
+
+  try {
+    buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
+  } catch {
     // noop
   }
 

--- a/packages/build-info/src/get-build-info.ts
+++ b/packages/build-info/src/get-build-info.ts
@@ -27,6 +27,8 @@ export const getBuildInfo = async (opts: ContextOptions) => {
   }
 
   try {
+    // if  buildSystem detection is crashing we should not crash the build info and package-manager
+    // detection
     buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
   } catch {
     // noop

--- a/packages/build-info/src/get-build-info.ts
+++ b/packages/build-info/src/get-build-info.ts
@@ -27,7 +27,11 @@ export const getBuildInfo = async (opts: ContextOptions) => {
 
   const info: Info = { frameworks }
 
-  info.buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
+  try {
+    info.buildSystems = await detectBuildSystems(context.projectDir, context.rootDir)
+  } catch (error) {
+    // noop
+  }
 
   // only if we find a root package.json we know this is a javascript workspace
   if (Object.keys(context.rootPackageJson).length > 0) {

--- a/packages/build-info/tests/detect-build-systems.test.ts
+++ b/packages/build-info/tests/detect-build-systems.test.ts
@@ -125,3 +125,14 @@ test('detects multiple build systems in a monorepo setup', async () => {
   const buildSystems = await detectBuildSystems(path.join(cwd, 'packages/website'), cwd)
   expect(buildSystems).toEqual([{ name: 'lerna', version: '^2.5.3' }, { name: 'gradle' }])
 })
+
+test('invalid package json handled gracefully', async () => {
+  const cwd = mockFileSystem({
+    'package.json': "{ 'devDependencies': { moon: '^0.5.1' } }",
+    '.moon/toolchain.yml': '',
+  })
+
+  const buildSystems = await detectBuildSystems(cwd)
+  console.log(buildSystems)
+  expect(buildSystems[0]).toEqual({ name: 'moon', version: undefined })
+})

--- a/packages/build-info/tests/detect-build-systems.test.ts
+++ b/packages/build-info/tests/detect-build-systems.test.ts
@@ -133,6 +133,5 @@ test('invalid package json handled gracefully', async () => {
   })
 
   const buildSystems = await detectBuildSystems(cwd)
-  console.log(buildSystems)
   expect(buildSystems[0]).toEqual({ name: 'moon', version: undefined })
 })

--- a/packages/build-info/tests/get-build-info.test.ts
+++ b/packages/build-info/tests/get-build-info.test.ts
@@ -29,6 +29,7 @@ describe('Golang', () => {
     })
     expect(info).toMatchInlineSnapshot(`
       {
+        "buildSystems": [],
         "frameworks": [],
       }
     `)

--- a/packages/build-info/tests/get-build-info.test.ts
+++ b/packages/build-info/tests/get-build-info.test.ts
@@ -29,7 +29,6 @@ describe('Golang', () => {
     })
     expect(info).toMatchInlineSnapshot(`
       {
-        "buildSystems": [],
         "frameworks": [],
       }
     `)


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Removes `detectBuildSystems`  from `listFrameworks` `try...catch` block so that it executes even when `listFrameworks` errors out.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
