### PR TITLE
fix(otel): make the otel-api package a peer dep of our build ecosystem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25526,7 +25526,6 @@
         "@netlify/plugins-list": "^6.75.0",
         "@netlify/run-utils": "^5.1.1",
         "@netlify/zip-it-and-ship-it": "9.29.2",
-        "@opentelemetry/api": "~1.7.0",
         "@sindresorhus/slugify": "^2.0.0",
         "ansi-escapes": "^6.0.0",
         "chalk": "^5.0.0",
@@ -25578,6 +25577,7 @@
       },
       "devDependencies": {
         "@netlify/nock-udp": "^3.1.2",
+        "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^1.18.1",
         "@types/node": "^14.18.53",
         "@vitest/coverage-c8": "^0.33.0",
@@ -25598,7 +25598,7 @@
         "process-exists": "^5.0.0",
         "sinon": "^13.0.0",
         "tmp-promise": "^3.0.2",
-        "tsd": "^0.30.7",
+        "tsd": "^0.30.0",
         "vitest": "^0.34.0",
         "yarn": "^1.22.4"
       },
@@ -25606,7 +25606,8 @@
         "node": "^14.16.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "@netlify/opentelemetry-sdk-setup": "^1.0.4"
+        "@netlify/opentelemetry-sdk-setup": "^1.0.4",
+        "@opentelemetry/api": "^1.7.0"
       },
       "peerDependenciesMeta": {
         "@netlify/opentelemetry-sdk-setup": {
@@ -26172,7 +26173,6 @@
       "dependencies": {
         "@honeycombio/opentelemetry-node": "~0.6.1",
         "@netlify/opentelemetry-utils": "^1.0.2",
-        "@opentelemetry/api": "~1.7.0",
         "@opentelemetry/core": "^1.17.1",
         "@opentelemetry/resources": "^1.18.1",
         "@opentelemetry/semantic-conventions": "^1.18.1",
@@ -26182,6 +26182,7 @@
         "otel-sdk-setup": "bin.js"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.7.0",
         "@types/node": "^14.18.53",
         "@vitest/coverage-c8": "^0.33.0",
         "@vitest/ui": "^0.34.0",
@@ -26191,6 +26192,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
       }
     },
     "packages/opentelemetry-sdk-setup/node_modules/yargs-parser": {
@@ -26204,10 +26208,8 @@
       "name": "@netlify/opentelemetry-utils",
       "version": "1.0.2",
       "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "~1.7.0"
-      },
       "devDependencies": {
+        "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^1.18.1",
         "@opentelemetry/sdk-trace-node": "^1.18.1",
         "@types/node": "^14.18.53",
@@ -26219,6 +26221,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
       }
     },
     "packages/redirect-parser": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -79,7 +79,6 @@
     "@netlify/plugins-list": "^6.75.0",
     "@netlify/run-utils": "^5.1.1",
     "@netlify/zip-it-and-ship-it": "9.29.2",
-    "@opentelemetry/api": "~1.7.0",
     "@sindresorhus/slugify": "^2.0.0",
     "ansi-escapes": "^6.0.0",
     "chalk": "^5.0.0",
@@ -129,6 +128,7 @@
   "devDependencies": {
     "@netlify/nock-udp": "^3.1.2",
     "@opentelemetry/sdk-trace-base": "^1.18.1",
+    "@opentelemetry/api": "^1.7.0",
     "@types/node": "^14.18.53",
     "@vitest/coverage-c8": "^0.33.0",
     "atob": "^2.1.2",
@@ -153,6 +153,7 @@
     "yarn": "^1.22.4"
   },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.7.0",
     "@netlify/opentelemetry-sdk-setup": "^1.0.4"
   },
   "peerDependenciesMeta": {

--- a/packages/opentelemetry-sdk-setup/package.json
+++ b/packages/opentelemetry-sdk-setup/package.json
@@ -28,16 +28,19 @@
     "url": "https://github.com/netlify/build/issues"
   },
   "author": "Netlify Inc.",
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.7.0"
+  },
   "dependencies": {
     "@honeycombio/opentelemetry-node": "~0.6.1",
     "@netlify/opentelemetry-utils": "^1.0.2",
-    "@opentelemetry/api": "~1.7.0",
     "@opentelemetry/core": "^1.17.1",
     "@opentelemetry/resources": "^1.18.1",
     "@opentelemetry/semantic-conventions": "^1.18.1",
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.7.0",
     "@types/node": "^14.18.53",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/ui": "^0.34.0",

--- a/packages/opentelemetry-utils/package.json
+++ b/packages/opentelemetry-utils/package.json
@@ -27,8 +27,8 @@
     "url": "https://github.com/netlify/build/issues"
   },
   "author": "Netlify Inc.",
-  "dependencies": {
-    "@opentelemetry/api": "~1.7.0"
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.7.0"
   },
   "devDependencies": {
     "@types/node": "^14.18.53",
@@ -38,7 +38,8 @@
     "vite": "^4.0.4",
     "vitest": "^0.34.0",
     "@opentelemetry/sdk-trace-node": "^1.18.1",
-    "@opentelemetry/sdk-trace-base": "^1.18.1"
+    "@opentelemetry/sdk-trace-base": "^1.18.1",
+    "@opentelemetry/api": "^1.7.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

This fixes the recent struggles we had with the `@opentelemetry/api` package singleton nature and our need to share the same otel-api instance across modules. This should ensure that within buildbot all of our packages use the same otel api package/instance.

Some notes on this approach though:
- It's my understanding that this could lead to errors for installations using old npm versions (pre v7 I believe) or installations that use the `legacy-peer-deps` flag. I don't think this a huge problem given our required engine node version, but I'm a bit wary because of the CLI, so would love to get a second opinion on the matter.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
