### PR TITLE
fix(build): add trusted plugin error type

### DIFF
--- a/packages/build/src/error/parse/serialize_status.ts
+++ b/packages/build/src/error/parse/serialize_status.ts
@@ -1,7 +1,14 @@
-// Serialize an error object to `statuses` properties
+import type { BuildError } from '../types.js'
+
+type ErrorState = 'failed_build' | 'failed_plugin' | 'canceled_build'
+
+/* Serialize an error object to `statuses` properties */
 export const serializeErrorStatus = function ({
   fullErrorInfo: { title, message, locationInfo, errorProps, errorMetadata },
   state,
+}: {
+  fullErrorInfo: BuildError
+  state: ErrorState
 }) {
   const text = getText({ locationInfo, errorProps })
   return { state, title, summary: message, text, extraData: errorMetadata }
@@ -17,7 +24,7 @@ const getText = function ({ locationInfo, errorProps }) {
   return parts.join('\n\n')
 }
 
-const getErrorProps = function (errorProps) {
+const getErrorProps = function (errorProps: string | undefined) {
   if (errorProps === undefined) {
     return
   }

--- a/packages/build/src/error/types.ts
+++ b/packages/build/src/error/types.ts
@@ -256,13 +256,15 @@ const ErrorTypeMap = {
   pluginInternal: 'pluginInternal',
   ipc: 'ipc',
   corePlugin: 'corePlugin',
+  trustedPlugin: 'trustedPlugin',
   coreStep: 'coreStep',
   api: 'api',
   exception: 'exception',
   telemetry: 'telemetry',
 } as const
 
-type ErrorTypes = keyof typeof ErrorTypeMap
+/* Error classes for build executions */
+export type ErrorTypes = keyof typeof ErrorTypeMap
 
 /**
  * List of error types, and their related properties
@@ -407,6 +409,17 @@ const TYPES: { [T in ErrorTypes]: ErrorType } = {
    * Core plugin internal error
    */
   corePlugin: {
+    title: ({ location: { packageName } }: { location: PluginLocation }) => `Plugin "${packageName}" internal error`,
+    stackType: 'stack',
+    showErrorProps: true,
+    rawStack: true,
+    locationType: 'buildFail',
+    severity: 'error',
+  },
+  /**
+   * Trusted plugin internal error (all of our `@netlify/*` plugins).
+   */
+  trustedPlugin: {
     title: ({ location: { packageName } }: { location: PluginLocation }) => `Plugin "${packageName}" internal error`,
     stackType: 'stack',
     showErrorProps: true,

--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -56,7 +56,9 @@ const startPlugin = async function ({ pluginDir, nodePath, buildDir, childEnv, s
     env: childEnv,
     extendEnv: false,
     stdio:
-      isTrustedPlugin(pluginPackageJson) && systemLogFile ? ['pipe', 'pipe', 'pipe', 'ipc', systemLogFile] : undefined,
+      isTrustedPlugin(pluginPackageJson?.name) && systemLogFile
+        ? ['pipe', 'pipe', 'pipe', 'ipc', systemLogFile]
+        : undefined,
   })
 
   try {

--- a/packages/build/src/steps/error.ts
+++ b/packages/build/src/steps/error.ts
@@ -1,14 +1,13 @@
-import type { ErrorParam } from '../core/types.js'
 import { cancelBuild } from '../error/cancel.js'
 import { handleBuildError } from '../error/handle.js'
 import { getFullErrorInfo, parseErrorInfo } from '../error/parse/parse.js'
-import { serializeErrorStatus } from '../error/parse/serialize_status.js'
 import { BuildError, isPluginLocation, PluginLocation, ErrorTypes } from '../error/types.js'
+import { serializeErrorStatus } from '../error/parse/serialize_status.js'
 import { isSoftFailEvent } from '../plugins/events.js'
 import { addErrorToActiveSpan, addEventToActiveSpan } from '../tracing/main.js'
+import { isTrustedPlugin } from '../steps/plugin.js'
 
-import { isTrustedPlugin } from "./plugin.js"
-
+import type { ErrorParam } from '../core/types.js'
 
 /**
  * Handle build command errors and plugin errors:

--- a/packages/build/src/steps/error.ts
+++ b/packages/build/src/steps/error.ts
@@ -1,13 +1,13 @@
+import type { ErrorParam } from '../core/types.js'
 import { cancelBuild } from '../error/cancel.js'
 import { handleBuildError } from '../error/handle.js'
 import { getFullErrorInfo, parseErrorInfo } from '../error/parse/parse.js'
-import { BuildError, isPluginLocation, PluginLocation, ErrorTypes } from '../error/types.js'
 import { serializeErrorStatus } from '../error/parse/serialize_status.js'
+import { BuildError, isPluginLocation, PluginLocation, ErrorTypes } from '../error/types.js'
 import { isSoftFailEvent } from '../plugins/events.js'
 import { addErrorToActiveSpan, addEventToActiveSpan } from '../tracing/main.js'
-import { isTrustedPlugin } from '../steps/plugin.js'
 
-import type { ErrorParam } from '../core/types.js'
+import { isTrustedPlugin } from './plugin.js'
 
 /**
  * Handle build command errors and plugin errors:

--- a/packages/build/src/steps/error.ts
+++ b/packages/build/src/steps/error.ts
@@ -114,7 +114,6 @@ export const getPluginErrorType = function (
   loadedFrom: string,
   packageName?: string,
 ): { type?: ErrorTypes } {
-  console.error(error)
   if (isTrustedPluginBug(error, packageName)) {
     return { type: 'trustedPlugin' }
   }

--- a/packages/build/src/steps/plugin.js
+++ b/packages/build/src/steps/plugin.js
@@ -7,7 +7,7 @@ import { getSuccessStatus } from '../status/success.js'
 import { getPluginErrorType } from './error.js'
 import { updateNetlifyConfig, listConfigSideFiles } from './update_config.js'
 
-export const isTrustedPlugin = (pluginPackageJson) => pluginPackageJson?.name?.startsWith('@netlify/')
+export const isTrustedPlugin = (packageName) => packageName?.startsWith('@netlify/')
 
 // Fire a plugin step
 export const firePluginStep = async function ({
@@ -48,7 +48,7 @@ export const firePluginStep = async function ({
         event,
         error,
         envChanges,
-        featureFlags: isTrustedPlugin(pluginPackageJson) ? featureFlags : undefined,
+        featureFlags: isTrustedPlugin(pluginPackageJson?.name) ? featureFlags : undefined,
         netlifyConfig,
         constants,
       },
@@ -83,7 +83,7 @@ export const firePluginStep = async function ({
       newStatus,
     }
   } catch (newError) {
-    const errorType = getPluginErrorType(newError, loadedFrom)
+    const errorType = getPluginErrorType(newError, loadedFrom, packageName)
     addErrorInfo(newError, {
       ...errorType,
       plugin: { pluginPackageJson, packageName },

--- a/packages/build/tests/error/fixtures/trusted_plugin/netlify.toml
+++ b/packages/build/tests/error/fixtures/trusted_plugin/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "@netlify/netlify-plugin-test"

--- a/packages/build/tests/error/fixtures/trusted_plugin/node_modules/@netlify/netlify-plugin-test/index.js
+++ b/packages/build/tests/error/fixtures/trusted_plugin/node_modules/@netlify/netlify-plugin-test/index.js
@@ -1,0 +1,7 @@
+export const onPreBuild = function ({
+  utils: {
+    build: { failBuild },
+  },
+}) {
+  failBuild('test', { error: new Error('Such controlled failure, very wow') })
+}

--- a/packages/build/tests/error/fixtures/trusted_plugin/node_modules/@netlify/netlify-plugin-test/manifest.yml
+++ b/packages/build/tests/error/fixtures/trusted_plugin/node_modules/@netlify/netlify-plugin-test/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/error/fixtures/trusted_plugin/node_modules/@netlify/netlify-plugin-test/package.json
+++ b/packages/build/tests/error/fixtures/trusted_plugin/node_modules/@netlify/netlify-plugin-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@netlify/netlify-plugin-test",
+  "version": "1.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test"
+}

--- a/packages/build/tests/error/fixtures/trusted_plugin/package.json
+++ b/packages/build/tests/error/fixtures/trusted_plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module_plugin",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test",
+  "dependencies": {
+    "@netlify/netlify-plugin-test": "^1.0.0"
+  }
+}

--- a/packages/build/tests/error/fixtures/trusted_plugin_uncaught/netlify.toml
+++ b/packages/build/tests/error/fixtures/trusted_plugin_uncaught/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "@netlify/netlify-plugin-test"

--- a/packages/build/tests/error/fixtures/trusted_plugin_uncaught/node_modules/@netlify/netlify-plugin-test/index.js
+++ b/packages/build/tests/error/fixtures/trusted_plugin_uncaught/node_modules/@netlify/netlify-plugin-test/index.js
@@ -1,0 +1,3 @@
+export const onPreBuild = function () {
+    throw new Error("I'm unhandled y'all")
+}

--- a/packages/build/tests/error/fixtures/trusted_plugin_uncaught/node_modules/@netlify/netlify-plugin-test/manifest.yml
+++ b/packages/build/tests/error/fixtures/trusted_plugin_uncaught/node_modules/@netlify/netlify-plugin-test/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/error/fixtures/trusted_plugin_uncaught/node_modules/@netlify/netlify-plugin-test/package.json
+++ b/packages/build/tests/error/fixtures/trusted_plugin_uncaught/node_modules/@netlify/netlify-plugin-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@netlify/netlify-plugin-test",
+  "version": "1.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test"
+}

--- a/packages/build/tests/error/fixtures/trusted_plugin_uncaught/package.json
+++ b/packages/build/tests/error/fixtures/trusted_plugin_uncaught/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module_plugin",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test",
+  "dependencies": {
+    "@netlify/netlify-plugin-test": "^1.0.0"
+  }
+}

--- a/packages/build/tests/error/tests.js
+++ b/packages/build/tests/error/tests.js
@@ -214,3 +214,15 @@ testMatrixAttributeTracing.forEach(({ description, input, expects }) => {
     t.deepEqual(attributes, expects)
   })
 })
+
+test('Trusted plugins - internal errors are system errors', async (t) => {
+  const fixture = new Fixture('./fixtures/trusted_plugin_uncaught')
+  const { severityCode } = await fixture.runBuildProgrammatic()
+  t.deepEqual(severityCode, 4)
+})
+
+test('Trusted plugins - controlled failures are user errors', async (t) => {
+  const fixture = new Fixture('./fixtures/trusted_plugin')
+  const { severityCode } = await fixture.runBuildProgrammatic()
+  t.deepEqual(severityCode, 2)
+})


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes COM-187 - https://linear.app/netlify/issue/COM-187/classify-internal-plugin-errors-for-trusted-netlify-plugins-as-system. Classify unhandled trusted plugin failures as system errors.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
