### PR TITLE
fix: test version selection for ui plugin

### DIFF
--- a/packages/build/src/plugins/expected_version.js
+++ b/packages/build/src/plugins/expected_version.js
@@ -27,7 +27,7 @@ export const addExpectedVersions = async function ({
   const pluginsList = await getPluginsList({ debug, logs, testOpts })
   return await Promise.all(
     pluginsOptions.map((pluginOptions) =>
-      addExpectedVersion({ pluginsList, autoPluginsDir, packageJson, pluginOptions, buildDir, featureFlags }),
+      addExpectedVersion({ pluginsList, autoPluginsDir, packageJson, pluginOptions, buildDir, featureFlags, testOpts }),
     ),
   )
 }
@@ -41,13 +41,14 @@ const addExpectedVersion = async function ({
   pluginOptions: { packageName, pluginPath, loadedFrom, nodeVersion, pinnedVersion },
   buildDir,
   featureFlags,
+  testOpts,
 }) {
   if (!needsExpectedVersion(pluginOptions)) {
     return pluginOptions
   }
 
   if (pluginsList[packageName] === undefined) {
-    validateUnlistedPlugin(packageName, loadedFrom)
+    validateUnlistedPlugin(packageName, loadedFrom, testOpts)
     return pluginOptions
   }
 
@@ -105,7 +106,11 @@ const needsExpectedVersion = function ({ loadedFrom }) {
 // Plugins that are not in our official list can only be specified in
 // `netlify.toml` providing they are also installed in the site's package.json.
 // Otherwise, the build should fail.
-const validateUnlistedPlugin = function (packageName, loadedFrom) {
+const validateUnlistedPlugin = function (packageName, loadedFrom, testOpts) {
+  if (testOpts.skipPluginList) {
+    return
+  }
+
   if (loadedFrom === 'package.json') {
     return
   }

--- a/packages/build/tests/plugins/fixtures/ui_auto_install/.netlify/plugins/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/plugins/fixtures/ui_auto_install/.netlify/plugins/node_modules/netlify-plugin-test/index.js
@@ -1,0 +1,3 @@
+export const onPreBuild = function () {
+    console.log('node.js version used to execute this plugin:', process.version)
+}

--- a/packages/build/tests/plugins/fixtures/ui_auto_install/.netlify/plugins/node_modules/netlify-plugin-test/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/ui_auto_install/.netlify/plugins/node_modules/netlify-plugin-test/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/ui_auto_install/.netlify/plugins/node_modules/netlify-plugin-test/package.json
+++ b/packages/build/tests/plugins/fixtures/ui_auto_install/.netlify/plugins/node_modules/netlify-plugin-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "netlify-plugin-test",
+  "version": "1.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test"
+}

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -124,6 +124,20 @@ test('Provided --node-path version is unused in buildbot for local plugin execut
   t.snapshot(normalizeOutput(output))
 })
 
+test('UI plugins dont use provided --node-path', async (t) => {
+  const nodePath = getNodePath('12.19.0')
+  const output = await new Fixture('./fixtures/ui_auto_install')
+    .withFlags({
+      nodePath,
+      mode: 'buildbot',
+      defaultConfig: { plugins: [{ package: 'netlify-plugin-test' }] },
+      testOpts: { skipPluginList: true },
+    })
+    .runWithBuild()
+  const systemNodeVersion = process.version
+  t.true(output.includes(`node.js version used to execute this plugin: ${systemNodeVersion}`))
+})
+
 test('Plugins can execute local binaries', async (t) => {
   const output = await new Fixture('./fixtures/local_bin').runWithBuild()
   t.snapshot(normalizeOutput(output))


### PR DESCRIPTION
In https://github.com/netlify/build/pull/5451, we introduced a regression. We started selecting the wrong Node.js version for UI Plugins. This was reverted in https://github.com/netlify/build/pull/5452.

To prevent this from happening again, here's a test for the version selection.

This PR could've been marked as `chore:`, but I marked it as `fix:` to trigger release-please - https://github.com/netlify/build/pull/5452 didn't do that, but should have.