### PR TITLE
fix: for angular v17, detect publish directory from `angular.json`

### DIFF
--- a/packages/build-info/src/frameworks/angular.test.ts
+++ b/packages/build-info/src/frameworks/angular.test.ts
@@ -29,7 +29,7 @@ test('should detect Angular', async ({ fs }) => {
   expect(detected?.[0].id).toBe('angular')
   expect(detected?.[0].name).toBe('Angular')
   expect(detected?.[0].build.command).toBe('ng build --prod')
-  expect(detected?.[0].build.directory).toBe('dist/demo/browser')
+  expect(detected?.[0].build.directory).toBe(fs.join('dist', 'demo', 'browser'))
   expect(detected?.[0].dev?.command).toBe('ng serve')
   expect(detected?.[0].plugins).toEqual(['@netlify/angular-runtime'])
 })

--- a/packages/build-info/src/frameworks/angular.test.ts
+++ b/packages/build-info/src/frameworks/angular.test.ts
@@ -17,7 +17,7 @@ test('should detect Angular', async ({ fs }) => {
   expect(detected?.[0].id).toBe('angular')
   expect(detected?.[0].name).toBe('Angular')
   expect(detected?.[0].build.command).toBe('ng build --prod')
-  expect(detected?.[0].build.directory).toBe('dist/')
+  expect(detected?.[0].build.directory).toBe('')
   expect(detected?.[0].dev?.command).toBe('ng serve')
   expect(detected?.[0].plugins).toEqual(['@netlify/angular-runtime'])
 })
@@ -28,5 +28,6 @@ test('should only install plugin on v17+', async ({ fs }) => {
     'angular.json': '',
   })
   const detected = await new Project(fs, cwd).detectFrameworks()
+  expect(detected?.[0].build.directory).toBe('dist/')
   expect(detected?.[0].plugins).toEqual([])
 })

--- a/packages/build-info/src/frameworks/angular.test.ts
+++ b/packages/build-info/src/frameworks/angular.test.ts
@@ -11,13 +11,25 @@ beforeEach((ctx) => {
 test('should detect Angular', async ({ fs }) => {
   const cwd = mockFileSystem({
     'package.json': JSON.stringify({ dependencies: { '@angular/cli': '17.0.0' } }),
-    'angular.json': '',
+    'angular.json': JSON.stringify({
+      projects: {
+        demo: {
+          architect: {
+            build: {
+              options: {
+                outputPath: 'dist/demo',
+              },
+            },
+          },
+        },
+      },
+    }),
   })
   const detected = await new Project(fs, cwd).detectFrameworks()
   expect(detected?.[0].id).toBe('angular')
   expect(detected?.[0].name).toBe('Angular')
   expect(detected?.[0].build.command).toBe('ng build --prod')
-  expect(detected?.[0].build.directory).toBe('')
+  expect(detected?.[0].build.directory).toBe('dist/demo/browser')
   expect(detected?.[0].dev?.command).toBe('ng serve')
   expect(detected?.[0].plugins).toEqual(['@netlify/angular-runtime'])
 })

--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -32,7 +32,15 @@ export class Angular extends BaseFramework implements Framework {
     if (this.detected) {
       if (this.version && gte(this.version, '17.0.0-rc')) {
         this.plugins.push('@netlify/angular-runtime')
-        this.build.directory = '' // will be overwritten by the plugin
+        const angularJson = await this.project.fs.gracefullyReadFile('angular.json')
+        if (angularJson) {
+          const { projects, defaultProject } = JSON.parse(angularJson)
+          const project = projects[defaultProject ?? Object.keys(projects)[0]]
+          const outputPath = project?.architect?.build?.options?.outputPath
+          if (outputPath) {
+            this.build.directory = `${outputPath}/browser`
+          }
+        }
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -32,6 +32,7 @@ export class Angular extends BaseFramework implements Framework {
     if (this.detected) {
       if (this.version && gte(this.version, '17.0.0-rc')) {
         this.plugins.push('@netlify/angular-runtime')
+        this.build.directory = '' // will be overwritten by the plugin
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -38,7 +38,7 @@ export class Angular extends BaseFramework implements Framework {
           const project = projects[defaultProject ?? Object.keys(projects)[0]]
           const outputPath = project?.architect?.build?.options?.outputPath
           if (outputPath) {
-            this.build.directory = `${outputPath}/browser`
+            this.build.directory = this.project.fs.join(outputPath, 'browser')
           }
         }
       }


### PR DESCRIPTION
With Angular v17, the publish directory changes based on contents of `angular.json`. It's hard to know this from build-info, but thankfully the build plugin deals with all of that! This PR updates the publish directory to `""`, which gives precedence to the value that's defined by the build plugin.