### PR TITLE
chore: update build timeout to 30 minutes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,7 +95,7 @@ jobs:
 
   test-build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]


### PR DESCRIPTION


#### Summary

Currently, the build tests frequently timeout on windows or macos in CI.

This should help for now.

