### PR TITLE
fix: update Solid Start default port

### DIFF
--- a/packages/framework-info/src/frameworks/solid-start.json
+++ b/packages/framework-info/src/frameworks/solid-start.json
@@ -9,7 +9,7 @@
   },
   "dev": {
     "command": "solid-start dev",
-    "port": 3000,
+    "port": 5173,
     "pollingStrategies": [{ "name": "TCP" }]
   },
   "build": {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

The default port for Solid Start has been updated to 5173, the new default port for vite

Fixes #4844

This was required because running `ntl dev` with no netlify.toml caused Solid Start's dev server running in the Netlify CLI to hang because it was waiting on port 3000 previously.

The steps to replicate the issue are in #4844 as well as setting it to 5173, showing it working.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
