### PR TITLE
fix: delete _headers and _redirect before starting nuxt dev

### DIFF
--- a/packages/build-info/src/frameworks/nuxt.test.ts
+++ b/packages/build-info/src/frameworks/nuxt.test.ts
@@ -1,3 +1,5 @@
+import { platform } from 'node:process'
+
 import { beforeEach, expect, describe, test } from 'vitest'
 
 import { mockFileSystem } from '../../tests/mock-file-system.js'
@@ -47,5 +49,11 @@ describe('Nuxt V3', () => {
       AWS_LAMBDA_JS_RUNTIME: 'nodejs18.x',
       NODE_VERSION: '18',
     })
+
+    if (platform === 'win32') {
+      expect(detected?.[0].getDevCommands()).toEqual(['del dist\\_redirects dist\\_headers & nuxt dev'])
+    } else {
+      expect(detected?.[0].getDevCommands()).toEqual(['rm dist/_redirects dist/_headers; nuxt dev'])
+    }
   })
 })

--- a/packages/build-info/src/frameworks/nuxt.ts
+++ b/packages/build-info/src/frameworks/nuxt.ts
@@ -1,3 +1,5 @@
+import { platform } from 'node:process'
+
 import { BaseFramework, Category, DetectedFramework, Detection, Framework } from './framework.js'
 
 export class Nuxt extends BaseFramework implements Framework {
@@ -45,5 +47,16 @@ export class Nuxt extends BaseFramework implements Framework {
 
   isV3(detected: Detection) {
     return detected.package?.name === 'nuxt3' || detected.package?.version?.major === 3
+  }
+
+  // Workaround for https://github.com/unjs/nitro/issues/1970
+  getDevCommands(): string[] {
+    return super.getDevCommands().map((command) => {
+      if (platform === 'win32') {
+        return `del dist\\_redirects dist\\_headers & ${command}`
+      } else {
+        return `rm dist/_redirects dist/_headers; ${command}`
+      }
+    })
   }
 }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Part of https://linear.app/netlify/issue/COM-184/nuxt-netlify-dev-doesnt-work. Running `ntl build` and then `ntl dev` on a Nuxt project leads to Dev picking up `dist/_redirects` and `dist/_headers`, even though the Nitro dev server will handle all of this on its own. This is breaking local dev currently.

In https://github.com/unjs/nitro/issues/1970, the Nitro team suggests we add `rm -rf` to the dev command. That's what this PR does!

TODO:
- [ ] test locally if this really fixes the bug

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
