### PR TITLE
fix(build-info): fixes a bug in the platform independent join function

### DIFF
--- a/packages/build-info/src/file-system.test.ts
+++ b/packages/build-info/src/file-system.test.ts
@@ -1,5 +1,4 @@
-import { join, relative } from 'path'
-import { join as posixJoin } from 'path/posix'
+import { join, relative, posix } from 'path'
 
 import { Response } from 'node-fetch'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -9,6 +8,7 @@ import { GithubProvider, WebFS } from './browser/file-system.js'
 import { detectPackageManager } from './package-managers/detect-package-manager.js'
 import { Project } from './project.js'
 
+const { join: posixJoin } = posix
 // This is a mock for the github api functionality to have consistent tests and no rate limiting
 global.fetch = vi.fn(async (url): Promise<any> => {
   switch (url) {

--- a/packages/build-info/src/file-system.test.ts
+++ b/packages/build-info/src/file-system.test.ts
@@ -86,22 +86,20 @@ describe.concurrent('Test the platform independent base functionality', () => {
   })
 
   test('join should join path segments and always replace to posix style', ({ fs }) => {
-    expect(fs.join('/', 'package.json')).toBe('/package.json')
-    expect(posixJoin('/', 'package.json')).toBe('/package.json')
-    expect(fs.join('', 'package.json')).toBe('package.json')
-    expect(posixJoin('', 'package.json')).toBe('package.json')
-    expect(fs.join('', '', '', 'package.json')).toBe('package.json')
-    expect(posixJoin('', '', '', 'package.json')).toBe('package.json')
-    expect(fs.join('a', 'b', 'c')).toBe('a/b/c')
-    expect(posixJoin('a', 'b', 'c')).toBe('a/b/c')
-    expect(fs.join('a', 'b/cd', 'e')).toBe('a/b/cd/e')
-    expect(posixJoin('a', 'b/cd', 'e')).toBe('a/b/cd/e')
-    expect(fs.join('a')).toBe('a')
-    expect(posixJoin('a')).toBe('a')
-    expect(fs.join('a/../b')).toBe('b')
-    expect(posixJoin('a/../b')).toBe('b')
-    expect(fs.join('a/../b', 'cd')).toBe('b/cd')
-    expect(posixJoin('a/../b', 'cd')).toBe('b/cd')
+    // test that the fs.join behaves exactly like the official node/posix join functionality
+    ;[fs.join, posixJoin].forEach((joinFn) => {
+      expect(joinFn('/', 'package.json')).toBe('/package.json')
+      expect(joinFn('/', '', 'package.json')).toBe('/package.json')
+      expect(joinFn('/', '..', 'package.json')).toBe('/package.json')
+      expect(joinFn('..', 'package.json')).toBe('../package.json')
+      expect(joinFn('', 'package.json')).toBe('package.json')
+      expect(joinFn('', '', '', 'package.json')).toBe('package.json')
+      expect(joinFn('a', 'b', 'c')).toBe('a/b/c')
+      expect(joinFn('a', 'b/cd', 'e')).toBe('a/b/cd/e')
+      expect(joinFn('a')).toBe('a')
+      expect(joinFn('a/../b')).toBe('b')
+      expect(joinFn('a/../b', 'cd')).toBe('b/cd')
+    })
   })
 
   test('join should replace backslashes to forward slashes', ({ fs }) => {

--- a/packages/build-info/src/file-system.test.ts
+++ b/packages/build-info/src/file-system.test.ts
@@ -1,4 +1,5 @@
 import { join, relative } from 'path'
+import { join as posixJoin } from 'path/posix'
 
 import { Response } from 'node-fetch'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -85,14 +86,28 @@ describe.concurrent('Test the platform independent base functionality', () => {
   })
 
   test('join should join path segments and always replace to posix style', ({ fs }) => {
+    expect(fs.join('/', 'package.json')).toBe('/package.json')
+    expect(posixJoin('/', 'package.json')).toBe('/package.json')
+    expect(fs.join('', 'package.json')).toBe('package.json')
+    expect(posixJoin('', 'package.json')).toBe('package.json')
+    expect(fs.join('', '', '', 'package.json')).toBe('package.json')
+    expect(posixJoin('', '', '', 'package.json')).toBe('package.json')
     expect(fs.join('a', 'b', 'c')).toBe('a/b/c')
+    expect(posixJoin('a', 'b', 'c')).toBe('a/b/c')
     expect(fs.join('a', 'b/cd', 'e')).toBe('a/b/cd/e')
+    expect(posixJoin('a', 'b/cd', 'e')).toBe('a/b/cd/e')
     expect(fs.join('a')).toBe('a')
-    expect(fs.join('a\\b')).toBe('a/b')
-    expect(fs.join('a\\b', 'other_ space')).toBe('a/b/other_ space')
-    expect(fs.join('/foo', 'bar', 'baz\\asdf', 'quux', '..')).toBe('/foo/bar/baz/asdf')
+    expect(posixJoin('a')).toBe('a')
     expect(fs.join('a/../b')).toBe('b')
+    expect(posixJoin('a/../b')).toBe('b')
     expect(fs.join('a/../b', 'cd')).toBe('b/cd')
+    expect(posixJoin('a/../b', 'cd')).toBe('b/cd')
+  })
+
+  test('join should replace backslashes to forward slashes', ({ fs }) => {
+    expect(fs.join('a\\b')).toBe('a/b')
+    expect(fs.join('/foo', 'bar', 'baz\\asdf', 'quux', '..')).toBe('/foo/bar/baz/asdf')
+    expect(fs.join('a\\b', 'other_ space')).toBe('a/b/other_ space')
   })
 
   test('basename should return the last path segment', ({ fs }) => {

--- a/packages/build-info/src/file-system.ts
+++ b/packages/build-info/src/file-system.ts
@@ -54,6 +54,8 @@ export type findUpOptions = {
 /**
  * helper function to normalize path segments for a platform independent join
  * resolves . and .. elements in a path array with directory names
+ *
+ * @param allowAboveRoot is used for non absolute paths to go up
  */
 function normalizePathSegments(parts: string[], allowAboveRoot: boolean) {
   const res: string[] = []
@@ -92,7 +94,7 @@ export function normalize(path: string): string {
     path += '/'
   }
 
-  return (isAbsolute ? '/' : '') + path
+  return `${isAbsolute ? '/' : ''}${path}`
 }
 
 /** A platform independent version of path.join() */


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes a bug when joining an empty string with a value in the platform-independent join functionality like `join('', 'package.json')` resulted in `/package.json` instead of `package.json`.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
