### PR TITLE
feat: expose edge function stats to datadog on amount of EF's and generated EF's

### DIFF
--- a/packages/build/src/plugins_core/edge_functions/get_edge_function_stats.ts
+++ b/packages/build/src/plugins_core/edge_functions/get_edge_function_stats.ts
@@ -1,0 +1,16 @@
+import { promises as fs } from 'fs'
+import { join, resolve } from 'path'
+
+export const getEdgeFunctionStats = async ({ buildDir, constants: { EDGE_FUNCTIONS_DIST: distDirectory } }) => {
+  const edgeFunctionsDistPath = resolve(buildDir, distDirectory)
+  const manifestPath = join(edgeFunctionsDistPath, 'manifest.json')
+  const data = await fs.readFile(manifestPath)
+  // @ts-expect-error TypeScript is not aware that parse can handle Buffer
+  const manifestData = JSON.parse(data)
+  const numGenEfs = Object.values(manifestData.function_config).filter(
+    (config: { generator?: string }) => config.generator,
+  ).length
+  const totalNumEfs = manifestData.routes.length + manifestData.post_cache_routes.length
+
+  return { num_gen_efs: numGenEfs, total_num_efs: totalNumEfs }
+}

--- a/packages/build/src/plugins_core/edge_functions/index.ts
+++ b/packages/build/src/plugins_core/edge_functions/index.ts
@@ -6,6 +6,7 @@ import { pathExists } from 'path-exists'
 
 import { logFunctionsToBundle } from '../../log/messages/core_steps.js'
 
+import { getEdgeFunctionStats } from './get_edge_function_stats.js'
 import { tagBundlingError } from './lib/error.js'
 import { validateEdgeFunctionsManifest } from './validate_manifest/validate_edge_functions_manifest.js'
 
@@ -74,9 +75,19 @@ const coreStep = async function ({
     throw error
   }
 
-  await validateEdgeFunctionsManifest({ buildDir, constants: { EDGE_FUNCTIONS_DIST: distDirectory }, featureFlags })
+  await validateEdgeFunctionsManifest({
+    buildDir,
+    constants: { EDGE_FUNCTIONS_DIST: distDirectory },
+    featureFlags,
+  })
 
-  return {}
+  // We gather data on the amount of EF's build and which were auto-generated
+  const efStats = getEdgeFunctionStats({
+    buildDir,
+    constants: { EDGE_FUNCTIONS_DIST: distDirectory },
+  })
+
+  return { tags: { ...efStats } }
 }
 
 // We run this core step if at least one of the functions directories (the


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

We want to expose some numbers around the amount of EF's that are being deployed, and which ones are autogenerated. Those will have a generator field in the manifest `function_config` object.

Connected to https://github.com/netlify/pod-compute/issues/415

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
