### PR TITLE
fix: use turbo --filter instead of deprecated --scope

### DIFF
--- a/packages/build-info/src/build-systems/turbo.ts
+++ b/packages/build-info/src/build-systems/turbo.ts
@@ -29,7 +29,7 @@ export class Turbo extends BaseBuildTool {
 
         return {
           type,
-          command: `turbo run ${target} --scope ${name}`,
+          command: `turbo run ${target} --filter ${name}`,
         }
       })
     }

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -148,8 +148,8 @@ describe('Nx turborepo', () => {
     const setting = settings.find((s) => s.packagePath === join('apps/web'))
     expect(setting).toMatchObject({
       packagePath: join('apps/web'),
-      buildCommand: 'turbo run build --scope web',
-      devCommand: 'turbo run dev --scope web',
+      buildCommand: 'turbo run build --filter web',
+      devCommand: 'turbo run dev --filter web',
       dist: join('apps/web/.next'),
       frameworkPort: 3000,
       plugins: ['@netlify/plugin-nextjs'],

--- a/packages/build-info/src/settings/get-build-settings.test.ts
+++ b/packages/build-info/src/settings/get-build-settings.test.ts
@@ -306,15 +306,15 @@ describe.each([
         expect.objectContaining({
           baseDirectory: '',
           packagePath: platformJoin('apps/docs'),
-          buildCommand: 'turbo run build --scope docs',
-          devCommand: 'turbo run dev --scope docs',
+          buildCommand: 'turbo run build --filter docs',
+          devCommand: 'turbo run dev --filter docs',
           dist: platformJoin('apps/docs/.next'),
         }),
         expect.objectContaining({
           baseDirectory: '',
           packagePath: platformJoin('apps/web'),
-          buildCommand: 'turbo run build --scope web',
-          devCommand: 'turbo run dev --scope web',
+          buildCommand: 'turbo run build --filter web',
+          devCommand: 'turbo run dev --filter web',
           dist: platformJoin('apps/web/.next'),
         }),
       ])
@@ -329,8 +329,8 @@ describe.each([
         expect.objectContaining({
           baseDirectory: '',
           packagePath: platformJoin('apps/web'),
-          buildCommand: 'turbo run build --scope web',
-          devCommand: 'turbo run dev --scope web',
+          buildCommand: 'turbo run build --filter web',
+          devCommand: 'turbo run dev --filter web',
           dist: platformJoin('apps/web/.next'),
         }),
       ])


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://github.com/netlify/build/issues/5040.

According to https://turbo.build/repo/docs/reference/command-line-reference/run#--scope, `--filter` is the direct replacement for `--scope`.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
