### PR TITLE
fix: pass internalSrcFolder to edge bundler

### DIFF
--- a/packages/build/src/plugins_core/edge_functions/index.js
+++ b/packages/build/src/plugins_core/edge_functions/index.js
@@ -64,6 +64,7 @@ const coreStep = async function ({
       featureFlags,
       importMapPaths: [userDefinedImportMap],
       systemLogger: featureFlags.edge_functions_system_logger ? systemLog : undefined,
+      internalSrcFolder: internalSrcPath,
     })
 
     systemLog('Edge Functions manifest:', manifest)

--- a/packages/build/tests/edge_functions/tests.js
+++ b/packages/build/tests/edge_functions/tests.js
@@ -94,6 +94,10 @@ test.serial('builds Edge Functions from the internal directory', async (t) => {
     .runWithBuild()
   t.snapshot(normalizeOutput(output))
   await assertManifest(t, 'functions_internal')
+  const manifestPath = join(FIXTURES_DIR, 'functions_internal/.netlify/edge-functions-dist/manifest.json')
+
+  const { routes } = await importJsonFile(manifestPath)
+  t.deepEqual(routes, [{ function: 'function-1', pattern: '^/.*/?$', generator: 'internalFunc' }])
 })
 
 test.serial('builds Edge Functions from both the user and the internal directoriws', async (t) => {
@@ -172,7 +176,7 @@ test('build plugins can manipulate netlifyToml.edge_functions array', async (t) 
 
   const { routes } = await importJsonFile(manifestPath)
 
-  t.deepEqual(routes, [{ function: 'mutated-function', pattern: '^/test-test/?$' }])
+  t.deepEqual(routes, [{ function: 'mutated-function', pattern: '^/test-test/?$', generator: 'internalFunc' }])
 })
 
 test.serial('cleans up the edge functions dist directory before bundling', async (t) => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Passing this folder to edge bundler so we can prefill some edge function generator fields.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
