### PR TITLE
fix: forward edgeFunctionsBootstrapURL via run_core_steps

### DIFF
--- a/packages/build/src/steps/run_core_steps.ts
+++ b/packages/build/src/steps/run_core_steps.ts
@@ -64,6 +64,7 @@ const executeBuildStep = async function ({
   buildSteps,
   repositoryRoot,
   systemLog,
+  edgeFunctionsBootstrapURL,
 }) {
   const configOpts = getConfigOpts({
     config,
@@ -113,6 +114,7 @@ const executeBuildStep = async function ({
       buildSteps,
       repositoryRoot: repositoryRootA,
       systemLog,
+      edgeFunctionsBootstrapURL,
     })
 
     return {
@@ -149,6 +151,7 @@ const runBuildStep = async function ({
   buildSteps,
   repositoryRoot,
   systemLog,
+  edgeFunctionsBootstrapURL,
 }) {
   const { netlifyConfig: netlifyConfigA, configMutations } = await runSteps({
     steps: getBuildSteps(buildSteps),
@@ -163,6 +166,7 @@ const runBuildStep = async function ({
     childEnv,
     repositoryRoot,
     systemLog,
+    edgeFunctionsBootstrapURL,
   } as any)
 
   return { netlifyConfig: netlifyConfigA, configMutations }


### PR DESCRIPTION
Part of https://github.com/netlify/pod-dev-foundations/issues/574, and follow-up to https://github.com/netlify/build/pull/5221.

I wanted to add a unit test, but the only log we could test for is printed to `stderr` by edge-bundler. We were able to test on that via `runWithBinary` in https://github.com/netlify/build/pull/5221, but this doesn't work for `run_core_steps`. Tested it manually, though, which worked!