### PR TITLE
fix(build-info): prefer `npm` over `bun` when both lockfiles are present

### DIFF
--- a/packages/build-info/src/package-managers/detect-package-manager.test.ts
+++ b/packages/build-info/src/package-managers/detect-package-manager.test.ts
@@ -131,7 +131,7 @@ test('should prefer the `packageManager` property over a lockfile', async ({ fs 
 
 test('should prefer yarn over bun when both lockfiles exist', async ({ fs }) => {
   const cwd = mockFileSystem({
-    'package.json': '',
+    'package.json': '{}',
     'yarn.lock': '',
     'bun.lockb': '',
   })
@@ -142,13 +142,24 @@ test('should prefer yarn over bun when both lockfiles exist', async ({ fs }) => 
 
 test('should prefer pnpm over bun when both lockfiles exist', async ({ fs }) => {
   const cwd = mockFileSystem({
-    'package.json': '',
+    'package.json': '{}',
     'pnpm-lock.yaml': '',
     'bun.lockb': '',
   })
   const project = new Project(fs, cwd)
   const pkgManager = await detectPackageManager(project)
   expect(pkgManager?.name).toBe('pnpm')
+})
+
+test('should prefer npm over bun when both lockfiles exist', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': '{}',
+    'package-lock.json': '',
+    'bun.lockb': '',
+  })
+  const project = new Project(fs, cwd)
+  const pkgManager = await detectPackageManager(project)
+  expect(pkgManager?.name).toBe('npm')
 })
 
 describe('workspaces package manager detection', () => {

--- a/packages/build-info/src/package-managers/detect-package-manager.ts
+++ b/packages/build-info/src/package-managers/detect-package-manager.ts
@@ -44,17 +44,17 @@ export const AVAILABLE_PACKAGE_MANAGERS: Record<PkgManager, PkgManagerFields> = 
     lockFile: 'pnpm-lock.yaml',
     forceEnvironment: 'NETLIFY_USE_PNPM',
   },
-  [PkgManager.BUN]: {
-    name: PkgManager.BUN,
-    installCommand: 'bun install',
-    runCommand: 'bun run',
-    lockFile: 'bun.lockb',
-  },
   [PkgManager.NPM]: {
     name: PkgManager.NPM,
     installCommand: 'npm install',
     runCommand: 'npm run',
     lockFile: 'package-lock.json',
+  },
+  [PkgManager.BUN]: {
+    name: PkgManager.BUN,
+    installCommand: 'bun install',
+    runCommand: 'bun run',
+    lockFile: 'bun.lockb',
   },
 }
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Make sure we prefer `npm` when both `package-lock.json` and `bun.lockb` are present.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
