### PR TITLE
feat(build-info): pass feature flags as json and change plugins to an object

### DIFF
--- a/packages/build-info/src/build-systems/nx.test.ts
+++ b/packages/build-info/src/build-systems/nx.test.ts
@@ -197,7 +197,7 @@ describe('nx-integrated project.json based', () => {
           frameworkPort: 4200,
           name: `Nx + Next.js ${join('packages/website')}`,
           packagePath: join('packages/website'),
-          plugins_recommended: ['@netlify/plugin-nextjs'],
+          plugins: [{ name: '@netlify/plugin-nextjs', alwaysInstall: true }],
         }),
       ]),
     )
@@ -212,7 +212,7 @@ describe('nx-integrated project.json based', () => {
           frameworkPort: 3000,
           name: `Nx + Astro ${join('packages/astro')}`,
           packagePath: join('packages/astro'),
-          plugins_recommended: [],
+          plugins: [],
         }),
       ]),
     )
@@ -250,7 +250,7 @@ describe('nx-integrated workspace.json based', () => {
           frameworkPort: 4200,
           name: `Nx + React Static ${join('apps/website')}`,
           packagePath: join('apps/website'),
-          plugins_recommended: [],
+          plugins: [],
         }),
       ]),
     )
@@ -264,7 +264,7 @@ describe('nx-integrated workspace.json based', () => {
           framework: { id: 'astro', name: 'Astro' },
           name: `Nx + Astro ${join('apps/astro')}`,
           packagePath: join('apps/astro'),
-          plugins_recommended: [],
+          plugins: [],
         }),
       ]),
     )

--- a/packages/build-info/src/build-systems/nx.test.ts
+++ b/packages/build-info/src/build-systems/nx.test.ts
@@ -197,7 +197,7 @@ describe('nx-integrated project.json based', () => {
           frameworkPort: 4200,
           name: `Nx + Next.js ${join('packages/website')}`,
           packagePath: join('packages/website'),
-          plugins: [{ name: '@netlify/plugin-nextjs', alwaysInstall: true }],
+          plugins: [{ name: '@netlify/plugin-nextjs', autoInstall: true }],
         }),
       ]),
     )

--- a/packages/build-info/src/build-systems/nx.test.ts
+++ b/packages/build-info/src/build-systems/nx.test.ts
@@ -197,7 +197,7 @@ describe('nx-integrated project.json based', () => {
           frameworkPort: 4200,
           name: `Nx + Next.js ${join('packages/website')}`,
           packagePath: join('packages/website'),
-          plugins: [{ name: '@netlify/plugin-nextjs', autoInstall: true }],
+          plugins: [{ package: '@netlify/plugin-nextjs', autoInstall: true }],
         }),
       ]),
     )

--- a/packages/build-info/src/frameworks/angular.test.ts
+++ b/packages/build-info/src/frameworks/angular.test.ts
@@ -32,7 +32,7 @@ test('should detect Angular', async ({ fs }) => {
   expect(detected?.[0].build.command).toBe('ng build --prod')
   expect(detected?.[0].build.directory).toBe(fs.join('dist', 'demo', 'browser'))
   expect(detected?.[0].dev?.command).toBe('ng serve')
-  expect(detected?.[0].plugins).toEqual([{ name: '@netlify/angular-runtime' }])
+  expect(detected?.[0].plugins).toEqual([{ package: '@netlify/angular-runtime' }])
 })
 
 test('should set publish directory based on builder', async ({ fs }) => {

--- a/packages/build-info/src/frameworks/angular.test.ts
+++ b/packages/build-info/src/frameworks/angular.test.ts
@@ -31,7 +31,7 @@ test('should detect Angular', async ({ fs }) => {
   expect(detected?.[0].build.command).toBe('ng build --prod')
   expect(detected?.[0].build.directory).toBe(fs.join('dist', 'demo', 'browser'))
   expect(detected?.[0].dev?.command).toBe('ng serve')
-  expect(detected?.[0].plugins).toEqual(['@netlify/angular-runtime'])
+  expect(detected?.[0].plugins).toEqual([{ name: '@netlify/angular-runtime' }])
 })
 
 test('should only install plugin on v17+', async ({ fs }) => {

--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -31,7 +31,7 @@ export class Angular extends BaseFramework implements Framework {
 
     if (this.detected) {
       if (this.version && gte(this.version, '17.0.0-rc')) {
-        this.plugins.push({ name: '@netlify/angular-runtime' })
+        this.plugins.push({ package: '@netlify/angular-runtime' })
         const angularJson = await this.project.fs.gracefullyReadFile('angular.json')
         if (angularJson) {
           const { projects, defaultProject } = JSON.parse(angularJson)

--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -31,7 +31,7 @@ export class Angular extends BaseFramework implements Framework {
 
     if (this.detected) {
       if (this.version && gte(this.version, '17.0.0-rc')) {
-        this.plugins.push('@netlify/angular-runtime')
+        this.plugins.push({ name: '@netlify/angular-runtime' })
         const angularJson = await this.project.fs.gracefullyReadFile('angular.json')
         if (angularJson) {
           const { projects, defaultProject } = JSON.parse(angularJson)

--- a/packages/build-info/src/frameworks/framework.ts
+++ b/packages/build-info/src/frameworks/framework.ts
@@ -41,7 +41,13 @@ export type FrameworkInfo = ReturnType<Framework['toJSON']>
 
 export type BuildPlugin = {
   name: string
-  /** Plugins that should be always installed */
+  /**
+   * This setting is for runtimes that are expected to be "automatically"
+   * installed. Even though they can be installed on package/toml, we always
+   * want them installed in the site settings. When installed our build will
+   * automatically install the latest version without the need of the user
+   * managing the version plugin.
+   */
   alwaysInstall?: boolean
   source?: 'toml'
 }

--- a/packages/build-info/src/frameworks/framework.ts
+++ b/packages/build-info/src/frameworks/framework.ts
@@ -48,7 +48,7 @@ export type BuildPlugin = {
    * automatically install the latest version without the need of the user
    * managing the version plugin.
    */
-  alwaysInstall?: boolean
+  autoInstall?: boolean
   source?: 'toml'
 }
 

--- a/packages/build-info/src/frameworks/framework.ts
+++ b/packages/build-info/src/frameworks/framework.ts
@@ -39,6 +39,13 @@ export type Detection = {
 
 export type FrameworkInfo = ReturnType<Framework['toJSON']>
 
+export type BuildPlugin = {
+  name: string
+  /** Plugins that should be always installed */
+  alwaysInstall?: boolean
+  source?: 'toml'
+}
+
 export interface Framework {
   project: Project
 
@@ -67,7 +74,7 @@ export interface Framework {
     light?: string
     dark?: string
   }
-  plugins: string[]
+  plugins: BuildPlugin[]
   env: Record<string, string>
 
   detect(): Promise<DetectedFramework | undefined>
@@ -147,7 +154,7 @@ export abstract class BaseFramework implements Framework {
   configFiles: string[] = []
   npmDependencies: string[] = []
   excludedNpmDependencies: string[] = []
-  plugins: string[] = []
+  plugins: BuildPlugin[] = []
   staticAssetsDirectory?: string
   env = {}
   dev?: {
@@ -355,7 +362,7 @@ export abstract class BaseFramework implements Framework {
             {},
           )
         : undefined,
-      plugins: this.plugins,
+      plugins: this.plugins.map(({ name }) => name),
     }
   }
 }

--- a/packages/build-info/src/frameworks/framework.ts
+++ b/packages/build-info/src/frameworks/framework.ts
@@ -40,7 +40,7 @@ export type Detection = {
 export type FrameworkInfo = ReturnType<Framework['toJSON']>
 
 export type BuildPlugin = {
-  name: string
+  package: string
   /**
    * This setting is for runtimes that are expected to be "automatically"
    * installed. Even though they can be installed on package/toml, we always
@@ -106,7 +106,7 @@ export interface Framework {
     staticAssetsDirectory?: string
     env: Record<string, string>
     logo?: Record<string, string>
-    plugins: string[]
+    plugins: BuildPlugin[]
   }
 }
 
@@ -368,7 +368,7 @@ export abstract class BaseFramework implements Framework {
             {},
           )
         : undefined,
-      plugins: this.plugins.map(({ name }) => name),
+      plugins: this.plugins,
     }
   }
 }

--- a/packages/build-info/src/frameworks/gatsby.test.ts
+++ b/packages/build-info/src/frameworks/gatsby.test.ts
@@ -27,7 +27,7 @@ test('should detect a simple Gatsby project and add the plugin if the node versi
   fs.cwd = cwd
   const detected = await new Project(fs, cwd).setNodeVersion('12.13.0').detectFrameworks()
   expect(detected?.[0].id).toBe('gatsby')
-  expect(detected?.[0].plugins).toMatchObject([{ name: '@netlify/plugin-gatsby' }])
+  expect(detected?.[0].plugins).toMatchObject([{ package: '@netlify/plugin-gatsby' }])
 })
 
 test('should detect a simple Gatsby 4 project', async ({ fs }) => {

--- a/packages/build-info/src/frameworks/gatsby.test.ts
+++ b/packages/build-info/src/frameworks/gatsby.test.ts
@@ -16,7 +16,7 @@ test('should not add the plugin if the node version is below 12.13.0', async ({ 
   fs.cwd = cwd
   const detected = await new Project(fs, cwd).setNodeVersion('12.12.9').detectFrameworks()
   expect(detected?.[0].id).toBe('gatsby')
-  expect(detected?.[0].plugins).toMatchObject([])
+  expect(detected?.[0].plugins).toHaveLength(0)
 })
 
 test('should detect a simple Gatsby project and add the plugin if the node version is large enough', async ({ fs }) => {
@@ -27,7 +27,7 @@ test('should detect a simple Gatsby project and add the plugin if the node versi
   fs.cwd = cwd
   const detected = await new Project(fs, cwd).setNodeVersion('12.13.0').detectFrameworks()
   expect(detected?.[0].id).toBe('gatsby')
-  expect(detected?.[0].plugins).toMatchObject(['@netlify/plugin-gatsby'])
+  expect(detected?.[0].plugins).toMatchObject([{ name: '@netlify/plugin-gatsby' }])
 })
 
 test('should detect a simple Gatsby 4 project', async ({ fs }) => {
@@ -67,8 +67,7 @@ test('should detect a simple Gatsby 4 project', async ({ fs }) => {
       frameworkPort: 8000,
       name: 'Gatsby',
       packagePath: '',
-      plugins_from_config_file: [],
-      plugins_recommended: [],
+      plugins: [],
       pollingStrategies: ['TCP', 'HTTP'],
     },
   ])

--- a/packages/build-info/src/frameworks/gatsby.ts
+++ b/packages/build-info/src/frameworks/gatsby.ts
@@ -45,7 +45,7 @@ export class Gatsby extends BaseFramework implements Framework {
 
       const nodeVersion = await this.project.getCurrentNodeVersion()
       if (nodeVersion && gte(nodeVersion, '12.13.0')) {
-        this.plugins.push('@netlify/plugin-gatsby')
+        this.plugins.push({ name: '@netlify/plugin-gatsby' })
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/frameworks/gatsby.ts
+++ b/packages/build-info/src/frameworks/gatsby.ts
@@ -45,7 +45,7 @@ export class Gatsby extends BaseFramework implements Framework {
 
       const nodeVersion = await this.project.getCurrentNodeVersion()
       if (nodeVersion && gte(nodeVersion, '12.13.0')) {
-        this.plugins.push({ name: '@netlify/plugin-gatsby' })
+        this.plugins.push({ package: '@netlify/plugin-gatsby' })
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -38,7 +38,15 @@ describe('Next.js Plugin', () => {
     const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual(['@netlify/plugin-nextjs'])
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
+  })
+
+  test('Should use the old runtime if the next.js version is not >= 13.5.0', async ({ fs, cwd }) => {
+    const project = new Project(fs, cwd).setNodeVersion('v18.0.0')
+    project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime' }
+    const frameworks = await project.detectFrameworks()
+    expect(frameworks?.[0].id).toBe('next')
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
   })
 
   test('Should not detect Next.js plugin for Next.js if when Node version < 10.13.0', async ({ fs, cwd }) => {
@@ -46,6 +54,44 @@ describe('Next.js Plugin', () => {
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
     expect(frameworks?.[0].plugins).toHaveLength(0)
+  })
+})
+
+describe('New Next.js Runtime', () => {
+  beforeEach((ctx) => {
+    ctx.cwd = mockFileSystem({
+      'package.json': JSON.stringify({
+        name: 'my-next-app',
+        version: '0.1.0',
+        private: true,
+        scripts: {
+          dev: 'next dev',
+          build: 'next build',
+          start: 'next start',
+        },
+        dependencies: {
+          next: '13.5.0',
+          react: '17.0.1',
+          'react-dom': '17.0.1',
+        },
+      }),
+    })
+  })
+
+  test('Should not use the new runtime if the node version is below 18', async ({ fs, cwd }) => {
+    const project = new Project(fs, cwd).setNodeVersion('v16.0.0')
+    project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime@latest' }
+    const frameworks = await project.detectFrameworks()
+    expect(frameworks?.[0].id).toBe('next')
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
+  })
+
+  test('Should use the old runtime if the next.js version is not >= 13.5.0', async ({ fs, cwd }) => {
+    const project = new Project(fs, cwd).setNodeVersion('v18.0.0')
+    project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime@latest' }
+    const frameworks = await project.detectFrameworks()
+    expect(frameworks?.[0].id).toBe('next')
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/next-runtime@latest', alwaysInstall: true }])
   })
 })
 
@@ -90,7 +136,7 @@ describe('simple Next.js project', async () => {
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async ({ fs, cwd }) => {
     const detected = await new Project(fs, cwd).setEnvironment({ NODE_VERSION: '18.x' }).detectFrameworks()
     expect(detected?.[0].id).toBe('next')
-    expect(detected?.[0].plugins).toMatchObject(['@netlify/plugin-nextjs'])
+    expect(detected?.[0].plugins).toMatchObject([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
   })
 })
 
@@ -134,7 +180,7 @@ describe('Nx monorepo', () => {
       devCommand: 'nx run website:serve',
       dist: join('dist/packages/website'),
       frameworkPort: 4200,
-      plugins_recommended: ['@netlify/plugin-nextjs'],
+      plugins: [{ name: '@netlify/plugin-nextjs', alwaysInstall: true }],
     })
   })
 })
@@ -152,7 +198,7 @@ describe('Nx turborepo', () => {
       devCommand: 'turbo run dev --filter web',
       dist: join('apps/web/.next'),
       frameworkPort: 3000,
-      plugins_recommended: ['@netlify/plugin-nextjs'],
+      plugins: [{ name: '@netlify/plugin-nextjs', alwaysInstall: true }],
     })
   })
 })

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -38,7 +38,7 @@ describe('Next.js Plugin', () => {
     const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 
   test('Should use the old runtime if the next.js version is not >= 13.5.0', async ({ fs, cwd }) => {
@@ -46,7 +46,7 @@ describe('Next.js Plugin', () => {
     project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime' }
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 
   test('Should not detect Next.js plugin for Next.js if when Node version < 10.13.0', async ({ fs, cwd }) => {
@@ -83,7 +83,7 @@ describe('New Next.js Runtime', () => {
     project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime@latest' }
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 
   test('Should use the old runtime if the next.js version is not >= 13.5.0', async ({ fs, cwd }) => {
@@ -91,7 +91,7 @@ describe('New Next.js Runtime', () => {
     project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime@latest' }
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/next-runtime@latest', alwaysInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/next-runtime@latest', autoInstall: true }])
   })
 })
 
@@ -136,7 +136,7 @@ describe('simple Next.js project', async () => {
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async ({ fs, cwd }) => {
     const detected = await new Project(fs, cwd).setEnvironment({ NODE_VERSION: '18.x' }).detectFrameworks()
     expect(detected?.[0].id).toBe('next')
-    expect(detected?.[0].plugins).toMatchObject([{ name: '@netlify/plugin-nextjs', alwaysInstall: true }])
+    expect(detected?.[0].plugins).toMatchObject([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 })
 
@@ -180,7 +180,7 @@ describe('Nx monorepo', () => {
       devCommand: 'nx run website:serve',
       dist: join('dist/packages/website'),
       frameworkPort: 4200,
-      plugins: [{ name: '@netlify/plugin-nextjs', alwaysInstall: true }],
+      plugins: [{ name: '@netlify/plugin-nextjs', autoInstall: true }],
     })
   })
 })
@@ -198,7 +198,7 @@ describe('Nx turborepo', () => {
       devCommand: 'turbo run dev --filter web',
       dist: join('apps/web/.next'),
       frameworkPort: 3000,
-      plugins: [{ name: '@netlify/plugin-nextjs', alwaysInstall: true }],
+      plugins: [{ name: '@netlify/plugin-nextjs', autoInstall: true }],
     })
   })
 })

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -38,7 +38,7 @@ describe('Next.js Plugin', () => {
     const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ package: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 
   test('Should use the old runtime if the next.js version is not >= 13.5.0', async ({ fs, cwd }) => {
@@ -46,7 +46,7 @@ describe('Next.js Plugin', () => {
     project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime' }
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ package: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 
   test('Should not detect Next.js plugin for Next.js if when Node version < 10.13.0', async ({ fs, cwd }) => {
@@ -83,7 +83,7 @@ describe('New Next.js Runtime', () => {
     project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime@latest' }
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ package: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 
   test('Should use the old runtime if the next.js version is not >= 13.5.0', async ({ fs, cwd }) => {
@@ -91,7 +91,7 @@ describe('New Next.js Runtime', () => {
     project.featureFlags = { project_ceruledge_ui: '@netlify/next-runtime@latest' }
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual([{ name: '@netlify/next-runtime@latest', autoInstall: true }])
+    expect(frameworks?.[0].plugins).toEqual([{ package: '@netlify/next-runtime@latest', autoInstall: true }])
   })
 })
 
@@ -136,7 +136,7 @@ describe('simple Next.js project', async () => {
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async ({ fs, cwd }) => {
     const detected = await new Project(fs, cwd).setEnvironment({ NODE_VERSION: '18.x' }).detectFrameworks()
     expect(detected?.[0].id).toBe('next')
-    expect(detected?.[0].plugins).toMatchObject([{ name: '@netlify/plugin-nextjs', autoInstall: true }])
+    expect(detected?.[0].plugins).toMatchObject([{ package: '@netlify/plugin-nextjs', autoInstall: true }])
   })
 })
 
@@ -180,7 +180,7 @@ describe('Nx monorepo', () => {
       devCommand: 'nx run website:serve',
       dist: join('dist/packages/website'),
       frameworkPort: 4200,
-      plugins: [{ name: '@netlify/plugin-nextjs', autoInstall: true }],
+      plugins: [{ package: '@netlify/plugin-nextjs', autoInstall: true }],
     })
   })
 })
@@ -198,7 +198,7 @@ describe('Nx turborepo', () => {
       devCommand: 'turbo run dev --filter web',
       dist: join('apps/web/.next'),
       frameworkPort: 3000,
-      plugins: [{ name: '@netlify/plugin-nextjs', autoInstall: true }],
+      plugins: [{ package: '@netlify/plugin-nextjs', autoInstall: true }],
     })
   })
 })

--- a/packages/build-info/src/frameworks/next.ts
+++ b/packages/build-info/src/frameworks/next.ts
@@ -40,9 +40,9 @@ export class Next extends BaseFramework implements Framework {
         gte(this.detected.package.version, '13.5.0') &&
         typeof runtimeFromRollout === 'string'
       ) {
-        this.plugins.push({ name: runtimeFromRollout ?? '@netlify/plugin-nextjs', alwaysInstall: true })
+        this.plugins.push({ name: runtimeFromRollout ?? '@netlify/plugin-nextjs', autoInstall: true })
       } else if (nodeVersion && gte(nodeVersion, '10.13.0')) {
-        this.plugins.push({ name: '@netlify/plugin-nextjs', alwaysInstall: true })
+        this.plugins.push({ name: '@netlify/plugin-nextjs', autoInstall: true })
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/frameworks/next.ts
+++ b/packages/build-info/src/frameworks/next.ts
@@ -32,8 +32,17 @@ export class Next extends BaseFramework implements Framework {
 
     if (this.detected) {
       const nodeVersion = await this.project.getCurrentNodeVersion()
-      if (nodeVersion && gte(nodeVersion, '10.13.0')) {
-        this.plugins.push('@netlify/plugin-nextjs')
+      const runtimeFromRollout = this.project.featureFlags['project_ceruledge_ui']
+      if (
+        nodeVersion &&
+        gte(nodeVersion, '18.0.0') &&
+        this.detected.package?.version &&
+        gte(this.detected.package.version, '13.5.0') &&
+        typeof runtimeFromRollout === 'string'
+      ) {
+        this.plugins.push({ name: runtimeFromRollout ?? '@netlify/plugin-nextjs', alwaysInstall: true })
+      } else if (nodeVersion && gte(nodeVersion, '10.13.0')) {
+        this.plugins.push({ name: '@netlify/plugin-nextjs', alwaysInstall: true })
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/frameworks/next.ts
+++ b/packages/build-info/src/frameworks/next.ts
@@ -40,9 +40,9 @@ export class Next extends BaseFramework implements Framework {
         gte(this.detected.package.version, '13.5.0') &&
         typeof runtimeFromRollout === 'string'
       ) {
-        this.plugins.push({ name: runtimeFromRollout ?? '@netlify/plugin-nextjs', autoInstall: true })
+        this.plugins.push({ package: runtimeFromRollout ?? '@netlify/plugin-nextjs', autoInstall: true })
       } else if (nodeVersion && gte(nodeVersion, '10.13.0')) {
-        this.plugins.push({ name: '@netlify/plugin-nextjs', autoInstall: true })
+        this.plugins.push({ package: '@netlify/plugin-nextjs', autoInstall: true })
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
+++ b/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
@@ -64,8 +64,7 @@ exports[`should retrieve the build info for providing a rootDir 1`] = `
       "frameworkPort": 3000,
       "name": "PNPM + Astro packages/blog",
       "packagePath": "packages/blog",
-      "plugins_from_config_file": [],
-      "plugins_recommended": [],
+      "plugins": [],
       "pollingStrategies": [
         "TCP",
         "HTTP",
@@ -84,9 +83,11 @@ exports[`should retrieve the build info for providing a rootDir 1`] = `
       "frameworkPort": 3000,
       "name": "PNPM + Next.js packages/website",
       "packagePath": "packages/website",
-      "plugins_from_config_file": [],
-      "plugins_recommended": [
-        "@netlify/plugin-nextjs",
+      "plugins": [
+        {
+          "alwaysInstall": true,
+          "name": "@netlify/plugin-nextjs",
+        },
       ],
       "pollingStrategies": [
         "TCP",
@@ -199,8 +200,7 @@ exports[`should retrieve the build info for providing a rootDir and a nested pro
       "frameworkPort": 3000,
       "name": "PNPM + Astro packages/blog",
       "packagePath": "packages/blog",
-      "plugins_from_config_file": [],
-      "plugins_recommended": [],
+      "plugins": [],
       "pollingStrategies": [
         "TCP",
         "HTTP",
@@ -274,8 +274,7 @@ exports[`should retrieve the build info for providing a rootDir and the same pro
       "frameworkPort": 3000,
       "name": "PNPM + Astro packages/blog",
       "packagePath": "packages/blog",
-      "plugins_from_config_file": [],
-      "plugins_recommended": [],
+      "plugins": [],
       "pollingStrategies": [
         "TCP",
         "HTTP",
@@ -294,9 +293,11 @@ exports[`should retrieve the build info for providing a rootDir and the same pro
       "frameworkPort": 3000,
       "name": "PNPM + Next.js packages/website",
       "packagePath": "packages/website",
-      "plugins_from_config_file": [],
-      "plugins_recommended": [
-        "@netlify/plugin-nextjs",
+      "plugins": [
+        {
+          "alwaysInstall": true,
+          "name": "@netlify/plugin-nextjs",
+        },
       ],
       "pollingStrategies": [
         "TCP",

--- a/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
+++ b/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
@@ -85,7 +85,7 @@ exports[`should retrieve the build info for providing a rootDir 1`] = `
       "packagePath": "packages/website",
       "plugins": [
         {
-          "alwaysInstall": true,
+          "autoInstall": true,
           "name": "@netlify/plugin-nextjs",
         },
       ],
@@ -295,7 +295,7 @@ exports[`should retrieve the build info for providing a rootDir and the same pro
       "packagePath": "packages/website",
       "plugins": [
         {
-          "alwaysInstall": true,
+          "autoInstall": true,
           "name": "@netlify/plugin-nextjs",
         },
       ],

--- a/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
+++ b/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
@@ -86,7 +86,7 @@ exports[`should retrieve the build info for providing a rootDir 1`] = `
       "plugins": [
         {
           "autoInstall": true,
-          "name": "@netlify/plugin-nextjs",
+          "package": "@netlify/plugin-nextjs",
         },
       ],
       "pollingStrategies": [
@@ -296,7 +296,7 @@ exports[`should retrieve the build info for providing a rootDir and the same pro
       "plugins": [
         {
           "autoInstall": true,
-          "name": "@netlify/plugin-nextjs",
+          "package": "@netlify/plugin-nextjs",
         },
       ],
       "pollingStrategies": [

--- a/packages/build-info/src/node/bin.ts
+++ b/packages/build-info/src/node/bin.ts
@@ -8,7 +8,11 @@ import { report } from '../metrics.js'
 import { getBuildInfo } from './get-build-info.js'
 import { initializeMetrics } from './metrics.js'
 
-type Args = Arguments<{ projectDir?: string; rootDir?: string; featureFlags: Record<string, boolean> }>
+type Args = Arguments<{
+  projectDir?: string
+  rootDir?: string
+  featureFlags: Record<string, number | boolean | string>
+}>
 
 yargs(hideBin(argv))
   .command(
@@ -22,13 +26,9 @@ yargs(hideBin(argv))
         },
         featureFlags: {
           string: true,
-          describe: 'comma separated list of feature flags',
-          coerce: (value = '') =>
-            value
-              .split(',')
-              .map((flag) => flag.trim())
-              .filter((flag) => flag.length)
-              .reduce((prev, cur) => ({ ...prev, [cur]: true }), {}),
+          describe: 'JSON stringified list of feature flags with values',
+          alias: 'ff',
+          coerce: (value: '{}') => JSON.parse(value),
         },
       }),
     async ({ projectDir, rootDir, featureFlags }: Args) => {
@@ -37,7 +37,12 @@ yargs(hideBin(argv))
       try {
         console.log(
           JSON.stringify(
-            await getBuildInfo({ projectDir, rootDir, featureFlags, bugsnagClient }),
+            await getBuildInfo({
+              projectDir,
+              rootDir,
+              featureFlags,
+              bugsnagClient,
+            }),
             // hide null values from the string output as we use null to identify it has already run but did not detect anything
             // undefined marks that it was never run
             (_, value) => (value !== null ? value : undefined),

--- a/packages/build-info/src/node/get-build-info.ts
+++ b/packages/build-info/src/node/get-build-info.ts
@@ -45,7 +45,7 @@ export async function getBuildInfo(
   config: {
     projectDir?: string
     rootDir?: string
-    featureFlags?: Record<string, boolean>
+    featureFlags?: Record<string, boolean | number | string>
     bugsnagClient?: Client
   } = { featureFlags: {} },
 ): Promise<Info> {
@@ -54,6 +54,7 @@ export async function getBuildInfo(
   fs.logger = new NoopLogger()
   const project = new Project(fs, config.projectDir, config.rootDir)
     .setBugsnag(config.bugsnagClient)
+    .setFeatureFlags(config.featureFlags)
     .setEnvironment(process.env)
     .setNodeVersion(process.version)
 

--- a/packages/build-info/src/project.ts
+++ b/packages/build-info/src/project.ts
@@ -62,6 +62,8 @@ export class Project {
   bugsnag: Client
   /** A logging instance  */
   logger: Logger
+  /** A list of enabled feature flags */
+  featureFlags: Record<string, boolean | number | string> = {}
 
   /** A function that is used to report errors */
   reportFn: typeof report = report
@@ -73,6 +75,11 @@ export class Project {
 
   setNodeVersion(version: string): this {
     this._nodeVersion = parse(coerce(version), { loose: true })
+    return this
+  }
+
+  setFeatureFlags(flags: Record<string, boolean | number | string> = {}): this {
+    this.featureFlags = { ...this.featureFlags, ...flags }
     return this
   }
 

--- a/packages/build-info/src/settings/get-build-settings.test.ts
+++ b/packages/build-info/src/settings/get-build-settings.test.ts
@@ -17,7 +17,7 @@ beforeEach((ctx) => {
 
 test('get the settings for a next project', async (ctx) => {
   const fixture = await createFixture('next-project', ctx)
-  const project = new Project(ctx.fs, fixture.cwd)
+  const project = new Project(ctx.fs, fixture.cwd).setNodeVersion('18.0.0')
   const settings = await project.getBuildSettings()
 
   expect(settings).toEqual([
@@ -27,8 +27,7 @@ test('get the settings for a next project', async (ctx) => {
       dist: '.next',
       env: {},
       frameworkPort: 3000,
-      plugins_recommended: [],
-      plugins_from_config_file: [],
+      plugins: [{ alwaysInstall: true, name: '@netlify/plugin-nextjs' }],
       pollingStrategies: ['TCP'],
     }),
   ])
@@ -36,7 +35,7 @@ test('get the settings for a next project', async (ctx) => {
 
 test('get the settings for a next project if a build system has no commands and overrides', async (ctx) => {
   const fixture = await createFixture('next-project', ctx)
-  const project = new Project(ctx.fs, fixture.cwd)
+  const project = new Project(ctx.fs, fixture.cwd).setNodeVersion('18.0.0')
   project.buildSystems = [new Bazel(project)]
   const settings = await project.getBuildSettings()
 
@@ -47,8 +46,7 @@ test('get the settings for a next project if a build system has no commands and 
       dist: '.next',
       env: {},
       frameworkPort: 3000,
-      plugins_recommended: [],
-      plugins_from_config_file: [],
+      plugins: [{ alwaysInstall: true, name: '@netlify/plugin-nextjs' }],
       pollingStrategies: ['TCP'],
     }),
   ])

--- a/packages/build-info/src/settings/get-build-settings.test.ts
+++ b/packages/build-info/src/settings/get-build-settings.test.ts
@@ -27,7 +27,7 @@ test('get the settings for a next project', async (ctx) => {
       dist: '.next',
       env: {},
       frameworkPort: 3000,
-      plugins: [{ alwaysInstall: true, name: '@netlify/plugin-nextjs' }],
+      plugins: [{ autoInstall: true, name: '@netlify/plugin-nextjs' }],
       pollingStrategies: ['TCP'],
     }),
   ])
@@ -46,7 +46,7 @@ test('get the settings for a next project if a build system has no commands and 
       dist: '.next',
       env: {},
       frameworkPort: 3000,
-      plugins: [{ alwaysInstall: true, name: '@netlify/plugin-nextjs' }],
+      plugins: [{ autoInstall: true, name: '@netlify/plugin-nextjs' }],
       pollingStrategies: ['TCP'],
     }),
   ])

--- a/packages/build-info/src/settings/get-build-settings.test.ts
+++ b/packages/build-info/src/settings/get-build-settings.test.ts
@@ -27,7 +27,7 @@ test('get the settings for a next project', async (ctx) => {
       dist: '.next',
       env: {},
       frameworkPort: 3000,
-      plugins: [{ autoInstall: true, name: '@netlify/plugin-nextjs' }],
+      plugins: [{ autoInstall: true, package: '@netlify/plugin-nextjs' }],
       pollingStrategies: ['TCP'],
     }),
   ])
@@ -46,7 +46,7 @@ test('get the settings for a next project if a build system has no commands and 
       dist: '.next',
       env: {},
       frameworkPort: 3000,
-      plugins: [{ autoInstall: true, name: '@netlify/plugin-nextjs' }],
+      plugins: [{ autoInstall: true, package: '@netlify/plugin-nextjs' }],
       pollingStrategies: ['TCP'],
     }),
   ])

--- a/packages/build-info/src/settings/get-build-settings.ts
+++ b/packages/build-info/src/settings/get-build-settings.ts
@@ -1,4 +1,4 @@
-import { type Framework } from '../frameworks/framework.js'
+import { BuildPlugin, type Framework } from '../frameworks/framework.js'
 import { type Project } from '../project.js'
 
 export type Settings = {
@@ -24,10 +24,8 @@ export type Settings = {
   /** The dist directory that contains the build output */
   dist: string
   env: Record<string, string | undefined>
-  /** Plugins installed via the netlify.toml */
-  plugins_from_config_file: string[]
   /** Plugins that are detected via the framework detection and therefore recommended */
-  plugins_recommended: string[]
+  plugins: BuildPlugin[]
   pollingStrategies: string[]
   /** The baseDirectory for the UI to configure (used to run the command in this working directory) */
   baseDirectory?: string
@@ -91,8 +89,7 @@ export async function getSettings(framework: Framework, project: Project, baseDi
     frameworkPort: framework.dev?.port,
     dist: project.fs.join(baseDirectory, framework.build.directory),
     env: framework.env || {},
-    plugins_from_config_file: [],
-    plugins_recommended: framework.plugins || [],
+    plugins: framework.plugins || [],
     framework: {
       id: framework.id,
       name: framework.name,

--- a/packages/build-info/src/settings/get-toml-settings.test.ts
+++ b/packages/build-info/src/settings/get-toml-settings.test.ts
@@ -107,7 +107,7 @@ package = "@netlify/plugin-nextjs"
       dist: '.next',
       frameworkPort: 3000,
       functionsDir: 'api',
-      plugins: [{ name: '@netlify/plugin-nextjs', source: 'toml' }],
+      plugins: [{ package: '@netlify/plugin-nextjs', source: 'toml' }],
     }),
   )
 })

--- a/packages/build-info/src/settings/get-toml-settings.test.ts
+++ b/packages/build-info/src/settings/get-toml-settings.test.ts
@@ -107,7 +107,7 @@ package = "@netlify/plugin-nextjs"
       dist: '.next',
       frameworkPort: 3000,
       functionsDir: 'api',
-      plugins_from_config_file: ['@netlify/plugin-nextjs'],
+      plugins: [{ name: '@netlify/plugin-nextjs', source: 'toml' }],
     }),
   )
 })

--- a/packages/build-info/src/settings/get-toml-settings.ts
+++ b/packages/build-info/src/settings/get-toml-settings.ts
@@ -44,7 +44,7 @@ export async function getTomlSettingsFromPath(
     settings.template = template ?? settings.template
 
     for (const plugin of plugins || []) {
-      settings.plugins.push({ name: plugin.package, source: 'toml' })
+      settings.plugins.push({ package: plugin.package, source: 'toml' })
     }
 
     return settings

--- a/packages/build-info/src/settings/get-toml-settings.ts
+++ b/packages/build-info/src/settings/get-toml-settings.ts
@@ -31,16 +31,21 @@ export async function getTomlSettingsFromPath(
   const tomlFilePath = fs.join(directory, 'netlify.toml')
 
   try {
-    const settings: Partial<Settings> = {}
+    const settings: Partial<Settings> & Pick<Settings, 'plugins'> = {
+      plugins: [],
+    }
     const { build, dev, functions, template, plugins } = gracefulParseToml<NetlifyTOML>(await fs.readFile(tomlFilePath))
 
     settings.buildCommand = build?.command ?? settings.buildCommand
     settings.dist = build?.publish ?? settings.dist
     settings.devCommand = dev?.command ?? settings.devCommand
     settings.frameworkPort = dev?.port ?? settings.frameworkPort
-    settings.plugins_from_config_file = plugins?.map((p) => p.package) ?? settings.plugins_from_config_file
     settings.functionsDir = (build?.functions || functions?.directory) ?? settings.functionsDir
     settings.template = template ?? settings.template
+
+    for (const plugin of plugins || []) {
+      settings.plugins.push({ name: plugin.package, source: 'toml' })
+    }
 
     return settings
   } catch {

--- a/packages/build-info/tests/__snapshots__/bin.test.ts.snap
+++ b/packages/build-info/tests/__snapshots__/bin.test.ts.snap
@@ -6,9 +6,10 @@ exports[`CLI --help flag 1`] = `
 Print relevant build information from a project.
 
 Options:
-  --help          Show help                                            [boolean]
-  --version       Show version number                                  [boolean]
-  --rootDir       The root directory of the project if different from projectDir
-                                                                        [string]
-  --featureFlags  comma separated list of feature flags                 [string]"
+  --help                Show help                                      [boolean]
+  --version             Show version number                            [boolean]
+  --rootDir             The root directory of the project if different from proj
+                        ectDir                                          [string]
+  --featureFlags, --ff  JSON stringified list of feature flags with values
+                                                                        [string]"
 `;


### PR DESCRIPTION
BREAKING CHANGE: Plugin build settings now use an object array, not string lists, allowing extra details like install source and if always needed at runtime.

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://linear.app/netlify/issue/FRA-139/update-build-info-to-include-netlifynext-runtime

Currently, we have a lot of hardcoded instances of the next runtime inside the react UI and the CLI, where we determine if it needs to be auto-installed:

- https://github.com/netlify/netlify-react-ui/blob/main/apps/netlify-react-ui/src/actions/repos.ts#L219-L239
- https://github.com/netlify/cli/blob/main/src/utils/init/utils.ts#L19-L43

![CleanShot 2023-12-18 at 10 55 55](https://github.com/netlify/build/assets/11156362/e6bd5057-a362-47b0-b1b3-56155cc3868e)

This makes it hard to roll out the new runtime over a central place. Therefore, I've introduced a breaking change here, making the plugins an array of objects that contains the additional information that the next runtime should always be automatically installed.

Based on the feature flag, we can now roll out the new or old runtime seamlessly with this change.

Therefore we had to change the featureflags to be a JSON of key value objects to retrieve the value of the string flag.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
