### PR TITLE
fix: incorrect pinned version for Next.js Runtime v5

### DIFF
--- a/packages/build/src/plugins/pinned_version.js
+++ b/packages/build/src/plugins/pinned_version.js
@@ -108,17 +108,14 @@ const pinPlugin = async function ({
 }) {
   const pinnedVersion = getMajorVersion(version)
   try {
-    const body = {
-      pinned_version: pinnedVersion
+    if (!(packageName === '@netlify/plugin-nextjs' && pinnedVersion === 5)) {
+      // TODO: remove this condition after Next.js Runtime v5 GA
+      await api.updatePlugin({
+        package: encodeURIComponent(packageName),
+        site_id: siteId,
+        body: { pinned_version: pinnedVersion }
+      })
     }
-    if (packageName === '@netlify/plugin-nextjs' && pinnedVersion === 5) {
-      body.pinned_version = 'rc'
-    }
-    await api.updatePlugin({
-      package: encodeURIComponent(packageName),
-      site_id: siteId,
-      body,
-    })
     // Bitballoon API randomly fails with 502.
     // Builds should be successful when this API call fails, but we still want
     // to report the error both in logs and in error monitoring.

--- a/packages/build/src/plugins/pinned_version.js
+++ b/packages/build/src/plugins/pinned_version.js
@@ -108,10 +108,16 @@ const pinPlugin = async function ({
 }) {
   const pinnedVersion = getMajorVersion(version)
   try {
+    const body = {
+      pinned_version: pinnedVersion
+    }
+    if (packageName === '@netlify/plugin-nextjs' && pinnedVersion === 5) {
+      body.pinned_version = 'rc'
+    }
     await api.updatePlugin({
       package: encodeURIComponent(packageName),
       site_id: siteId,
-      body: { pinned_version: pinnedVersion },
+      body,
     })
     // Bitballoon API randomly fails with 502.
     // Builds should be successful when this API call fails, but we still want


### PR DESCRIPTION
#### Summary

Fixes COM-566

Note: This is a very naive-kinda PR, probably just submitted for self-satisfaction or fun. This might not be the best way to handle this ~as pinning the version to `rc` could cause other issues later~ (edit: pinning completely skipped). Feel free to close the PR and use a more robust way to solve this.
