### PR TITLE
feat: pass through siteFeatureFlagPrefix to API

### DIFF
--- a/packages/config/src/api/site_info.js
+++ b/packages/config/src/api/site_info.js
@@ -14,7 +14,7 @@ export const getSiteInfo = async function ({
   api,
   siteId,
   mode,
-  featureFlagPrefix,
+  siteFeatureFlagPrefix,
   testOpts: { env: testEnv = true } = {},
 }) {
   if (api === undefined || mode === 'buildbot' || !testEnv) {
@@ -23,7 +23,7 @@ export const getSiteInfo = async function ({
   }
 
   const [siteInfo, accounts, addons] = await Promise.all([
-    getSite(api, siteId, featureFlagPrefix),
+    getSite(api, siteId, siteFeatureFlagPrefix),
     getAccounts(api),
     getAddons(api, siteId),
   ])
@@ -37,13 +37,13 @@ export const getSiteInfo = async function ({
   return { siteInfo, accounts, addons }
 }
 
-const getSite = async function (api, siteId, featureFlagPrefix = null) {
+const getSite = async function (api, siteId, siteFeatureFlagPrefix = null) {
   if (siteId === undefined) {
     return {}
   }
 
   try {
-    const site = await api.getSite({ siteId, feature_flag: featureFlagPrefix })
+    const site = await api.getSite({ siteId, feature_flag: siteFeatureFlagPrefix })
     return { ...site, id: siteId }
   } catch (error) {
     throwUserError(`Failed retrieving site data for site ${siteId}: ${error.message}. ${ERROR_CALL_TO_ACTION}`)

--- a/packages/config/src/api/site_info.js
+++ b/packages/config/src/api/site_info.js
@@ -10,14 +10,20 @@ import { ERROR_CALL_TO_ACTION } from '../log/messages.js'
 // Silently ignore API errors. For example the network connection might be down,
 // but local builds should still work regardless.
 
-export const getSiteInfo = async function ({ api, siteId, mode, testOpts: { env: testEnv = true } = {} }) {
+export const getSiteInfo = async function ({
+  api,
+  siteId,
+  mode,
+  featureFlagPrefix,
+  testOpts: { env: testEnv = true } = {},
+}) {
   if (api === undefined || mode === 'buildbot' || !testEnv) {
     const siteInfo = siteId === undefined ? {} : { id: siteId }
     return { siteInfo, accounts: [], addons: [] }
   }
 
   const [siteInfo, accounts, addons] = await Promise.all([
-    getSite(api, siteId),
+    getSite(api, siteId, featureFlagPrefix),
     getAccounts(api),
     getAddons(api, siteId),
   ])
@@ -31,13 +37,13 @@ export const getSiteInfo = async function ({ api, siteId, mode, testOpts: { env:
   return { siteInfo, accounts, addons }
 }
 
-const getSite = async function (api, siteId) {
+const getSite = async function (api, siteId, featureFlagPrefix = null) {
   if (siteId === undefined) {
     return {}
   }
 
   try {
-    const site = await api.getSite({ siteId })
+    const site = await api.getSite({ siteId, feature_flag: featureFlagPrefix })
     return { ...site, id: siteId }
   } catch (error) {
     throwUserError(`Failed retrieving site data for site ${siteId}: ${error.message}. ${ERROR_CALL_TO_ACTION}`)

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -22,8 +22,18 @@ import { getRedirectsPath, addRedirects } from './redirects.js'
 // Takes an optional configuration file path as input and return the resolved
 // `config` together with related properties such as the `configPath`.
 export const resolveConfig = async function (opts) {
-  const { cachedConfig, cachedConfigPath, host, scheme, pathPrefix, testOpts, token, offline, ...optsA } =
-    addDefaultOpts(opts)
+  const {
+    cachedConfig,
+    cachedConfigPath,
+    host,
+    scheme,
+    pathPrefix,
+    testOpts,
+    token,
+    offline,
+    featureFlagPrefix,
+    ...optsA
+  } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
   const api = getApiClient({ token, offline, host, scheme, pathPrefix, testOpts })
 
@@ -52,7 +62,7 @@ export const resolveConfig = async function (opts) {
     featureFlags,
   } = await normalizeOpts(optsA)
 
-  const { siteInfo, accounts, addons } = await getSiteInfo({ api, siteId, mode, testOpts })
+  const { siteInfo, accounts, addons } = await getSiteInfo({ api, siteId, mode, testOpts, featureFlagPrefix })
 
   const { defaultConfig: defaultConfigA, baseRelDir: baseRelDirA } = parseDefaultConfig({
     defaultConfig,

--- a/packages/config/src/main.js
+++ b/packages/config/src/main.js
@@ -31,7 +31,7 @@ export const resolveConfig = async function (opts) {
     testOpts,
     token,
     offline,
-    featureFlagPrefix,
+    siteFeatureFlagPrefix,
     ...optsA
   } = addDefaultOpts(opts)
   // `api` is not JSON-serializable, so we cannot cache it inside `cachedConfig`
@@ -62,7 +62,7 @@ export const resolveConfig = async function (opts) {
     featureFlags,
   } = await normalizeOpts(optsA)
 
-  const { siteInfo, accounts, addons } = await getSiteInfo({ api, siteId, mode, testOpts, featureFlagPrefix })
+  const { siteInfo, accounts, addons } = await getSiteInfo({ api, siteId, mode, testOpts, siteFeatureFlagPrefix })
 
   const { defaultConfig: defaultConfigA, baseRelDir: baseRelDirA } = parseDefaultConfig({
     defaultConfig,


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Related to: https://github.com/netlify/pod-dev-foundations/issues/519 , https://github.com/netlify/cli/pull/5792

Adds the `siteFeatureFlagPrefix` to be sent through to the api with `feature_flags`, so that the API returns feature_flags in the `getSite` call.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
<img width="258" alt="Screenshot 2023-06-13 at 2 07 55 PM" src="https://github.com/netlify/build/assets/4700602/175a128a-61b7-4b15-b1e5-15fe16aeb460">
