### PR TITLE
fix: replace statsd-client with hot-shots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8512,16 +8512,6 @@
       "integrity": "sha512-ytRZWmXF0i4VFSG8NQ67NUDQ3NGe3E4oByFrxH8eJyW5uBOM5juIdXCg81OY/IcK81qHCzrvGEo8tujlIQbexw==",
       "dev": true
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -8546,15 +8536,6 @@
       "dev": true,
       "dependencies": {
         "@types/chai": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -8583,29 +8564,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
-    },
-    "node_modules/@types/express": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
-      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "dev": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -8677,12 +8635,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/mime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -8710,18 +8662,6 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
-    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -8740,25 +8680,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
-      "dependencies": {
-        "@types/mime": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/statsd-client": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@types/statsd-client/-/statsd-client-0.4.3.tgz",
-      "integrity": "sha512-MHPv/Y+PXlx3o6ZrWjvjweQTd25UEb8jhvD7Y3FSDsqUhUVsatAcc6MKCHCeBVwY2bufgTJ8X0m6OkCbaWji3Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -17013,6 +16934,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/hot-shots": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-9.3.0.tgz",
+      "integrity": "sha512-e4tgWptiBvlIMnAX0ORe+dNEt0HznD+T2ckzXDUwCBsU7uWr2mwq5UtoT+Df5r9hD5S/DuP8rTxJUQvqAFSFKA==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.x"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -20544,6 +20476,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -25066,12 +25004,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/statsd-client": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.4.7.tgz",
-      "integrity": "sha512-+sGCE6FednJ/vI7vywErOg/mhVqmf6Zlktz7cdGRnF/cQWXD9ifMgtqU1CIIXmhSwm11SCk4zDN+bwNCvIR/Kg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -26309,6 +26241,20 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unix-dgram": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz",
+      "integrity": "sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.16.0"
+      },
+      "engines": {
+        "node": ">=0.10.48"
       }
     },
     "node_modules/unixify": {
@@ -27674,6 +27620,7 @@
         "figures": "^4.0.0",
         "filter-obj": "^3.0.0",
         "got": "^10.0.0",
+        "hot-shots": "9.3.0",
         "indent-string": "^5.0.0",
         "is-plain-obj": "^4.0.0",
         "js-yaml": "^4.0.0",
@@ -27699,7 +27646,6 @@
         "rfdc": "^1.3.0",
         "safe-json-stringify": "^1.2.0",
         "semver": "^7.0.0",
-        "statsd-client": "0.4.7",
         "string-width": "^5.0.0",
         "strip-ansi": "^7.0.0",
         "supports-color": "^9.0.0",
@@ -27717,7 +27663,6 @@
       "devDependencies": {
         "@netlify/nock-udp": "^3.1.0",
         "@types/node": "^14.18.31",
-        "@types/statsd-client": "^0.4.3",
         "atob": "^2.1.2",
         "ava": "^4.0.0",
         "c8": "^7.12.0",
@@ -33734,7 +33679,6 @@
         "@netlify/zip-it-and-ship-it": "^8.2.0",
         "@sindresorhus/slugify": "^2.0.0",
         "@types/node": "^14.18.31",
-        "@types/statsd-client": "^0.4.3",
         "ansi-escapes": "^5.0.0",
         "atob": "^2.1.2",
         "ava": "^4.0.0",
@@ -33754,6 +33698,7 @@
         "get-stream": "^6.0.0",
         "got": "^10.0.0",
         "has-ansi": "^5.0.0",
+        "hot-shots": "9.3.0",
         "indent-string": "^5.0.0",
         "is-ci": "^3.0.0",
         "is-plain-obj": "^4.0.0",
@@ -33784,7 +33729,6 @@
         "safe-json-stringify": "^1.2.0",
         "semver": "^7.0.0",
         "sinon": "^13.0.0",
-        "statsd-client": "0.4.7",
         "string-width": "^5.0.0",
         "strip-ansi": "^7.0.0",
         "supports-color": "^9.0.0",
@@ -35211,16 +35155,6 @@
       "integrity": "sha512-ytRZWmXF0i4VFSG8NQ67NUDQ3NGe3E4oByFrxH8eJyW5uBOM5juIdXCg81OY/IcK81qHCzrvGEo8tujlIQbexw==",
       "dev": true
     },
-    "@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -35245,15 +35179,6 @@
       "dev": true,
       "requires": {
         "@types/chai": "*"
-      }
-    },
-    "@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/eslint": {
@@ -35282,29 +35207,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
-    },
-    "@types/express": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
-      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "dev": true,
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -35376,12 +35278,6 @@
         "@types/lodash": "*"
       }
     },
-    "@types/mime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -35409,18 +35305,6 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
-    },
-    "@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
-    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -35439,25 +35323,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
-    },
-    "@types/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
-      "requires": {
-        "@types/mime": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/statsd-client": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@types/statsd-client/-/statsd-client-0.4.3.tgz",
-      "integrity": "sha512-MHPv/Y+PXlx3o6ZrWjvjweQTd25UEb8jhvD7Y3FSDsqUhUVsatAcc6MKCHCeBVwY2bufgTJ8X0m6OkCbaWji3Q==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*"
-      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -41483,6 +41348,14 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "hot-shots": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-9.3.0.tgz",
+      "integrity": "sha512-e4tgWptiBvlIMnAX0ORe+dNEt0HznD+T2ckzXDUwCBsU7uWr2mwq5UtoT+Df5r9hD5S/DuP8rTxJUQvqAFSFKA==",
+      "requires": {
+        "unix-dgram": "2.x"
+      }
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -44118,6 +43991,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.4",
@@ -47538,11 +47417,6 @@
         }
       }
     },
-    "statsd-client": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.4.7.tgz",
-      "integrity": "sha512-+sGCE6FednJ/vI7vywErOg/mhVqmf6Zlktz7cdGRnF/cQWXD9ifMgtqU1CIIXmhSwm11SCk4zDN+bwNCvIR/Kg=="
-    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -48465,6 +48339,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unix-dgram": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz",
+      "integrity": "sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.16.0"
+      }
     },
     "unixify": {
       "version": "1.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -80,6 +80,7 @@
     "figures": "^4.0.0",
     "filter-obj": "^3.0.0",
     "got": "^10.0.0",
+    "hot-shots": "9.3.0",
     "indent-string": "^5.0.0",
     "is-plain-obj": "^4.0.0",
     "js-yaml": "^4.0.0",
@@ -105,7 +106,6 @@
     "rfdc": "^1.3.0",
     "safe-json-stringify": "^1.2.0",
     "semver": "^7.0.0",
-    "statsd-client": "0.4.7",
     "string-width": "^5.0.0",
     "strip-ansi": "^7.0.0",
     "supports-color": "^9.0.0",
@@ -120,7 +120,6 @@
   "devDependencies": {
     "@netlify/nock-udp": "^3.1.0",
     "@types/node": "^14.18.31",
-    "@types/statsd-client": "^0.4.3",
     "atob": "^2.1.2",
     "ava": "^4.0.0",
     "c8": "^7.12.0",

--- a/packages/build/src/core/main.ts
+++ b/packages/build/src/core/main.ts
@@ -107,7 +107,7 @@ export default async function buildSite(flags: Partial<BuildCLIFlags> = {}): Pro
       testOpts,
       errorParams,
     })
-    await reportError({ error, framework, statsdOpts })
+    await reportError(error, statsdOpts, framework)
 
     return { success, severityCode, logs }
   }
@@ -122,7 +122,7 @@ const handleBuildSuccess = async function ({ framework, dry, logs, timers, durat
   logBuildSuccess(logs)
 
   logTimer(logs, durationNs, 'Netlify Build', systemLog)
-  await reportTimers({ timers, statsdOpts, framework })
+  await reportTimers(timers, statsdOpts, framework)
 }
 
 // Handles the calls and errors of telemetry reports

--- a/packages/build/src/error/report.ts
+++ b/packages/build/src/error/report.ts
@@ -11,8 +11,10 @@ import { getErrorInfo } from './info.js'
 
 const TOP_PARENT_TAG = 'run_netlify_build'
 
-// Record error rates of the build phase for monitoring.
-// Sends to statsd daemon.
+/**
+ * Record error rates of the build phase for monitoring.
+ * Sends to statsd daemon.
+ */
 export const reportError = async function (
   error: Error,
   statsdOpts: InputStatsDOptions,

--- a/packages/build/src/error/report.ts
+++ b/packages/build/src/error/report.ts
@@ -37,16 +37,16 @@ export const reportError = async function (
 
   const parent = pluginName ? pluginName : TOP_PARENT_TAG
   const stage = pluginName ? errorInfo.location?.event : errorInfo.stage
-  const statsdTags: Tags = { stage: stage ?? 'system', parent }
+  const statsDTags: Tags = { stage: stage ?? 'system', parent }
 
   // Do not add a framework tag if empty string or null/undefined
   if (framework) {
-    statsdTags.framework = framework
+    statsDTags.framework = framework
   }
 
   const client = await startClient(statsdOpts)
 
-  client.increment('buildbot.build.stage.error', 1, formatTags(statsdTags))
+  client.increment('buildbot.build.stage.error', 1, formatTags(statsDTags))
 
   await closeClient(client)
 }

--- a/packages/build/src/report/statsd.ts
+++ b/packages/build/src/report/statsd.ts
@@ -3,7 +3,20 @@ import { promisify } from 'util'
 import slugify from '@sindresorhus/slugify'
 import { StatsD } from 'hot-shots'
 
-export const startClient = async function (host: string, port: number): Promise<StatsD> {
+export interface InputStatsDOptions {
+  host?: string
+  port?: number
+}
+
+export type StatsDOptions = Required<InputStatsDOptions>
+
+export const validateStatsDOptions = function (statsdOpts: InputStatsDOptions): statsdOpts is StatsDOptions {
+  return !!(statsdOpts && statsdOpts.host && statsdOpts.port)
+}
+
+export const startClient = async function (statsdOpts: StatsDOptions): Promise<StatsD> {
+  const { host, port } = statsdOpts
+
   return new StatsD({
     host,
     port,

--- a/packages/build/src/report/statsd.ts
+++ b/packages/build/src/report/statsd.ts
@@ -1,40 +1,43 @@
 import { promisify } from 'util'
 
 import slugify from '@sindresorhus/slugify'
-import StatsdClient from 'statsd-client'
+import { StatsD } from 'hot-shots'
 
-// TODO: replace with `timers/promises` after dropping Node < 15.0.0
-const pSetTimeout = promisify(setTimeout)
-
-// See https://github.com/msiebuhr/node-statsd-client/blob/45a93ee4c94ca72f244a40b06cb542d4bd7c3766/lib/EphemeralSocket.js#L81
-const CLOSE_TIMEOUT = 11
-
-// The socket creation is delayed until the first packet is sent. In our
-// case, this happens just before `client.close()` is called, which is too
-// late and make it not send anything. We need to manually create it using
-// the internal API.
-export const startClient = async function (host: string, port: number): Promise<StatsdClient> {
-  const client = new StatsdClient({ host, port, socketTimeout: 0 })
-
-  // @ts-expect-error using internals :D
-  await promisify(client._socket._createSocket.bind(client._socket))()
-
-  return client
+export const startClient = async function (host: string, port: number): Promise<StatsD> {
+  return new StatsD({
+    host,
+    port,
+    // This caches the dns resolution for subsequent sends of metrics for this instance
+    // Because we only try to send the metrics on close, this comes only into effect if `bufferFlushInterval` time is exceeded
+    cacheDns: true,
+    // set the maxBufferSize to infinite and the bufferFlushInterval very high, so that we only
+    // send the metrics on close or if more than 10 seconds past by
+    maxBufferSize: Infinity,
+    bufferFlushInterval: 10_000,
+  })
 }
 
-// UDP packets are buffered and flushed at regular intervals by statsd-client.
-// Closing force flushing all of them.
-export const closeClient = async function (client: StatsdClient): Promise<void> {
-  client.close()
-
-  // statsd-client does not provide a way of knowing when the socket is done
-  // closing, so we need to use the following hack.
-  await pSetTimeout(CLOSE_TIMEOUT)
-  await pSetTimeout(CLOSE_TIMEOUT)
+export const closeClient = async function (client: StatsD): Promise<void> {
+  await promisify(client.close.bind(client))()
 }
 
 // Make sure the timer name does not include special characters.
 // For example, the `packageName` of local plugins includes dots.
 export const normalizeTagName = function (name: string): string {
   return slugify(name, { separator: '_' })
+}
+
+// Formats and flattens the tags as array
+// We do this because we might send the same tag with different values `{ tag: ['a', 'b'] }`
+// which cannot be represented in an flattened object and `hot-shots` also supports tags as array in the format `['tag:a', 'tag:b']`
+export const formatTags = function (tags: Record<string, string | string[]>): string[] {
+  return Object.entries(tags)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return value.map((subValue) => `${key}:${subValue}`)
+      } else {
+        return `${key}:${value}`
+      }
+    })
+    .flat()
 }

--- a/packages/build/src/report/statsd.ts
+++ b/packages/build/src/report/statsd.ts
@@ -17,6 +17,8 @@ export const startClient = async function (host: string, port: number): Promise<
   })
 }
 
+// UDP packets are buffered and flushed every 10 seconds.
+// Close the client to force flushing all of them.
 export const closeClient = async function (client: StatsD): Promise<void> {
   await promisify(client.close.bind(client))()
 }

--- a/packages/build/src/report/statsd.ts
+++ b/packages/build/src/report/statsd.ts
@@ -14,6 +14,9 @@ export const validateStatsDOptions = function (statsdOpts: InputStatsDOptions): 
   return !!(statsdOpts && statsdOpts.host && statsdOpts.port)
 }
 
+/**
+ * Start a new StatsD Client and a new UDP socket
+ */
 export const startClient = async function (statsdOpts: StatsDOptions): Promise<StatsD> {
   const { host, port } = statsdOpts
 
@@ -30,21 +33,29 @@ export const startClient = async function (statsdOpts: StatsDOptions): Promise<S
   })
 }
 
-// UDP packets are buffered and flushed every 10 seconds.
-// Close the client to force flushing all of them.
+/**
+ * Close the StatsD Client
+ *
+ * UDP packets are buffered and flushed every 10 seconds and
+ * closing the client forces all buffered metrics to be flushed.
+ */
 export const closeClient = async function (client: StatsD): Promise<void> {
   await promisify(client.close.bind(client))()
 }
 
-// Make sure the timer name does not include special characters.
-// For example, the `packageName` of local plugins includes dots.
+/**
+ * Make sure the timer name does not include special characters.
+ * For example, the `packageName` of local plugins includes dots.
+ */
 export const normalizeTagName = function (name: string): string {
   return slugify(name, { separator: '_' })
 }
 
-// Formats and flattens the tags as array
-// We do this because we might send the same tag with different values `{ tag: ['a', 'b'] }`
-// which cannot be represented in an flattened object and `hot-shots` also supports tags as array in the format `['tag:a', 'tag:b']`
+/**
+ * Formats and flattens the tags as array
+ * We do this because we might send the same tag with different values `{ tag: ['a', 'b'] }`
+ * which cannot be represented in an flattened object and `hot-shots` also supports tags as array in the format `['tag:a', 'tag:b']`
+ */
 export const formatTags = function (tags: Record<string, string | string[]>): string[] {
   return Object.entries(tags)
     .map(([key, value]) => {

--- a/packages/build/src/time/report.ts
+++ b/packages/build/src/time/report.ts
@@ -49,7 +49,8 @@ const sendTimer = function (timer: Timer, client: StatsD, framework?: string): v
   const durationMs = roundTimerToMillisecs(durationNs)
   const statsdTags: Tags = { stage: stageTag, parent: parentTag, ...tags }
 
-  if (framework != undefined) {
+  // Do not add a framework tag if empty string or null/undefined
+  if (framework) {
     statsdTags.framework = framework
   }
 

--- a/packages/build/src/time/report.ts
+++ b/packages/build/src/time/report.ts
@@ -47,12 +47,12 @@ const sendTimers = async function (timers: Timer[], statsdOpts: StatsDOptions, f
 const sendTimer = function (timer: Timer, client: StatsD, framework?: string): void {
   const { metricName, stageTag, parentTag, durationNs, tags } = timer
   const durationMs = roundTimerToMillisecs(durationNs)
-  const statsdTags: Tags = { stage: stageTag, parent: parentTag, ...tags }
+  const statsDTags: Tags = { stage: stageTag, parent: parentTag, ...tags }
 
   // Do not add a framework tag if empty string or null/undefined
   if (framework) {
-    statsdTags.framework = framework
+    statsDTags.framework = framework
   }
 
-  client.distribution(metricName, durationMs, formatTags(statsdTags))
+  client.distribution(metricName, durationMs, formatTags(statsDTags))
 }

--- a/packages/build/src/time/report.ts
+++ b/packages/build/src/time/report.ts
@@ -20,8 +20,10 @@ interface Timer {
   tags: Record<string, string | string[]>
 }
 
-// Record the duration of a build phase, for monitoring.
-// Sends to statsd daemon.
+/**
+ * Record the duration of a build phase, for monitoring.
+ * Sends to statsd daemon.
+ */
 export const reportTimers = async function (
   timers: Timer[],
   statsdOpts: InputStatsDOptions,

--- a/packages/build/src/time/report.ts
+++ b/packages/build/src/time/report.ts
@@ -1,20 +1,51 @@
-import { closeClient, startClient } from '../report/statsd.js'
+import type { Tags, StatsD } from 'hot-shots'
+
+import { closeClient, formatTags, startClient } from '../report/statsd.js'
 
 import { addAggregatedTimers } from './aggregate.js'
 import { roundTimerToMillisecs } from './measure.js'
 
+interface Timer {
+  metricName: string
+  stageTag: string
+  parentTag: string
+  durationNs: number
+  tags: Record<string, string | string[]>
+}
+
+// TODO Once we have more TS coverage make host & port required and instead make `statsdOpts` below optional
+// that should be more clean
+export interface StatsDOptions {
+  host?: string
+  port?: number
+}
+
+interface TimerOptions {
+  timers: Timer[]
+  statsdOpts: StatsDOptions
+  framework?: string
+}
+
 // Record the duration of a build phase, for monitoring.
 // Sends to statsd daemon.
-export const reportTimers = async function ({ timers, statsdOpts: { host, port }, framework }) {
-  if (host === undefined) {
+export const reportTimers = async function ({
+  timers,
+  statsdOpts: { host, port },
+  framework,
+}: TimerOptions): Promise<void> {
+  if (host === undefined || port === undefined) {
     return
   }
 
   const timersA = addAggregatedTimers(timers)
-  await sendTimers({ timers: timersA, host, port, framework })
+  await sendTimers({ timers: timersA, statsdOpts: { host, port }, framework })
 }
 
-const sendTimers = async function ({ timers, host, port, framework }) {
+const sendTimers = async function ({
+  timers,
+  statsdOpts: { host, port },
+  framework,
+}: TimerOptions & { statsdOpts: Required<StatsDOptions> }): Promise<void> {
   const client = await startClient(host, port)
   timers.forEach((timer) => {
     sendTimer({ timer, client, framework })
@@ -22,8 +53,21 @@ const sendTimers = async function ({ timers, host, port, framework }) {
   await closeClient(client)
 }
 
-const sendTimer = function ({ timer: { metricName, stageTag, parentTag, durationNs, tags }, client, framework }) {
+const sendTimer = function ({
+  timer: { metricName, stageTag, parentTag, durationNs, tags },
+  client,
+  framework,
+}: {
+  timer: Timer
+  client: StatsD
+  framework?: string
+}): void {
   const durationMs = roundTimerToMillisecs(durationNs)
-  const frameworkTag = framework === undefined ? {} : { framework }
-  client.distribution(metricName, durationMs, { stage: stageTag, parent: parentTag, ...tags, ...frameworkTag })
+  const statsdTags: Tags = { stage: stageTag, parent: parentTag, ...tags }
+
+  if (framework != undefined) {
+    statsdTags.framework = framework
+  }
+
+  client.distribution(metricName, durationMs, formatTags(statsdTags))
 }

--- a/packages/build/src/time/report.ts
+++ b/packages/build/src/time/report.ts
@@ -1,6 +1,13 @@
 import type { Tags, StatsD } from 'hot-shots'
 
-import { closeClient, formatTags, startClient } from '../report/statsd.js'
+import {
+  closeClient,
+  formatTags,
+  InputStatsDOptions,
+  startClient,
+  StatsDOptions,
+  validateStatsDOptions,
+} from '../report/statsd.js'
 
 import { addAggregatedTimers } from './aggregate.js'
 import { roundTimerToMillisecs } from './measure.js'
@@ -13,55 +20,30 @@ interface Timer {
   tags: Record<string, string | string[]>
 }
 
-// TODO Once we have more TS coverage make host & port required and instead make `statsdOpts` below optional
-// that should be more clean
-export interface StatsDOptions {
-  host?: string
-  port?: number
-}
-
-interface TimerOptions {
-  timers: Timer[]
-  statsdOpts: StatsDOptions
-  framework?: string
-}
-
 // Record the duration of a build phase, for monitoring.
 // Sends to statsd daemon.
-export const reportTimers = async function ({
-  timers,
-  statsdOpts: { host, port },
-  framework,
-}: TimerOptions): Promise<void> {
-  if (host === undefined || port === undefined) {
+export const reportTimers = async function (
+  timers: Timer[],
+  statsdOpts: InputStatsDOptions,
+  framework?: string,
+): Promise<void> {
+  if (!validateStatsDOptions(statsdOpts)) {
     return
   }
 
-  const timersA = addAggregatedTimers(timers)
-  await sendTimers({ timers: timersA, statsdOpts: { host, port }, framework })
+  await sendTimers(addAggregatedTimers(timers), statsdOpts, framework)
 }
 
-const sendTimers = async function ({
-  timers,
-  statsdOpts: { host, port },
-  framework,
-}: TimerOptions & { statsdOpts: Required<StatsDOptions> }): Promise<void> {
-  const client = await startClient(host, port)
+const sendTimers = async function (timers: Timer[], statsdOpts: StatsDOptions, framework?: string): Promise<void> {
+  const client = await startClient(statsdOpts)
   timers.forEach((timer) => {
-    sendTimer({ timer, client, framework })
+    sendTimer(timer, client, framework)
   })
   await closeClient(client)
 }
 
-const sendTimer = function ({
-  timer: { metricName, stageTag, parentTag, durationNs, tags },
-  client,
-  framework,
-}: {
-  timer: Timer
-  client: StatsD
-  framework?: string
-}): void {
+const sendTimer = function (timer: Timer, client: StatsD, framework?: string): void {
+  const { metricName, stageTag, parentTag, durationNs, tags } = timer
   const durationMs = roundTimerToMillisecs(durationNs)
   const statsdTags: Tags = { stage: stageTag, parent: parentTag, ...tags }
 

--- a/packages/build/tests/error_reporting/tests.js
+++ b/packages/build/tests/error_reporting/tests.js
@@ -1,8 +1,27 @@
+import dns from 'dns'
+
 import { intercept, cleanAll } from '@netlify/nock-udp'
 import { Fixture } from '@netlify/testing'
 import test from 'ava'
+import sinon from 'sinon'
+
+test.before(() => {
+  const origLookup = dns.lookup
+  // we have to stub dns lookup as hot-shots is caching dns and therefore calling dns.lookup directly
+  sinon.stub(dns, 'lookup').callsFake((host, options, cb = options) => {
+    if (options === cb) {
+      options = {}
+    }
+    if (host.startsWith(`timetest.`)) {
+      cb(undefined, host, 4)
+    } else {
+      origLookup(host, options, cb)
+    }
+  })
+})
 
 test.after(() => {
+  dns.lookup.restore()
   cleanAll()
 })
 
@@ -31,7 +50,7 @@ const getTrackingRequestsString = async function (t, fixtureName, used = true) {
 
 const getAllTrackingRequests = async function (t, fixtureName, used) {
   // Ensure there's no conflict between each test scope
-  const host = encodeURI(t.title)
+  const host = `timetest.${encodeURI(t.title)}`
   const port = '1234'
   const scope = intercept(`${host}:${port}`, { persist: true, allowUnknown: true })
 

--- a/packages/build/tests/error_reporting/tests.js
+++ b/packages/build/tests/error_reporting/tests.js
@@ -12,7 +12,7 @@ test.before(() => {
     if (options === cb) {
       options = {}
     }
-    if (host.startsWith(`timetest.`)) {
+    if (host.startsWith(`errorreportingtest.`)) {
       cb(undefined, host, 4)
     } else {
       origLookup(host, options, cb)
@@ -50,7 +50,7 @@ const getTrackingRequestsString = async function (t, fixtureName, used = true) {
 
 const getAllTrackingRequests = async function (t, fixtureName, used) {
   // Ensure there's no conflict between each test scope
-  const host = `timetest.${encodeURI(t.title)}`
+  const host = `errorreportingtest.${encodeURI(t.title)}`
   const port = '1234'
   const scope = intercept(`${host}:${port}`, { persist: true, allowUnknown: true })
 

--- a/packages/build/tests/time/tests.js
+++ b/packages/build/tests/time/tests.js
@@ -1,8 +1,27 @@
+import dns from 'dns'
+
 import { intercept, cleanAll } from '@netlify/nock-udp'
 import { Fixture } from '@netlify/testing'
 import test from 'ava'
+import sinon from 'sinon'
+
+test.before(() => {
+  const origLookup = dns.lookup
+  // we have to stub dns lookup as hot-shots is caching dns and therefore calling dns.lookup directly
+  sinon.stub(dns, 'lookup').callsFake((host, options, cb = options) => {
+    if (options === cb) {
+      options = {}
+    }
+    if (host.startsWith(`timetest.`)) {
+      cb(undefined, host, 4)
+    } else {
+      origLookup(host, options, cb)
+    }
+  })
+})
 
 test.after(() => {
+  dns.lookup.restore()
   cleanAll()
 })
 
@@ -70,7 +89,7 @@ const getTimerRequestsString = async function (t, fixtureName, flags) {
 
 const getAllTimerRequests = async function (t, fixtureName, flags = {}) {
   // Ensure there's no conflict between each test scope
-  const host = encodeURI(t.title)
+  const host = `timetest.${encodeURI(t.title)}`
   const port = '1234'
   const scope = intercept(`${host}:${port}`, { persist: true, allowUnknown: true })
 


### PR DESCRIPTION
#### Summary

This replaces `statsd-client` with the recommended replacement `hot-shots` ([link](https://github.com/brightcove/hot-shots)). I tried to do the exact same thing as before, the inline comments should describe what the exact logic is when and how to send metrics.

This is a prerequisite for #4798 
