### PR TITLE
feat: propagate featureflags to plugins

### DIFF
--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -6,14 +6,14 @@ import { getUtils } from './utils.js'
 
 // Run a specific plugin event handler
 export const run = async function (
-  { event, error, constants, envChanges, netlifyConfig },
+  { event, error, constants, envChanges, featureFlags, netlifyConfig },
   { methods, inputs, packageJson, verbose },
 ) {
   const method = methods[event]
   const runState = {}
   const utils = getUtils({ event, constants, runState })
   const netlifyConfigCopy = cloneNetlifyConfig(netlifyConfig)
-  const runOptions = { utils, constants, inputs, netlifyConfig: netlifyConfigCopy, packageJson, error }
+  const runOptions = { utils, constants, inputs, netlifyConfig: netlifyConfigCopy, packageJson, error, featureFlags }
 
   const envBefore = setEnvChanges(envChanges)
 

--- a/packages/build/src/steps/plugin.js
+++ b/packages/build/src/steps/plugin.js
@@ -26,6 +26,7 @@ export const firePluginStep = async function ({
   steps,
   error,
   logs,
+  featureFlags,
   debug,
   verbose,
 }) {
@@ -40,7 +41,14 @@ export const firePluginStep = async function ({
     } = await callChild({
       childProcess,
       eventName: 'run',
-      payload: { event, error, envChanges, netlifyConfig, constants },
+      payload: {
+        event,
+        error,
+        envChanges,
+        featureFlags,
+        netlifyConfig,
+        constants,
+      },
       logs,
       verbose,
     })

--- a/packages/build/src/steps/run_step.ts
+++ b/packages/build/src/steps/run_step.ts
@@ -318,6 +318,7 @@ const tFireStep = function ({
     steps,
     error,
     logs,
+    featureFlags,
     debug,
     verbose,
   })

--- a/packages/build/tests/plugins/fixtures/feature_flags/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/feature_flags/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/feature_flags/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/feature_flags/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin"

--- a/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
@@ -1,0 +1,3 @@
+export const onBuild = function ({ featureFlags }) {
+  console.log(Object.keys(featureFlags))
+}

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -142,6 +142,15 @@ test('Plugins can have inputs', async (t) => {
   t.snapshot(normalizeOutput(output))
 })
 
+test('Plugins are passed featureflags', async (t) => {
+  const output = await new Fixture('./fixtures/feature_flags')
+    .withFlags({
+      featureFlags: { test_flag: true },
+    })
+    .runWithBuild()
+  t.true(output.includes('test_flag'))
+})
+
 test('process.env changes are propagated to other plugins', async (t) => {
   const output = await new Fixture('./fixtures/env_changes_plugin').runWithBuild()
   t.snapshot(normalizeOutput(output))


### PR DESCRIPTION
#### Summary

Addresses https://github.com/netlify/pod-compute/issues/491 and https://github.com/netlify/pod-ecosystem-frameworks/issues/471.

This PR propagates the `featureFlags` object that's passed into `@netlify/build` down towards plugins. The Netlify Team can use this to roll out changes to plugins more precisely.

There's discussions around changing where those values come from (BitBalloon vs Buildbot, see e.g. https://github.com/netlify/pod-compute/issues/491#issuecomment-1523024232), but with this PR i'd like to just address that they're usable from plugins, not where they're sourced from.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
