### PR TITLE
fix: pass internalSrcFolder to zisi

### DIFF
--- a/packages/build/src/plugins_core/functions/zisi.js
+++ b/packages/build/src/plugins_core/functions/zisi.js
@@ -30,6 +30,7 @@ export const getZisiParameters = ({
     featureFlags: zisiFeatureFlags,
     repositoryRoot,
     configFileDirectories,
+    internalSrcFolder: internalFunctionsSrc,
   }
 }
 

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -522,6 +522,21 @@ test.serial('functions can have a config with different parameters passed to zip
   t.snapshot(normalizeOutput(output))
 })
 
+test.serial('internalSrcFolder is passed to zip-it-and-ship-it and helps prefill the generator field', async (t) => {
+  const zipItAndShipItSpy = sinon.spy(zipItAndShipIt, 'zipFunctions')
+
+  await new Fixture('./fixtures/functions_internal_src_folder').withFlags({ mode: 'buildbot' }).runWithBuild()
+  zipItAndShipItSpy.restore()
+  const { args: call1Args } = zipItAndShipItSpy.getCall(0)
+
+  const { internalSrcFolder, manifest } = call1Args[2]
+  const { functions } = await importJsonFile(manifest)
+
+  t.is(internalSrcFolder, join(FIXTURES_DIR, 'functions_internal_src_folder/.netlify/functions-internal'))
+  t.is(functions[0].generator, 'internalFunc')
+  t.is(functions[1].generator, undefined)
+})
+
 test('Generates a `manifest.json` file when running outside of buildbot', async (t) => {
   await removeDir(`${FIXTURES_DIR}/functions_internal_manifest/.netlify/functions`)
   await new Fixture('./fixtures/functions_internal_manifest').withFlags({ mode: 'cli' }).runWithBuild()


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

I actually did not pass internalSrcFolder to prefilling the generator field did not work :p 

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
