### PR TITLE
chore: migrate from deprecated set-output command

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,9 +26,9 @@ jobs:
           package=${package_tag%/*}
           tag=${package_tag#*/}
           version=${info##*/}
-          echo "::set-output name=package::${package}"
-          echo "::set-output name=tag::${tag}"
-          echo "::set-output name=version::${version}"
+          echo "package=${package}" >> $GITHUB_OUTPUT
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Log extracted information
         run: |-
           echo package=${{ steps.extract.outputs.package }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,10 @@ jobs:
       # Sets an output parameter if this is a release PR
       - name: Check for release
         id: release-check
-        run: echo "::set-output name=IS_RELEASE::true"
+        # For windows we have to use $env:
+        run: |-
+          echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+          echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
         if: ${{ startsWith(github.head_ref, 'release-') }}
       - uses: actions/checkout@v3
         with:
@@ -100,7 +103,10 @@ jobs:
       # Sets an output parameter if this is a release PR
       - name: Check for release
         id: release-check
-        run: echo "::set-output name=IS_RELEASE::true"
+        # For windows we have to use $env:
+        run: |-
+          echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+          echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
         if: ${{ startsWith(github.head_ref, 'release-') }}
       - name: Git checkout
         uses: actions/checkout@v3
@@ -137,11 +143,14 @@ jobs:
       - name: Get test coverage flags
         id: test-coverage-flags
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
+        # For windows we have to use $env:
         run: |-
           os=${{ matrix.os }}
-          node=${{ matrix.node-version }}
-          echo "::set-output name=os::${os/-latest/}"
-          echo "::set-output name=node::node_${node//[.*]/}"
+          node=$(node --version)
+          echo "os=${os/-latest/}" >> $GITHUB_OUTPUT
+          echo "os=${os/-latest/}" >> $env:GITHUB_OUTPUT
+          echo "node=node_${node/.*.*/}" >> $GITHUB_OUTPUT
+          echo "node=node_${node/.*.*/}" >> $env:GITHUB_OUTPUT
         shell: bash
       - uses: codecov/codecov-action@v3
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}


### PR DESCRIPTION
#### Summary

Also changes the codecov label for nodejs to be "<node-major-version>" (right now "14" and "18") instead of "*" and "14.16.0"
