### PR TITLE
fix: document deno_import_map in function types

### DIFF
--- a/packages/build/types/config/functions.d.ts
+++ b/packages/build/types/config/functions.d.ts
@@ -31,6 +31,6 @@ type FunctionsObject = {
 /* eslint-enable camelcase */
 
 export type Functions = {
-  '*': FunctionsObject
+  '*': FunctionsObject & { deno_import_map?: string }
   [pattern: GlobPattern]: FunctionsObject
 }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

See https://github.com/netlify/next-runtime/pull/2302#discussion_r1335753300 - we're missing the `deno_import_map` field in our types for `functions`.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
