### PR TITLE
fix: correct default sveltekit publish directory

### DIFF
--- a/packages/framework-info/src/frameworks/svelte-kit.json
+++ b/packages/framework-info/src/frameworks/svelte-kit.json
@@ -14,7 +14,7 @@
   },
   "build": {
     "command": "vite build",
-    "directory": ".svelte-kit"
+    "directory": "build"
   },
   "logo": {
     "default": "/logos/svelte-kit/default.svg",


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

The default publish dir used by the SvelteKit Netlify adapter is `build`. `.svelte-kit` is the internal build dir, not the publish dir. 

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
