### PR TITLE
fix: hide edgeFunctionsBootstrapURL

### DIFF
--- a/packages/build/src/log/messages/config.js
+++ b/packages/build/src/log/messages/config.js
@@ -56,6 +56,7 @@ const INTERNAL_FLAGS = [
   'systemLogFile',
   'timeline',
   'explicitSecretKeys',
+  'edgeFunctionsBootstrapURL',
 ]
 const HIDDEN_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, ...INTERNAL_FLAGS]
 const HIDDEN_DEBUG_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS]


### PR DESCRIPTION
As Eduardo noted in https://netlify.slack.com/archives/C05556LEX28/p1691754020445069, we should hide this internal field from logs.