### PR TITLE
fix: omit the git path even if no other omit paths provided

### DIFF
--- a/packages/build/src/plugins_core/secrets_scanning/utils.ts
+++ b/packages/build/src/plugins_core/secrets_scanning/utils.ts
@@ -87,8 +87,6 @@ export function getSecretKeysToScanFor(env: Record<string, unknown>, secretKeys:
  * @returns string[] of relative paths from base of files that should be searched
  */
 export async function getFilePathsToScan({ env, base }): Promise<string[]> {
-  const omitPathsAlways = ['.git']
-
   // node modules is dense and is only useful to scan if the repo itself commits these
   // files. As a simple check to understand if the repo would commit these files, we expect
   // that they would not ignore them from their git settings. So if gitignore includes
@@ -118,10 +116,10 @@ export async function getFilePathsToScan({ env, base }): Promise<string[]> {
   // this is needed for windows machines and snapshot tests consistency.
   files = files.map((f) => f.split(path.sep).join('/'))
 
-  let omitPaths: string[] = []
+  // always omit .git directories as they can be massive and are not the current version of the code or build output
+  let omitPaths: string[] = ['.git']
   if (typeof env.SECRETS_SCAN_OMIT_PATHS === 'string') {
     omitPaths = env.SECRETS_SCAN_OMIT_PATHS.split(',')
-      .concat(omitPathsAlways)
       .map((s) => s.trim())
       .filter(Boolean)
   }

--- a/packages/build/src/plugins_core/secrets_scanning/utils.ts
+++ b/packages/build/src/plugins_core/secrets_scanning/utils.ts
@@ -117,7 +117,7 @@ export async function getFilePathsToScan({ env, base }): Promise<string[]> {
   files = files.map((f) => f.split(path.sep).join('/'))
 
   // always omit .git directories as they can be massive and are not the current version of the code or build output
-  let omitPaths: string[] = ['.git']
+  let omitPaths: string[] = ['.git/']
   if (typeof env.SECRETS_SCAN_OMIT_PATHS === 'string') {
     omitPaths = env.SECRETS_SCAN_OMIT_PATHS.split(',')
       .map((s) => s.trim())

--- a/packages/build/src/plugins_core/secrets_scanning/utils.ts
+++ b/packages/build/src/plugins_core/secrets_scanning/utils.ts
@@ -87,6 +87,8 @@ export function getSecretKeysToScanFor(env: Record<string, unknown>, secretKeys:
  * @returns string[] of relative paths from base of files that should be searched
  */
 export async function getFilePathsToScan({ env, base }): Promise<string[]> {
+  const omitPathsAlways = ['.git/']
+
   // node modules is dense and is only useful to scan if the repo itself commits these
   // files. As a simple check to understand if the repo would commit these files, we expect
   // that they would not ignore them from their git settings. So if gitignore includes
@@ -116,13 +118,14 @@ export async function getFilePathsToScan({ env, base }): Promise<string[]> {
   // this is needed for windows machines and snapshot tests consistency.
   files = files.map((f) => f.split(path.sep).join('/'))
 
-  // always omit .git directories as they can be massive and are not the current version of the code or build output
-  let omitPaths: string[] = ['.git/']
+  let omitPaths: string[] = []
   if (typeof env.SECRETS_SCAN_OMIT_PATHS === 'string') {
     omitPaths = env.SECRETS_SCAN_OMIT_PATHS.split(',')
       .map((s) => s.trim())
       .filter(Boolean)
   }
+
+  omitPaths = omitPaths.concat(omitPathsAlways)
 
   if (omitPaths.length > 0) {
     files = files.filter((relativePath) => !omitPathMatches(relativePath, omitPaths))


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

We always want to ignore .git folders and the previous attempt only ignored them if the omit paths env var was also passed.


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
