### PR TITLE
fix: buildResult.logs should have correct type

### DIFF
--- a/packages/build/src/core/types.ts
+++ b/packages/build/src/core/types.ts
@@ -1,4 +1,5 @@
 import { NetlifyConfig } from '../../types/index.js'
+import { BufferedLogs } from '../log/logger.js'
 
 export type Mode = 'buildbot' | 'cli' | 'require'
 
@@ -48,7 +49,7 @@ export type BuildResult = {
   severityCode: SeverityCode
   netlifyConfig?: NetlifyConfig
   configMutations?: any
-  logs?: string[]
+  logs?: BufferedLogs
 }
 
 export enum SeverityCode {


### PR DESCRIPTION
While working on a test for https://github.com/netlify/build/pull/5231, I noticed that `BuildResult#logs` had an invalid type. It's being populated here: https://github.com/netlify/build/blob/4eae1ff04a44266cc56377a5a35b52f3354ccae5/packages/build/src/core/build.ts#L32

This PR fixes the type.