### PR TITLE
fix(tracing): namespace attributes in build error events and add further data

### DIFF
--- a/packages/build/src/tracing/main.ts
+++ b/packages/build/src/tracing/main.ts
@@ -8,6 +8,7 @@ import { NodeSDK } from '@opentelemetry/sdk-node'
 import type { TracingOptions } from '../core/types.js'
 import { isBuildError } from '../error/info.js'
 import { parseErrorInfo } from '../error/parse/parse.js'
+import { buildErrorToTracingAttributes } from '../error/types.js'
 import { ROOT_PACKAGE_JSON } from '../utils/json.js'
 
 let sdk: NodeSDK | undefined
@@ -94,9 +95,9 @@ export const addErrorToActiveSpan = function (error: Error) {
   const span = trace.getActiveSpan()
   if (!span) return
   if (isBuildError(error)) {
-    const { severity, type } = parseErrorInfo(error)
-    if (severity == 'none') return
-    span.setAttributes({ severity, type })
+    const buildError = parseErrorInfo(error)
+    if (buildError.severity == 'none') return
+    span.setAttributes(buildErrorToTracingAttributes(buildError))
   }
 
   span.recordException(error)

--- a/packages/build/tests/tracing/tests.js
+++ b/packages/build/tests/tracing/tests.js
@@ -207,7 +207,11 @@ test('addErrorToActiveSpan - when error severity info', async (t) => {
 
     t.is(span.status.code, SpanStatusCode.ERROR)
     // Severities are infered from the Error Type
-    t.deepEqual(span.attributes, { severity: 'info', type: 'failPlugin' })
+    t.deepEqual(span.attributes, {
+      'build.error.location.type': 'buildFail',
+      'build.error.severity': 'info',
+      'build.error.type': 'failPlugin',
+    })
 
     const firstEvent = span.events[0]
     t.deepEqual(firstEvent.name, 'exception')


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fix for - COM-129 - https://linear.app/netlify/issue/COM-129/expose-location-information-for-errors-in-netlifybuild

This adds further errorInfo data and adequately namespaces our attributes added to the execption events.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
