### PR TITLE
chore(deps): update dependency @honeycombio/opentelemetry-node to v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,9 +1426,9 @@
       "dev": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -1438,14 +1438,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
-      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
+        "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1456,20 +1456,21 @@
       }
     },
     "node_modules/@honeycombio/opentelemetry-node": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@honeycombio/opentelemetry-node/-/opentelemetry-node-0.4.0.tgz",
-      "integrity": "sha512-6PFX8FGW7uA7vQ3mxNIoN36rH9Zx5kXh4kKP9zu28nynyWyy9JE3l8PNJYd9FS2L/d88ZUpQAiQ1pROaANd5MA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@honeycombio/opentelemetry-node/-/opentelemetry-node-0.5.0.tgz",
+      "integrity": "sha512-bAg//j0Lh0SFC0LhUrrgpO4FVScOBDt+my4YXeIo9lHi1aXXn6meaB/ycecjVfjyQLaGYWKPKu2C66rTgKIzMQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.3",
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.36.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.36.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.36.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.36.1",
-        "@opentelemetry/resources": "^1.10.1",
-        "@opentelemetry/sdk-metrics": "^1.10.1",
-        "@opentelemetry/sdk-node": "^0.36.1",
-        "@opentelemetry/sdk-trace-base": "^1.10.1",
+        "@opentelemetry/core": "^1.13.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.39.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.41.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.41.0",
+        "@opentelemetry/resources": "^1.13.0",
+        "@opentelemetry/sdk-metrics": "^1.13.0",
+        "@opentelemetry/sdk-node": "^0.39.1",
+        "@opentelemetry/sdk-trace-base": "^1.13.0",
         "axios": "^1.1.3"
       },
       "engines": {
@@ -7581,10 +7582,21 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.2.tgz",
+      "integrity": "sha512-JEV2RAqijAFdWeT6HddYymfnkiRu2ASxoTBr4WsnGJhOjWZkEy6vp+Sx9ozr1NaIODOa2HUyckExIqQjn6qywQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.10.1.tgz",
-      "integrity": "sha512-6CC9sWOZDkUkKrAR957fmxXXlaK3uiBu5xVnuNEQ7hI7VqkUC/r0mNYIql0ouRInLz5o0HwmDuga1eXgQU7KNQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.13.0.tgz",
+      "integrity": "sha512-pS5fU4lrRjOIPZQqA2V1SUM9QUFXbO+8flubAiy6ntLjnAjJJUdRFOUOxK6v86ZHI2p2S8A0vD0BTu95FZYvjA==",
       "engines": {
         "node": ">=14"
       },
@@ -7593,11 +7605,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7607,13 +7619,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.10.1.tgz",
-      "integrity": "sha512-bZIoSD6M7uxO19HtRJCAceAahX56LUmj5N/XQFHmoi3iFqA2JfR7bqsyHQCYbgINdiee155UejaqkNpgvjV7fw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.13.0.tgz",
+      "integrity": "sha512-ke/STs/erRDqKmNv6Dv+5SetXsVD+Zm1/Wo8cLdAGrZn6kG6Fyp5EXVO/BJuzx6q+jHCdODm8jV4veXl4m71nQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0",
         "jaeger-client": "^3.15.0"
       },
       "engines": {
@@ -7623,18 +7635,71 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/resources": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+      "integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+      "integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.36.1.tgz",
-      "integrity": "sha512-yQPHny0Y3HIE1BSqbN82MoqqbbJeLINjL7Qf3kJwv1zt5YLUhYbn3FkqHQWS0YWpAvdjK0/OcN40SjEbVz2HRA==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.41.2.tgz",
+      "integrity": "sha512-gQuCcd5QSMkfi1XIriWAoak/vaRvFzpvtzh2hjziIvbnA3VtoGD3bDb2dzEzOA1iSWO0/tHwnBsSmmUZsETyOA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-metrics": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7644,15 +7709,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.36.1.tgz",
-      "integrity": "sha512-JcpEBwtBpNhVvmCLH3zjTPDcOld2AeI5rNglv2JrB16QCxQ5pwsOgzw7mPe/UR4u/53Ij7LIjFTOCeyVto/6aA==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.2.tgz",
+      "integrity": "sha512-+YeIcL4nuldWE89K8NBLImpXCvih04u1MBnn8EzvoywG2TKR5JC3CZEPepODIxlsfGSgP8W5khCEP1NHZzftYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-metrics": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7662,17 +7727,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.36.1.tgz",
-      "integrity": "sha512-dKJRKvIiyupuZJOVCzW9wNfsK6RxkELnzCSJHzFoIwhGRXSYpbWyYrfHj4ZJZWYZiQSJ7+I8BFUa4aSkBgnO0w==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.39.1.tgz",
+      "integrity": "sha512-S+FgIhmZiFMsUivtAlCyzf3L5ezPyCqvlzt4hSZmiKs0kqapau1HS4cSpGacs9Jy499TRSNtqfjj7GxZrNIevw==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.39.1",
+        "@opentelemetry/otlp-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-transformer": "0.39.1",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-metrics": "1.13.0"
       },
       "engines": {
         "node": ">=14"
@@ -7681,17 +7746,164 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
+      "integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.39.1.tgz",
+      "integrity": "sha512-Uj2i6t5v9aexV03xvVobwLV0Yxn7lQcCxBGN5KKxcs8BTZYSfjdwhrFjsOxvEQ2cXugL0aIzCuTKxrlXYTmFwA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/otlp-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-transformer": "0.39.1",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-metrics": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.39.1.tgz",
+      "integrity": "sha512-Pv5X8fbi6jD/RJBePyn7MnCSuE6MbPB6dl+7YYBWJ5RcMGYMwvLXjd4h2jWsPV2TSUg38H/RoSP0aXvQ06Y7iw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.39.1.tgz",
+      "integrity": "sha512-0hgVnXXz5efI382B/24NxD4b6Zxlh7nxCdJkxkdmQMbn0yRiwoq/ZT+QG8eUL6JNzsBAV1WJlF5aJNsL8skHvw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.39.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-logs": "0.39.1",
+        "@opentelemetry/sdk-metrics": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+      "integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.39.1.tgz",
+      "integrity": "sha512-/gmgKfZ1ZVFporKuwsewqIyvaUIGpv76JZ7lBpHQQPb37IMpaXO6pdqFI4ebHAWfNIm3akMyhmdtzivcgF3lgw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.38.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz",
+      "integrity": "sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+      "integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.36.1.tgz",
-      "integrity": "sha512-U2HdWvQho2VkeSAcAhkZ2wjfUb/1SKQixo5x6LNBF17ES4QYuh5+BagYxfN5FP4dbLnjZpTtFk5lj+97lfNLEw==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.41.2.tgz",
+      "integrity": "sha512-tRM/mq7PFj7mXCws5ICMVp/rmgU93JvZdoLE0uLj4tugNz231u2ZgeRYXulBjdeHM88ZQSsWTJMu2mvr/3JV1A==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7701,15 +7913,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.36.1.tgz",
-      "integrity": "sha512-q/jKlfuKiHqltDzgzgEvXkoEJ/EyVSIAZhfiaoyBeQ49UhHCPvNTH36/hSwbGSEhKeX98WxXZK4NB/S3sUs8ig==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.39.1.tgz",
+      "integrity": "sha512-AEhnJfVmo1g+7NxszAuf3c6vddld2DGH2+IM4XrPxCklucCsIpuStuC5EVZbCXXXBMpAY+n3t04QMxIQqNrcSw==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/otlp-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-transformer": "0.39.1",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0"
       },
       "engines": {
         "node": ">=14"
@@ -7718,17 +7930,162 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.36.1.tgz",
-      "integrity": "sha512-pNfrto7amygyyhmL4Kf96wuepROEecBYXSrtoXIVb1aUhUqjWLsA3/6DR3unB5EfSRA1Oq1Z9bqHfNuKqGfPNw==",
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
+      "integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.39.1.tgz",
+      "integrity": "sha512-Pv5X8fbi6jD/RJBePyn7MnCSuE6MbPB6dl+7YYBWJ5RcMGYMwvLXjd4h2jWsPV2TSUg38H/RoSP0aXvQ06Y7iw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.39.1.tgz",
+      "integrity": "sha512-0hgVnXXz5efI382B/24NxD4b6Zxlh7nxCdJkxkdmQMbn0yRiwoq/ZT+QG8eUL6JNzsBAV1WJlF5aJNsL8skHvw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.39.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-logs": "0.39.1",
+        "@opentelemetry/sdk-metrics": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+      "integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.39.1.tgz",
+      "integrity": "sha512-/gmgKfZ1ZVFporKuwsewqIyvaUIGpv76JZ7lBpHQQPb37IMpaXO6pdqFI4ebHAWfNIm3akMyhmdtzivcgF3lgw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.38.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz",
+      "integrity": "sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+      "integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.41.2.tgz",
+      "integrity": "sha512-IGZga9IIckqYE3IpRE9FO9G5umabObIrChlXUHYpMJtDgx797dsb3qXCvLeuAwB+HoB8NsEZstlzmLnoa6/HmA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-BxmEMiP6tHiFroe5/dTt9BsxCci7BTLtF7A6d4DKHLiLweWWZxQ9l7hON7qt/IhpKrQcAFD1OzZ1Gq2ZkNzhCw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "protobufjs": "^7.2.3"
       },
       "engines": {
         "node": ">=14"
@@ -7738,14 +8095,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.10.1.tgz",
-      "integrity": "sha512-8gF8MjcFf6IhQ7vm6W4tPYtu/vQswYVzpYvk3pUSaX9BMGrwgjeXg+LpuRtaxGoiGd08/g7JjZ4sWLUaELnzWw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.13.0.tgz",
+      "integrity": "sha512-4IuUmYEhlHm8tAGtd6KKkktEO9Bt7dpdBdAPVAzhmXsPwGi0yExo7E5qfi9HtHQcdfP9SnrGRkeorVtrZkGlhg==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
       },
       "engines": {
         "node": ">=14"
@@ -7754,12 +8111,65 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.36.1.tgz",
-      "integrity": "sha512-gtYErugMEF5NXVacmuE+tHFBiyB82YIiO5l8iZX9/4R4TDV8uCWdrLW5QZMqgTzPhiyOG9AITFdqhwIZMw/5lA==",
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
       "dependencies": {
-        "require-in-the-middle": "^6.0.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+      "integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+      "integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.39.1.tgz",
+      "integrity": "sha512-s7/9tPmM0l5KCd07VQizC4AO2/5UJdkXq5gMSHPdCeiMKSeBEdyDyQX7A+Cq+RYZM452qzFmrJ4ut628J5bnSg==",
+      "dependencies": {
+        "require-in-the-middle": "^7.1.0",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
       },
@@ -7771,11 +8181,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-fpjPwLafJIjgxY5qx7Ly74AYmRCd9spC6/jCxvEgGheg1YT4+NkfVnrfllxLRgc9wQNhDj7Y0Knp8RcmXLLVfA==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-pfwa6d+Dax3itZcGWiA0AoXeVaCuZbbqUTsCtOysd2re8C2PWXNxDONUfBWsn+KgxAdi+ljwTjJGiaVLDaIEvQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1"
+        "@opentelemetry/core": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7785,14 +8195,14 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-71TdQ3Z0D2Trq8rc2UMvky7tmIpg8kVPUhdYH3p0tNsTmbx6GDpEBOpjp2/zCFvQ0SZFVfHH2Oj2OZxZiz+FNQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-OErK8dYjXG01XIMIpmOV2SzL9ctkZ0Nyhf2UumICOAKtgLvR5dG1JMlsNVp8Jn0RzpsKc6Urv7JpP69wzRXN+A==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@grpc/proto-loader": "^0.7.3",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "protobufjs": "^7.2.3"
       },
       "engines": {
         "node": ">=14"
@@ -7802,12 +8212,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-9ErknJ5fS7r2NxEFeca93H+pGWnCjZCUWsz6Stcj5/z2rgsiZGHXLz3fQoUGQz+iXjiXKkks9wxTCRgWOW+Yiw==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.39.1.tgz",
+      "integrity": "sha512-VssdfGYu6LkSliQATdkvoP8lPSQuNLENRdHTUOV2veF4iqY/UpxBFFlkarY29W+MYjWXIBfYntgNjQvcn78A+w==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/otlp-exporter-base": "0.39.1",
         "protobufjs": "^7.1.2"
       },
       "engines": {
@@ -7817,15 +8227,53 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.36.1.tgz",
-      "integrity": "sha512-d2MomkVHBHwfsmNz6E60s/sm7gtpSjFwDzkFLm9brVq//VXzEhaEyfYSeTabdUs4BmrzhqTIogHWlcd6cOiL+w==",
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.39.1.tgz",
+      "integrity": "sha512-Pv5X8fbi6jD/RJBePyn7MnCSuE6MbPB6dl+7YYBWJ5RcMGYMwvLXjd4h2jWsPV2TSUg38H/RoSP0aXvQ06Y7iw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.2.tgz",
+      "integrity": "sha512-jJbPwB0tNu2v+Xi0c/v/R3YBLJKLonw1p+v3RVjT2VfzeUyzSp/tBeVdY7RZtL6dzZpA9XSmp8UEfWIFQo33yA==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.41.2",
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-logs": "0.41.2",
+        "@opentelemetry/sdk-metrics": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7835,40 +8283,84 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.10.1.tgz",
-      "integrity": "sha512-YrWqU93PH8RyCmqGhtDZgyk64D+cp8XIjQsLhEgOPcOsxvxSSGXnGt46rx9Z8+WdIbJgj13Q4nV/xuh36k+O+A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.13.0.tgz",
+      "integrity": "sha512-HOo91EI4UbuG8xQVLFziTzrcIn0MJQhy8m9jorh8aonb94jFVFi3CFNIiAnIGOabmnshJLOABxpYXsiPB8Xnzg==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1"
+        "@opentelemetry/core": "1.13.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.10.1.tgz",
-      "integrity": "sha512-qvwFfDPoBw2YQW/OsGHdLdD/rqNRGBRLz5UZR/akO21C4qwIK+lQcXbSi5ve0p2eLHnFshhNFqDmgQclOYBcmg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.13.0.tgz",
+      "integrity": "sha512-IV9TO+u1Jzm9mUDAD3gyXf89eyvgEJUY1t+GB5QmS4wjVeWrSMUtD0JjH3yG9SNqkrQOqOGJq7YUSSetW+Lf5Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1"
+        "@opentelemetry/core": "1.13.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7877,14 +8369,30 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.2.tgz",
+      "integrity": "sha512-smqKIw0tTW15waj7BAPHFomii5c3aHnSE4LQYTszGoK5P9nZs8tEAIpu15UBxi3aG31ZfsLmm4EUQkjckdlFrw==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "lodash.merge": "4.6.2"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.2.tgz",
+      "integrity": "sha512-9aIlcX8GnhcsAHW/Wl8bzk4ZnWTpNlLtud+fxUfBtFATu6OZ6TrGrF4JkT9EVrnoxwtPIDtjHdEsSjOqisY/iA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -7894,22 +8402,22 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.36.1.tgz",
-      "integrity": "sha512-7cRIxls3Ccg6HmzSu30R5upi0yHEizab2rm2rATrAyFV3JJ/ISA7cojmwKwYG8p4rkPNNPLOwCxI3vlLJrBnKA==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.39.1.tgz",
+      "integrity": "sha512-qODReBGNSdfRS5gvCFj1SdiIi/3ZFTZb0H1KvWE/OrTkklyL5RhIs7vDwvEGHmha+YpUu0Y2+R2+itSBSu/jCA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-jaeger": "1.10.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.36.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.36.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.36.1",
-        "@opentelemetry/exporter-zipkin": "1.10.1",
-        "@opentelemetry/instrumentation": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1",
-        "@opentelemetry/sdk-trace-node": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/exporter-jaeger": "1.13.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.39.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.39.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.39.1",
+        "@opentelemetry/exporter-zipkin": "1.13.0",
+        "@opentelemetry/instrumentation": "0.39.1",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-metrics": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0",
+        "@opentelemetry/sdk-trace-node": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
       },
       "engines": {
         "node": ">=14"
@@ -7918,14 +8426,198 @@
         "@opentelemetry/api": ">=1.3.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
+      "integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.39.1.tgz",
+      "integrity": "sha512-l5RhLKx6U+yuLhMrtgavTDthX50E1mZM3/SSySC7OPZiArFHV/b/9x9jxAzrOgIQUDxyj4N0V9aLKSA2t7Qzxg==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-transformer": "0.39.1",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.39.1.tgz",
+      "integrity": "sha512-oJQC7a67iwExRYynKqn/O9Fl5gUjDa43ZQsZu2iKAADs/6YJ+u5MJ/wcq3CpJsn2KU/8j8HWAKOcDkkQXPuJ9A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/otlp-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.39.1",
+        "@opentelemetry/otlp-transformer": "0.39.1",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.39.1.tgz",
+      "integrity": "sha512-Pv5X8fbi6jD/RJBePyn7MnCSuE6MbPB6dl+7YYBWJ5RcMGYMwvLXjd4h2jWsPV2TSUg38H/RoSP0aXvQ06Y7iw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.39.1.tgz",
+      "integrity": "sha512-u3ErFRQqQFKjjIMuwLWxz/tLPYInfmiAmSy//fGSCzCh2ZdJgqQjMOAxBgqFtCF2xFL+OmMhyuC2ThMzceGRWA==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/otlp-exporter-base": "0.39.1",
+        "protobufjs": "^7.2.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.39.1.tgz",
+      "integrity": "sha512-0hgVnXXz5efI382B/24NxD4b6Zxlh7nxCdJkxkdmQMbn0yRiwoq/ZT+QG8eUL6JNzsBAV1WJlF5aJNsL8skHvw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.39.1",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/sdk-logs": "0.39.1",
+        "@opentelemetry/sdk-metrics": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+      "integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.39.1.tgz",
+      "integrity": "sha512-/gmgKfZ1ZVFporKuwsewqIyvaUIGpv76JZ7lBpHQQPb37IMpaXO6pdqFI4ebHAWfNIm3akMyhmdtzivcgF3lgw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.38.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz",
+      "integrity": "sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+      "integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -7935,15 +8627,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.10.1.tgz",
-      "integrity": "sha512-/y+s1j8rPTaKnPnbrsbYv3ygTb4hjx/1H32zqobFr85cvWX+Tt1RWmcZ51TaPAfq5uJobGFhhLh6ADI2RDvk5Q==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.13.0.tgz",
+      "integrity": "sha512-FXA85lXKTsnbOflA/TBuBf2pmhD3c8uDjNjG0YqK+ap8UayfALmfJhf+aG1yBOUHevCY0JXJ4/xtbXExxpsMog==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.10.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/propagator-b3": "1.10.1",
-        "@opentelemetry/propagator-jaeger": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1",
+        "@opentelemetry/context-async-hooks": "1.13.0",
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/propagator-b3": "1.13.0",
+        "@opentelemetry/propagator-jaeger": "1.13.0",
+        "@opentelemetry/sdk-trace-base": "1.13.0",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -7953,10 +8645,63 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+      "integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+      "integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.13.0",
+        "@opentelemetry/resources": "1.13.0",
+        "@opentelemetry/semantic-conventions": "1.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
       "engines": {
         "node": ">=14"
       }
@@ -21144,9 +21889,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-6.0.0.tgz",
-      "integrity": "sha512-+dtWQ7l2lqQDxheaG3jjyN1QI37gEwvzACSgjYi4/C2y+ZTUMeRW8BIOm+9NBKvwaMBUSZfPXVOt1skB0vBkRw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -24293,7 +25038,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
-        "@honeycombio/opentelemetry-node": "^0.4.0",
+        "@honeycombio/opentelemetry-node": "^0.5.0",
         "@netlify/cache-utils": "^5.1.5",
         "@netlify/config": "^20.8.0",
         "@netlify/edge-bundler": "8.18.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/js": "^7.0.0",
-    "@honeycombio/opentelemetry-node": "^0.4.0",
+    "@honeycombio/opentelemetry-node": "^0.5.0",
     "@netlify/cache-utils": "^5.1.5",
     "@netlify/config": "^20.8.0",
     "@netlify/edge-bundler": "8.18.0",


### PR DESCRIPTION
#### Summary

Fixes netlify/cli#5928

pnpm users with `hoist=false` are currently broken because `@honeycombio/opentelemetry-node` has an undeclared dependency on `@opentelemtry/core` (netlify/cli#5928). This was fixed in https://github.com/honeycombio/honeycomb-opentelemetry-node/pull/207 and released in [`v0.5.0`](https://github.com/honeycombio/honeycomb-opentelemetry-node/releases/tag/v0.5.0). While the package is still in prerelease, the release notes do not declare any breaking changes, so this should be a safe upgrade.

I generated this with `(cd packages/build/ && npm install @honeycombio/opentelemetry-node@^0.5.0)`. Unfortunately this does appear to bump some other packages, however I don't see anything concerning there.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [X] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [X] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [X] Update or add tests (if any source code was changed or added) 🧪
- [X] Update or add documentation (if features were changed or added) 📝
- [X] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

One of my cats: Bon Bon.
![PXL_20230624_050413433](https://github.com/netlify/build/assets/11010321/b6bffd68-5edc-42d8-a001-83d458ba7232)