### PR TITLE
fix: add clearPublishDirectory to getSettings

### DIFF
--- a/packages/build-info/src/frameworks/nuxt.test.ts
+++ b/packages/build-info/src/frameworks/nuxt.test.ts
@@ -51,6 +51,7 @@ describe('Nuxt V3', () => {
       NODE_VERSION: '18',
     })
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const settings = await getSettings(detected![0], project, cwd)
     expect(settings.clearPublishDirectory).toBeTruthy()
   })

--- a/packages/build-info/src/frameworks/nuxt.test.ts
+++ b/packages/build-info/src/frameworks/nuxt.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, describe, test } from 'vitest'
 
 import { mockFileSystem } from '../../tests/mock-file-system.js'
+import { getSettings } from '../index.js'
 import { NodeFS } from '../node/file-system.js'
 import { Project } from '../project.js'
 
@@ -36,7 +37,8 @@ describe('Nuxt V3', () => {
     ['major version', { 'package.json': JSON.stringify({ dependencies: { nuxt: '^3.0.0' } }) }],
   ])('should detect Nuxt via the %s', async (_, files) => {
     const cwd = mockFileSystem(files)
-    const detected = await new Project(fs, cwd).detectFrameworks()
+    const project = new Project(fs, cwd)
+    const detected = await project.detectFrameworks()
     expect(detected?.[0].id).toBe('nuxt')
     expect(detected?.[0].name).toBe('Nuxt 3')
     expect(detected?.[0].build.command).toBe('nuxt build')
@@ -48,5 +50,8 @@ describe('Nuxt V3', () => {
       AWS_LAMBDA_JS_RUNTIME: 'nodejs18.x',
       NODE_VERSION: '18',
     })
+
+    const settings = await getSettings(detected![0], project, cwd)
+    expect(settings.clearPublishDirectory).toBeTruthy()
   })
 })

--- a/packages/build-info/src/settings/get-build-settings.ts
+++ b/packages/build-info/src/settings/get-build-settings.ts
@@ -88,7 +88,6 @@ export async function getSettings(framework: Framework, project: Project, baseDi
     name: framework.name,
     buildCommand: buildCommands[0],
     devCommand: devCommands[0],
-    clearPublishDirectory: framework.dev?.clearPublishDirectory,
     frameworkPort: framework.dev?.port,
     dist: project.fs.join(baseDirectory, framework.build.directory),
     env: framework.env || {},
@@ -101,6 +100,10 @@ export async function getSettings(framework: Framework, project: Project, baseDi
     baseDirectory,
     packagePath: baseDirectory,
     pollingStrategies: framework.dev?.pollingStrategies?.map(({ name }) => name) || [],
+  }
+
+  if (typeof framework.dev?.clearPublishDirectory !== 'undefined') {
+    settings.clearPublishDirectory = framework.dev.clearPublishDirectory
   }
 
   if (baseDirectory?.length && project.workspace?.isRoot) {

--- a/packages/build-info/src/settings/get-build-settings.ts
+++ b/packages/build-info/src/settings/get-build-settings.ts
@@ -19,6 +19,8 @@ export type Settings = {
     id: string
     name: string
   }
+  /** Wether to clear the publish directory before local dev */
+  clearPublishDirectory?: boolean
   /** The dist directory that contains the build output */
   dist: string
   env: Record<string, string | undefined>
@@ -86,6 +88,7 @@ export async function getSettings(framework: Framework, project: Project, baseDi
     name: framework.name,
     buildCommand: buildCommands[0],
     devCommand: devCommands[0],
+    clearPublishDirectory: framework.dev?.clearPublishDirectory,
     frameworkPort: framework.dev?.port,
     dist: project.fs.join(baseDirectory, framework.build.directory),
     env: framework.env || {},


### PR DESCRIPTION
Follow-up to https://github.com/netlify/build/pull/5430. The way we interact with build-info in the CLI is via getSettings, so we should make that new property available on `Settings`!