### PR TITLE
feat: send all bundlers to metric

### DIFF
--- a/packages/build/src/plugins_core/functions/index.ts
+++ b/packages/build/src/plugins_core/functions/index.ts
@@ -12,12 +12,11 @@ import { getZisiParameters } from './zisi.js'
 
 // Get a list of all unique bundlers in this run
 const getBundlers = (results: Awaited<ReturnType<typeof zipFunctions>> = []) =>
-  Array.from(
-    new Set(
-      results
-        .map((bundle) => (bundle.runtime === RuntimeType.JAVASCRIPT ? bundle.bundler : null))
-        .filter(Boolean) as NodeBundlerType[],
-    ),
+  // using a Set to filter duplicates
+  new Set(
+    results
+      .map((bundle) => (bundle.runtime === RuntimeType.JAVASCRIPT ? bundle.bundler : null))
+      .filter(Boolean) as NodeBundlerType[],
   )
 
 const zipFunctionsAndLogResults = async ({
@@ -50,7 +49,7 @@ const zipFunctionsAndLogResults = async ({
     const sourceDirectories = [internalFunctionsSrc, functionsSrc].filter(Boolean)
     const results = await zipItAndShipIt.zipFunctions(sourceDirectories, functionsDist, zisiParameters)
 
-    const bundlers = getBundlers(results)
+    const bundlers = Array.from(getBundlers(results))
 
     logBundleResults({ logs, results })
 

--- a/packages/build/src/plugins_core/functions/index.ts
+++ b/packages/build/src/plugins_core/functions/index.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 
-import { zipFunctions } from '@netlify/zip-it-and-ship-it'
+import { NodeBundlerType, RuntimeType, zipFunctions } from '@netlify/zip-it-and-ship-it'
 import { pathExists } from 'path-exists'
 
 import { log } from '../../log/logger.js'
@@ -10,10 +10,15 @@ import { getZipError } from './error.js'
 import { getUserAndInternalFunctions, validateFunctionsSrc } from './utils.js'
 import { getZisiParameters } from './zisi.js'
 
-// Returns `true` if at least one of the functions has been configured to use
-// esbuild.
-const isUsingEsbuild = (functionsConfig = {}) =>
-  Object.values(functionsConfig).some((configObject) => configObject.node_bundler === 'esbuild')
+// Get a list of all unique bundlers in this run
+const getBundlers = (results: Awaited<ReturnType<typeof zipFunctions>> = []) =>
+  Array.from(
+    new Set(
+      results
+        .map((bundle) => (bundle.runtime === RuntimeType.JAVASCRIPT ? bundle.bundler : null))
+        .filter(Boolean) as NodeBundlerType[],
+    ),
+  )
 
 const zipFunctionsAndLogResults = async ({
   buildDir,
@@ -37,7 +42,6 @@ const zipFunctionsAndLogResults = async ({
     isRunningLocally,
     repositoryRoot,
   })
-  const bundler = isUsingEsbuild(functionsConfig) ? 'esbuild' : 'zisi'
 
   try {
     // Printing an empty line before bundling output.
@@ -46,9 +50,11 @@ const zipFunctionsAndLogResults = async ({
     const sourceDirectories = [internalFunctionsSrc, functionsSrc].filter(Boolean)
     const results = await zipItAndShipIt.zipFunctions(sourceDirectories, functionsDist, zisiParameters)
 
+    const bundlers = getBundlers(results)
+
     logBundleResults({ logs, results })
 
-    return { bundler }
+    return { bundlers }
   } catch (error) {
     throw await getZipError(error, functionsSrc)
   }
@@ -74,7 +80,7 @@ const coreStep = async function ({
   const functionsDist = resolve(buildDir, relativeFunctionsDist)
   const internalFunctionsSrc = resolve(buildDir, relativeInternalFunctionsSrc)
   const internalFunctionsSrcExists = await pathExists(internalFunctionsSrc)
-  const functionsSrcExists = await validateFunctionsSrc({ functionsSrc, logs, relativeFunctionsSrc })
+  const functionsSrcExists = await validateFunctionsSrc({ functionsSrc, relativeFunctionsSrc })
   const [userFunctions = [], internalFunctions = []] = await getUserAndInternalFunctions({
     featureFlags,
     functionsSrc,
@@ -104,7 +110,7 @@ const coreStep = async function ({
     return {}
   }
 
-  const { bundler } = await zipFunctionsAndLogResults({
+  const { bundlers } = await zipFunctionsAndLogResults({
     buildDir,
     childEnv,
     featureFlags,
@@ -119,7 +125,7 @@ const coreStep = async function ({
 
   return {
     tags: {
-      bundler,
+      bundler: bundlers,
     },
   }
 }
@@ -155,7 +161,7 @@ export const bundleFunctions = {
 // `zip-it-and-ship-it` methods. Therefore, we need to use an intermediary
 // function and export them so tests can use it.
 export const zipItAndShipIt = {
-  async zipFunctions(...args) {
+  async zipFunctions(...args: Parameters<typeof zipFunctions>) {
     return await zipFunctions(...args)
   },
 }

--- a/packages/build/tests/time/fixtures/functions_nft/functions/function_one.js
+++ b/packages/build/tests/time/fixtures/functions_nft/functions/function_one.js
@@ -1,0 +1,1 @@
+export default true

--- a/packages/build/tests/time/fixtures/functions_nft/functions/function_two.js
+++ b/packages/build/tests/time/fixtures/functions_nft/functions/function_two.js
@@ -1,0 +1,1 @@
+export default true

--- a/packages/build/tests/time/fixtures/functions_nft/netlify.toml
+++ b/packages/build/tests/time/fixtures/functions_nft/netlify.toml
@@ -1,3 +1,3 @@
 [functions]
 directory = "functions"
-node_bundler = "zisi"
+node_bundler = "nft"

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -62,13 +62,24 @@ test('Default --framework CLI flag to nothing', async (t) => {
   t.true(timerRequests.every((timerRequest) => !timerRequest.includes('framework:')))
 })
 
-test('Sends a `bundler: "zisi"` tag when no functions use the esbuild bundler', async (t) => {
+test('Sends a `bundler: "zisi"` tag when bundler set to zisi', async (t) => {
   const timerRequests = await getAllTimerRequests(t, './fixtures/functions_zisi')
   const functionsBundlingRequest = timerRequests.find((timerRequest) =>
     timerRequest.includes('stage:functions_bundling'),
   )
 
   t.true(functionsBundlingRequest.includes('bundler:zisi'))
+  t.false(functionsBundlingRequest.includes('bundler:zisi,bundler:zisi'))
+})
+
+test('Sends a `bundler: "nft"` tag when bundler set to nft', async (t) => {
+  const timerRequests = await getAllTimerRequests(t, './fixtures/functions_nft')
+  const functionsBundlingRequest = timerRequests.find((timerRequest) =>
+    timerRequest.includes('stage:functions_bundling'),
+  )
+
+  t.true(functionsBundlingRequest.includes('bundler:nft'))
+  t.false(functionsBundlingRequest.includes('bundler:nft,bundler:nft'))
 })
 
 test('Sends a `bundler: "esbuild"` tag when at least one function uses the esbuild bundler', async (t) => {
@@ -77,7 +88,7 @@ test('Sends a `bundler: "esbuild"` tag when at least one function uses the esbui
     timerRequest.includes('stage:functions_bundling'),
   )
 
-  t.true(functionsBundlingRequest.includes('bundler:esbuild'))
+  t.true(functionsBundlingRequest.includes('bundler:nft,bundler:esbuild'))
 })
 
 // Retrieve statsd packets sent to --statsd.host|port, and get their snapshot


### PR DESCRIPTION
#### Summary

In order to get more insights into which bundlers are actually used in builds, it would be good to have all bundlers in the metrics.

Currently, we only add  `bundler:esbuild` or `bundler:zisi` to the metric. This PR ensures that we send also `bundler:nft`.
The detection of the bundler is now based on the return value of `zip-it-and-ship-it` and not on the config and because of this it might happen that one build has multiple functions with different bundlers and we now send all bundlers one build uses. 

So in the metric UI this is shown as follows when doing the default grouping: 
<img width="824" alt="Screenshot 2023-01-05 at 14 43 59" src="https://user-images.githubusercontent.com/231804/210794288-2ae0df60-46be-4c19-9185-c7f4184c8438.png">

but the indexing is still only for three values:
<img width="781" alt="Screenshot 2023-01-05 at 14 43 05" src="https://user-images.githubusercontent.com/231804/210794348-b78fdac6-8fd2-4391-a1bb-f5608c890877.png">

