### PR TITLE
fix: prevent addExact running when no integrations supplied

### DIFF
--- a/packages/build/src/install/main.js
+++ b/packages/build/src/install/main.js
@@ -12,6 +12,9 @@ export const installDependencies = function ({ packageRoot, isLocal }) {
 
 // Add new Node.js dependencies, with exact semver ranges
 export const addExactDependencies = function ({ packageRoot, isLocal, packages }) {
+  if (!packages || packages.length === 0) {
+    return
+  }
   return runCommand({ packageRoot, packages, isLocal, type: 'addExact' })
 }
 

--- a/packages/build/src/install/missing.js
+++ b/packages/build/src/install/missing.js
@@ -17,6 +17,10 @@ export const installMissingPlugins = async function ({ missingPlugins, autoPlugi
   const packages = missingPlugins.map(getPackage)
   logInstallMissingPlugins(logs, packages)
 
+  if (packages.length === 0) {
+    return
+  }
+
   await createAutoPluginsDir(logs, autoPluginsDir)
   await addExactDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })
 }
@@ -24,6 +28,10 @@ export const installMissingPlugins = async function ({ missingPlugins, autoPlugi
 export const installIntegrationPlugins = async function ({ integrations, autoPluginsDir, mode, logs }) {
   const packages = integrations.map(getIntegrationPackage)
   logInstallIntegrations(logs, integrations)
+
+  if (packages.length === 0) {
+    return
+  }
 
   await createAutoPluginsDir(logs, autoPluginsDir)
   await addExactDependencies({ packageRoot: autoPluginsDir, isLocal: mode !== 'buildbot', packages })

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -155,6 +155,10 @@ const handleIntegrations = async function ({ integrations, autoPluginsDir, mode,
   const toInstall = integrations.filter((integration) => integration.has_build)
   await installIntegrationPlugins({ integrations: toInstall, autoPluginsDir, mode, logs })
 
+  if (toInstall.length === 0) {
+    return []
+  }
+
   return Promise.all(
     toInstall.map((integration) =>
       resolveIntegration({


### PR DESCRIPTION
Related netlify/pillar-support#699

---

Add _several_ excessive gates to prevent `addExact` being called when no integrations are supplied. This is seemingly causing a few build issues, may be npm version related