### PR TITLE
fix: autoinstall Angular v17

### DIFF
--- a/packages/framework-info/src/frameworks/angular.json
+++ b/packages/framework-info/src/frameworks/angular.json
@@ -22,5 +22,10 @@
     "dark": "/logos/angular/default.svg"
   },
   "env": {},
-  "plugins": []
+  "plugins": [
+    {
+      "packageName": "@netlify/angular-runtime",
+      "condition": { "minNodeVersion": "17.0.0" }
+    }
+  ]
 }


### PR DESCRIPTION
In https://github.com/netlify/netlify-plugin-angular-universal/pull/67, we're working on improved Angular support for v17+. This PR adds auto-install for the package :)

To be merged after https://github.com/netlify/netlify-plugin-angular-universal/pull/67 is done + released.