### PR TITLE
fix: update minimum version of semver to be ESM compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25856,7 +25856,7 @@
         "resolve": "^2.0.0-next.1",
         "rfdc": "^1.3.0",
         "safe-json-stringify": "^1.2.0",
-        "semver": "^7.0.0",
+        "semver": "^7.3.8",
         "string-width": "^5.0.0",
         "strip-ansi": "^7.0.0",
         "supports-color": "^9.0.0",
@@ -26289,7 +26289,7 @@
         "p-locate": "^6.0.0",
         "process": "^0.11.10",
         "read-pkg-up": "^9.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.3.8"
       },
       "devDependencies": {
         "babel-loader": "^8.2.2",
@@ -26520,7 +26520,7 @@
       },
       "devDependencies": {
         "@types/node": "^18.14.2",
-        "semver": "^7.0.0",
+        "semver": "^7.3.8",
         "typescript": "^5.0.0",
         "vitest": "^0.30.1"
       },
@@ -32502,7 +32502,7 @@
         "resolve": "^2.0.0-next.1",
         "rfdc": "^1.3.0",
         "safe-json-stringify": "^1.2.0",
-        "semver": "^7.0.0",
+        "semver": "^7.3.8",
         "sinon": "^13.0.0",
         "string-width": "^5.0.0",
         "strip-ansi": "^7.0.0",
@@ -33015,7 +33015,7 @@
         "process": "^0.11.10",
         "read-pkg-up": "^9.0.0",
         "rollup-plugin-node-polyfills": "^0.2.1",
-        "semver": "^7.3.4",
+        "semver": "^7.3.8",
         "tmp-promise": "^3.0.2",
         "typescript": "^5.0.0",
         "vite": "^4.0.4",
@@ -33120,7 +33120,7 @@
       "requires": {
         "@types/node": "^18.14.2",
         "execa": "^6.0.0",
-        "semver": "^7.0.0",
+        "semver": "^7.3.8",
         "typescript": "^5.0.0",
         "vitest": "^0.30.1"
       },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -106,7 +106,7 @@
     "resolve": "^2.0.0-next.1",
     "rfdc": "^1.3.0",
     "safe-json-stringify": "^1.2.0",
-    "semver": "^7.0.0",
+    "semver": "^7.3.8",
     "string-width": "^5.0.0",
     "strip-ansi": "^7.0.0",
     "supports-color": "^9.0.0",

--- a/packages/framework-info/package.json
+++ b/packages/framework-info/package.json
@@ -68,7 +68,7 @@
     "p-locate": "^6.0.0",
     "process": "^0.11.10",
     "read-pkg-up": "^9.0.0",
-    "semver": "^7.3.4"
+    "semver": "^7.3.8"
   },
   "devDependencies": {
     "babel-loader": "^8.2.2",

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.14.2",
-    "semver": "^7.0.0",
+    "semver": "^7.3.8",
     "typescript": "^5.0.0",
     "vitest": "^0.30.1"
   },


### PR DESCRIPTION
### Summary

Ref netlify/cli#5749

with version 7.3.7 this happens, so we need at least 7.3.8: 

<img width="2054" alt="Screenshot 2023-06-05 at 14 18 08" src="https://github.com/netlify/zip-it-and-ship-it/assets/231804/8cd3e8f8-8564-4cde-8f45-e2d8f54ad61d">
