### PR TITLE
fix: correctly set repository in package.json files

### DIFF
--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -24,7 +24,11 @@
   },
   "keywords": [],
   "license": "MIT",
-  "repository": "netlify/build-info",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/build-info"
+  },
   "bugs": {
     "url": "https://github.com/netlify/build/issues"
   },

--- a/packages/headers-parser/package.json
+++ b/packages/headers-parser/package.json
@@ -40,7 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/netlify/build.git"
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/headers-parser"
   },
   "bugs": {
     "url": "https://github.com/netlify/build/issues"

--- a/packages/js-client/package.json
+++ b/packages/js-client/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/netlify/build",
   "repository": {
     "type": "git",
-    "url": "https://github.com/netlify/build.git"
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/js-client"
   },
   "bugs": {
     "url": "https://github.com/netlify/build/issues"

--- a/packages/nock-udp/package.json
+++ b/packages/nock-udp/package.json
@@ -18,6 +18,11 @@
   },
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/nock-udp"
+  },
   "bugs": {
     "url": "https://github.com/netlify/build/issues"
   },

--- a/packages/redirect-parser/package.json
+++ b/packages/redirect-parser/package.json
@@ -40,7 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/netlify/build.git"
+    "url": "https://github.com/netlify/build.git",
+    "directory": "packages/redirect-parser"
   },
   "bugs": {
     "url": "https://github.com/netlify/build/issues"


### PR DESCRIPTION
#### Summary

Just noticed that they are not correct, especially for build-info. This is the reason why renovate-bot cannot fetch the changelog.

