### PR TITLE
Update CODEOWNERS (bulk-codeowners)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-.github/CODEOWNERS @netlify/core-pod-accounts @netlify/pillar-dev-workflow
-/packages/build/src/plugins_core/functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
-/packages/build/src/plugins_core/edge_functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
+.github/CODEOWNERS @netlify/pillar-dev-workflow @netlify/core-pod-accounts
+/packages/build/src/plugins_core/functions/ @netlify/runtime-pod-compute @netlify/ecosystem-pod-developer-foundations
+/packages/build/src/plugins_core/edge_functions/ @netlify/runtime-pod-compute @netlify/ecosystem-pod-developer-foundations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-.github/CODEOWNERS                               @netlify/pillar-dev-workflow
-/packages/build/src/plugins_core/functions/      @netlify/runtime-pod-compute
-/packages/build/src/plugins_core/edge_functions/ @netlify/runtime-pod-compute
+.github/CODEOWNERS @netlify/core-pod-accounts @netlify/pillar-dev-workflow
+/packages/build/src/plugins_core/functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
+/packages/build/src/plugins_core/edge_functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute


### PR DESCRIPTION

Updating the CODOWNERS file to accomodate the reorg.

## How this change was made
Changes are being made to replace no-longer-valid team names with the names of teams
that are replacing them, and adding what will be the new names for teams that should
exist post-reorg.

The code making these changes is in https://github.com/netlify/codeowners-scanner/

The announcement about this is in [#crew-engineering](https://netlify.slack.com/archives/CPJQSPQE4/p1683313309631019)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>