### PR TITLE
fix(build): add support for ntl otel sdk setup on preloading

### DIFF
--- a/packages/build/src/core/flags.js
+++ b/packages/build/src/core/flags.js
@@ -204,6 +204,11 @@ Default: false`,
     describe: 'Enable distributed tracing for build',
     hidden: true,
   },
+  'tracing.preloadingEnabled': {
+    boolean: true,
+    describe: 'Enable distributed tracing for build via module preloading, to be removed once fully rolled out',
+    hidden: true,
+  },
   'tracing.apiKey': {
     string: true,
     describe: 'API Key for the tracing backend provider',

--- a/packages/build/src/core/normalize_flags.ts
+++ b/packages/build/src/core/normalize_flags.ts
@@ -101,6 +101,7 @@ const getDefaultFlags = function ({ env: envOpt = {} }, combinedEnv) {
     // honeycomb directly - https://github.com/honeycombio/honeycomb-opentelemetry-node/issues/201
     tracing: {
       enabled: false,
+      preloadingEnabled: false,
       apiKey: '-',
       // defaults to always sample
       sampleRate: 1,

--- a/packages/build/src/core/types.ts
+++ b/packages/build/src/core/types.ts
@@ -85,6 +85,8 @@ export type ErrorParam = {
 
 export type TracingOptions = {
   enabled: boolean
+  /* Tracing is enabled via module preloading, to be removed once we fully rolled it out  */
+  preloadingEnabled: boolean
   httpProtocol: string
   host: string
   port: number

--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -50,6 +50,8 @@ const startPlugin = async function ({ pluginDir, nodePath, buildDir, childEnv, s
     preferLocal: true,
     localDir: pluginDir,
     nodePath,
+    // make sure we don't pass build's node cli properties for now (e.g. --import)
+    nodeOptions: [],
     execPath: nodePath,
     env: childEnv,
     extendEnv: false,


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Related with COM-110 - https://linear.app/netlify/issue/COM-110/make-opentelemetry-an-optional-dependency-in-build - and a follow up to #5401. This adds support for build to skip its internal tracing initialisation if we detect the preloading had executed.

I've tested this out locally via:
```
node --import ./packages/opentelemetry-sdk-setup/lib/bin.js ./packages/build/lib/core/bin.js --debug --tracing.debug=true --tracing.preloadingEnabled=true --tracing.sampleRate=1 --tracing.apiKey=<some-api-key>  --tracing.httpProtocol=https --tracing.host=api.honeycomb.io --tracing.port=443 --tracing.baggageFilePath=$(pwd)/baggage-mock  ../../github/www-and-blog/
```

The baggage file:
```
somefield=value,foo=bar
```

The resulting trace:
- https://ui.honeycomb.io/gatsbyinc/environments/dev-buildbot/datasets/-netlify-build/trace/gUcKEv937iE?fields[]=s_name&fields[]=s_serviceName&span=8d83e57ae4408c58

![image](https://github.com/netlify/build/assets/5799039/c6a7884b-0ad9-4a75-b42b-08f425e8a7e9)


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
