### PR TITLE
fix: remove RegEx negative lookbehind in file system

### DIFF
--- a/packages/build-info/src/file-system.ts
+++ b/packages/build-info/src/file-system.ts
@@ -160,8 +160,8 @@ export abstract class FileSystem {
       return absoluteTo.substring(absoluteFrom.length).replace(/^\//, '')
     }
 
-    const fromParts = join(absoluteFrom).split('/')
-    const toParts = join(absoluteTo).split('/')
+    const fromParts = this.join(absoluteFrom).split('/')
+    const toParts = this.join(absoluteTo).split('/')
     for (let i = 0, max = toParts.length; i < max; i++) {
       if (toParts[i] === fromParts?.[i]) {
         matching.push(toParts[i])

--- a/packages/build-info/src/file-system.ts
+++ b/packages/build-info/src/file-system.ts
@@ -157,12 +157,11 @@ export abstract class FileSystem {
 
     if (absoluteTo.startsWith(absoluteFrom)) {
       // lazily matches a slash afterwards if it's a directory
-      return absoluteTo.replace(new RegExp(`^${absoluteFrom}/*`), '')
+      return absoluteTo.substring(absoluteFrom.length).replace(/^\//, '')
     }
 
-    // split by / excluding the starting slash
-    const fromParts = this.join(absoluteFrom).split(/(?<!^)\//gm)
-    const toParts = this.join(absoluteTo).split(/(?<!^)\//gm)
+    const fromParts = join(absoluteFrom).split('/')
+    const toParts = join(absoluteTo).split('/')
     for (let i = 0, max = toParts.length; i < max; i++) {
       if (toParts[i] === fromParts?.[i]) {
         matching.push(toParts[i])
@@ -178,7 +177,7 @@ export abstract class FileSystem {
     const up = Math.max(toUp, fromUp)
 
     // if we have something from the 'from' to go up the max difference
-    const result = fromUp > 0 ? [...new Array<string>(up).fill('..')] : []
+    const result = fromUp > 0 ? Array<string>(up).fill('..') : []
 
     // if we have some parts left add them to the going up
     if (toUp > 0) {


### PR DESCRIPTION
This is needed as it is not supported in old safari versions and therefore breaking the react-ui. https://caniuse.com/js-regexp-lookbehind

🎉 Thanks for submitting a pull request! 🎉

#### Summary

This is needed as it caused an incident in the UI: https://github.com/netlify/netlify-react-ui/pull/17576

Fixes https://github.com/netlify/netlify-react-ui/issues/17640

the negative look behinds inside the `yaml` dependency should not be a problem as they are wrapped in a try-catch:

![CleanShot 2023-06-14 at 10 49 03](https://github.com/netlify/build/assets/11156362/244a702b-c322-4e2e-adae-8cfb77600b13)

As `@netlify/build-info` is used inside the react-ui, we need to support old safari versions, and therefore we cannot use a negative look behind.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
