### PR TITLE
feat: make cache-utils monorepo aware

### DIFF
--- a/packages/build/src/core/constants.ts
+++ b/packages/build/src/core/constants.ts
@@ -96,7 +96,7 @@ export const getConstants = async function ({
   mode,
 }): Promise<NetlifyPluginConstants> {
   const isLocal = mode !== 'buildbot'
-  const normalizedCacheDir = getCacheDir({ cacheDir, cwd: buildDir })
+  const normalizedCacheDir = getCacheDir({ cacheDir, cwd: join(buildDir, packagePath || '') })
   const constants = {
     // Path to the Netlify configuration file
     CONFIG_PATH: configPath,


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Currently, the `.netlify/cache` directory is always created in the current working directory. For monorepos, this means it's creating at the repository root, which is not correct. We need to leverage the `packagePath` for functions and all the other paths here as well to create the `.netlify/cache` folder along the packagePath if set.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
