### PR TITLE
feat: supply system log to trusted plugins via FD

### DIFF
--- a/packages/build/src/core/build.ts
+++ b/packages/build/src/core/build.ts
@@ -204,6 +204,7 @@ const tExecBuild = async function ({
     logs,
     debug,
     systemLog,
+    systemLogFile,
     verbose,
     timers: timersA,
     sendStatus,
@@ -264,6 +265,7 @@ export const runAndReportBuild = async function ({
   logs,
   debug,
   systemLog,
+  systemLogFile,
   verbose,
   timers,
   sendStatus,
@@ -315,6 +317,7 @@ export const runAndReportBuild = async function ({
       logs,
       debug,
       systemLog,
+      systemLogFile,
       verbose,
       timers,
       sendStatus,
@@ -418,6 +421,7 @@ const initAndRunBuild = async function ({
   logs,
   debug,
   systemLog,
+  systemLogFile,
   verbose,
   sendStatus,
   saveConfig,
@@ -466,6 +470,7 @@ const initAndRunBuild = async function ({
     timers: timersA,
     featureFlags,
     quiet,
+    systemLogFile,
   })
 
   try {

--- a/packages/build/src/plugins/child/run.js
+++ b/packages/build/src/plugins/child/run.js
@@ -2,6 +2,7 @@ import { getNewEnvChanges, setEnvChanges } from '../../env/changes.js'
 import { logPluginMethodStart, logPluginMethodEnd } from '../../log/messages/ipc.js'
 
 import { cloneNetlifyConfig, getConfigMutations } from './diff.js'
+import { getSystemLog } from './systemLog.js'
 import { getUtils } from './utils.js'
 
 // Run a specific plugin event handler
@@ -11,9 +12,19 @@ export const run = async function (
 ) {
   const method = methods[event]
   const runState = {}
+  const systemLog = getSystemLog()
   const utils = getUtils({ event, constants, runState })
   const netlifyConfigCopy = cloneNetlifyConfig(netlifyConfig)
-  const runOptions = { utils, constants, inputs, netlifyConfig: netlifyConfigCopy, packageJson, error, featureFlags }
+  const runOptions = {
+    utils,
+    constants,
+    inputs,
+    netlifyConfig: netlifyConfigCopy,
+    packageJson,
+    error,
+    featureFlags,
+    systemLog,
+  }
 
   const envBefore = setEnvChanges(envChanges)
 

--- a/packages/build/src/plugins/child/systemLog.js
+++ b/packages/build/src/plugins/child/systemLog.js
@@ -1,0 +1,15 @@
+import { appendFileSync, openSync } from 'fs'
+
+const systemLogLocation = '/dev/fd/4'
+
+export const getSystemLog = () => {
+  try {
+    // throws if system log wasn't hooked up
+    const fd = openSync(systemLogLocation, 'a')
+    return (message) => {
+      appendFileSync(fd, `${message}\n`)
+    }
+  } catch {
+    return
+  }
+}

--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -44,6 +44,7 @@ const tStartPlugins = async function ({ pluginsOptions, buildDir, childEnv, logs
 export const startPlugins = measureDuration(tStartPlugins, 'start_plugins')
 
 const startPlugin = async function ({ pluginDir, nodePath, buildDir, childEnv, systemLogFile, pluginPackageJson }) {
+  // todo: extract this into a function that's shared with the feature flag impl
   const isTrustedPlugin = pluginPackageJson?.name?.startsWith('@netlify/')
 
   const childProcess = execaNode(CHILD_MAIN_FILE, [], {

--- a/packages/build/src/steps/plugin.js
+++ b/packages/build/src/steps/plugin.js
@@ -7,6 +7,8 @@ import { getSuccessStatus } from '../status/success.js'
 import { getPluginErrorType } from './error.js'
 import { updateNetlifyConfig, listConfigSideFiles } from './update_config.js'
 
+export const isTrustedPlugin = (pluginPackageJson) => pluginPackageJson?.name?.startsWith('@netlify/')
+
 // Fire a plugin step
 export const firePluginStep = async function ({
   event,
@@ -33,8 +35,6 @@ export const firePluginStep = async function ({
 }) {
   const listeners = pipePluginOutput(childProcess, logs)
 
-  const isTrustedPlugin = pluginPackageJson?.name?.startsWith('@netlify/')
-
   try {
     const configSideFiles = await listConfigSideFiles([headersPath, redirectsPath])
     const {
@@ -48,7 +48,7 @@ export const firePluginStep = async function ({
         event,
         error,
         envChanges,
-        featureFlags: isTrustedPlugin ? featureFlags : undefined,
+        featureFlags: isTrustedPlugin(pluginPackageJson) ? featureFlags : undefined,
         netlifyConfig,
         constants,
       },

--- a/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
@@ -3,6 +3,6 @@ import { appendFileSync } from  "fs"
 const systemLog = "/dev/fd/4" // 🪄 magic ✨
 
 export const onBuild = function ({ featureFlags }) {
-  appendFileSync(systemLog, "some system-facing logs")
+  appendFileSync(systemLog, "some system-facing logs\n")
   console.log(JSON.stringify(featureFlags))
 }

--- a/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
@@ -1,3 +1,8 @@
+import { appendFileSync } from  "fs"
+
+const systemLog = "/dev/fd/4" // 🪄 magic ✨
+
 export const onBuild = function ({ featureFlags }) {
+  appendFileSync(systemLog, "some system-facing logs")
   console.log(JSON.stringify(featureFlags))
 }

--- a/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
@@ -1,4 +1,4 @@
 export const onBuild = function ({ featureFlags, systemLog }) {
-  systemLog("some system-facing logs")
+  systemLog?.("some system-facing logs")
   console.log(JSON.stringify(featureFlags))
 }

--- a/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags/plugin.js
@@ -1,8 +1,4 @@
-import { appendFileSync } from  "fs"
-
-const systemLog = "/dev/fd/4" // 🪄 magic ✨
-
-export const onBuild = function ({ featureFlags }) {
-  appendFileSync(systemLog, "some system-facing logs\n")
+export const onBuild = function ({ featureFlags, systemLog }) {
+  systemLog("some system-facing logs")
   console.log(JSON.stringify(featureFlags))
 }

--- a/packages/build/tests/plugins/fixtures/feature_flags_untrusted/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags_untrusted/plugin.js
@@ -1,16 +1,5 @@
-import { appendFileSync } from  "fs"
-
-const isSystemLogAccessible = () => {
-  try {
-    appendFileSync("/dev/fd/4", "some system-facing logs")
-    return true
-  } catch (error) {
-    return false
-  }
-}
-
-export const onBuild = function ({ featureFlags }) {
-  if (isSystemLogAccessible()) {
+export const onBuild = function ({ featureFlags, systemLog }) {
+  if (systemLog) {
     throw new Error("System log shouldn't be acessible from untrusted plugins")
   }
   console.log("typeof featureflags:", typeof featureFlags)

--- a/packages/build/tests/plugins/fixtures/feature_flags_untrusted/plugin.js
+++ b/packages/build/tests/plugins/fixtures/feature_flags_untrusted/plugin.js
@@ -1,3 +1,17 @@
+import { appendFileSync } from  "fs"
+
+const isSystemLogAccessible = () => {
+  try {
+    appendFileSync("/dev/fd/4", "some system-facing logs")
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
 export const onBuild = function ({ featureFlags }) {
+  if (isSystemLogAccessible()) {
+    throw new Error("System log shouldn't be acessible from untrusted plugins")
+  }
   console.log("typeof featureflags:", typeof featureFlags)
 }

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises'
+import { platform } from 'process'
 import { fileURLToPath } from 'url'
 
 import { Fixture, normalizeOutput, removeDir } from '@netlify/testing'
@@ -154,11 +155,13 @@ test('Trusted plugins are passed featureflags and system log', async (t) => {
     })
     .runWithBuild()
 
-  const systemLog = (await fs.readFile(systemLogFile, { encoding: 'utf8' })).split('\n')
+  if (platform !== 'win32') {
+    const systemLog = (await fs.readFile(systemLogFile, { encoding: 'utf8' })).split('\n')
 
-  const expectedSystemLogs = 'some system-facing logs'
-  t.false(output.includes(expectedSystemLogs))
-  t.true(systemLog.includes(expectedSystemLogs))
+    const expectedSystemLogs = 'some system-facing logs'
+    t.false(output.includes(expectedSystemLogs))
+    t.true(systemLog.includes(expectedSystemLogs))
+  }
 
   t.true(
     output.includes(

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -155,6 +155,7 @@ test('Trusted plugins are passed featureflags and system log', async (t) => {
     })
     .runWithBuild()
 
+  // windows doesn't support the `/dev/fd/` API we're relying on for system logging.
   if (platform !== 'win32') {
     const systemLog = (await fs.readFile(systemLogFile, { encoding: 'utf8' })).split('\n')
 

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -144,7 +144,7 @@ test('Plugins can have inputs', async (t) => {
   t.snapshot(normalizeOutput(output))
 })
 
-test('Plugins are passed featureflags', async (t) => {
+test.only('Trusted plugins are passed featureflags and system log', async (t) => {
   const systemLogFile = await tmpName()
   const output = await new Fixture('./fixtures/feature_flags')
     .withFlags({

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -144,7 +144,7 @@ test('Plugins can have inputs', async (t) => {
   t.snapshot(normalizeOutput(output))
 })
 
-test.only('Trusted plugins are passed featureflags and system log', async (t) => {
+test('Trusted plugins are passed featureflags and system log', async (t) => {
   const systemLogFile = await tmpName()
   const output = await new Fixture('./fixtures/feature_flags')
     .withFlags({
@@ -154,11 +154,11 @@ test.only('Trusted plugins are passed featureflags and system log', async (t) =>
     })
     .runWithBuild()
 
-  const systemLog = await fs.readFile(systemLogFile, { encoding: 'utf8' })
+  const systemLog = (await fs.readFile(systemLogFile, { encoding: 'utf8' })).split('\n')
 
   const expectedSystemLogs = 'some system-facing logs'
   t.false(output.includes(expectedSystemLogs))
-  t.is(systemLog, expectedSystemLogs)
+  t.true(systemLog.includes(expectedSystemLogs))
 
   t.true(
     output.includes(

--- a/packages/build/types/netlify_plugin_options.d.ts
+++ b/packages/build/types/netlify_plugin_options.d.ts
@@ -21,4 +21,5 @@ export interface NetlifyPluginOptions<TInputs extends PluginInputs<StringKeys<TI
   constants: NetlifyPluginConstants
   utils: NetlifyPluginUtils
   featureFlags?: Record<string, unknown>
+  systemLog?(message: string): void
 }


### PR DESCRIPTION
System logs are super useful for our internal observability. Giving system logs to (trusted) build plugins isn't straight-forward since plugins are run inside a child process. This PR is an attempt at bridging this, by sharing the system log file descriptor with the child process. This means build plugins will be able to write to system logs like this:

```js
import { appendFileSync } from  "fs"

export const onBuild = function () {
  // ...
  appendFileSync("/dev/fd/4", "next.js customer using ISC, SSR and XYZ")
  // ...
}

```

`/dev/fd/4` is a bit of a magic name - but it works.

There's still some tests failing, but I wanted to share the approach sooner than later, and get your feedback.