### PR TITLE
fix: don't poll HTTP on startup to prevent dependency cycle between framework dev server and Netlify Dev

### DIFF
--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -12,7 +12,7 @@ export class Angular extends BaseFramework implements Framework {
   dev = {
     port: 4200,
     command: 'ng serve',
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/astro.test.ts
+++ b/packages/build-info/src/frameworks/astro.test.ts
@@ -22,6 +22,9 @@ test.each([
   expect(detected?.[0].build.directory).toBe('dist')
   expect(detected?.[0].dev?.command).toBe('astro dev')
   expect(detected?.[0].dev?.port).toBe(4321)
+  // Astro makes passthrough requests to the dev server, which will be an infinite loop before the dev server started.
+  // we can prevent this by only checking the TCP port, and not HTTP.
+  expect(detected?.[0].dev?.pollingStrategies).toEqual([{ name: 'TCP' }])
 })
 
 test('should return 3000 for less than 3.0.0', async () => {

--- a/packages/build-info/src/frameworks/astro.ts
+++ b/packages/build-info/src/frameworks/astro.ts
@@ -13,7 +13,7 @@ export class Astro extends BaseFramework implements Framework {
   dev = {
     port: 4321,
     command: 'astro dev',
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/brunch.ts
+++ b/packages/build-info/src/frameworks/brunch.ts
@@ -10,7 +10,7 @@ export class Brunch extends BaseFramework implements Framework {
   dev = {
     command: 'brunch watch --server',
     port: 3333,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/cecil.ts
+++ b/packages/build-info/src/frameworks/cecil.ts
@@ -9,7 +9,7 @@ export class Cecil extends BaseFramework implements Framework {
   dev = {
     command: 'cecil serve',
     port: 8000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/docpad.ts
+++ b/packages/build-info/src/frameworks/docpad.ts
@@ -9,7 +9,7 @@ export class DocPad extends BaseFramework implements Framework {
   dev = {
     command: 'docpad run',
     port: 9778,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/docusaurus.ts
+++ b/packages/build-info/src/frameworks/docusaurus.ts
@@ -17,7 +17,7 @@ export class Docusaurus extends BaseFramework implements Framework {
   dev = {
     command: 'docusaurus start',
     port: 3000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/eleventy.ts
+++ b/packages/build-info/src/frameworks/eleventy.ts
@@ -10,7 +10,7 @@ export class Eleventy extends BaseFramework implements Framework {
   dev = {
     command: 'eleventy --serve',
     port: 8080,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/ember.ts
+++ b/packages/build-info/src/frameworks/ember.ts
@@ -10,7 +10,7 @@ export class Ember extends BaseFramework implements Framework {
   dev = {
     command: 'ember serve',
     port: 4200,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/expo.ts
+++ b/packages/build-info/src/frameworks/expo.ts
@@ -10,7 +10,7 @@ export class Expo extends BaseFramework implements Framework {
   dev = {
     command: 'expo start --web',
     port: 19006,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/gatsby.test.ts
+++ b/packages/build-info/src/frameworks/gatsby.test.ts
@@ -69,7 +69,7 @@ test('should detect a simple Gatsby 4 project', async ({ fs }) => {
       packagePath: '',
       plugins_from_config_file: [],
       plugins_recommended: [],
-      pollingStrategies: ['TCP', 'HTTP'],
+      pollingStrategies: ['TCP'],
     },
   ])
 })

--- a/packages/build-info/src/frameworks/gatsby.ts
+++ b/packages/build-info/src/frameworks/gatsby.ts
@@ -13,7 +13,7 @@ export class Gatsby extends BaseFramework implements Framework {
   dev = {
     command: 'gatsby develop',
     port: 8000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/gridsome.ts
+++ b/packages/build-info/src/frameworks/gridsome.ts
@@ -10,7 +10,7 @@ export class Gridsome extends BaseFramework implements Framework {
   dev = {
     command: 'gridsome develop',
     port: 8080,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/harp.ts
+++ b/packages/build-info/src/frameworks/harp.ts
@@ -9,7 +9,7 @@ export class Harp extends BaseFramework implements Framework {
   dev = {
     command: 'harp server',
     port: 9000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/hexo.ts
+++ b/packages/build-info/src/frameworks/hexo.ts
@@ -10,7 +10,7 @@ export class Hexo extends BaseFramework implements Framework {
   dev = {
     command: 'hexo server',
     port: 4000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/hugo.ts
+++ b/packages/build-info/src/frameworks/hugo.ts
@@ -9,7 +9,7 @@ export class Hugo extends BaseFramework implements Framework {
   dev = {
     command: 'hugo server -w',
     port: 1313,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/jekyll.ts
+++ b/packages/build-info/src/frameworks/jekyll.ts
@@ -9,7 +9,7 @@ export class Jekyll extends BaseFramework implements Framework {
   dev = {
     command: 'bundle exec jekyll serve -w',
     port: 4000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/middleman.ts
+++ b/packages/build-info/src/frameworks/middleman.ts
@@ -9,7 +9,7 @@ export class Middleman extends BaseFramework implements Framework {
   dev = {
     command: 'bundle exec middleman server',
     port: 4567,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/nuxt.ts
+++ b/packages/build-info/src/frameworks/nuxt.ts
@@ -9,7 +9,7 @@ export class Nuxt extends BaseFramework implements Framework {
   dev = {
     command: 'nuxt',
     port: 3000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
     clearPublishDirectory: true,
   }
 

--- a/packages/build-info/src/frameworks/observable.ts
+++ b/packages/build-info/src/frameworks/observable.ts
@@ -9,7 +9,7 @@ export class Observable extends BaseFramework implements Framework {
   dev = {
     command: 'observable preview',
     port: 3000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/parcel.ts
+++ b/packages/build-info/src/frameworks/parcel.ts
@@ -9,7 +9,7 @@ export class Parcel extends BaseFramework implements Framework {
   dev = {
     command: 'parcel',
     port: 1234,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/phenomic.ts
+++ b/packages/build-info/src/frameworks/phenomic.ts
@@ -9,7 +9,7 @@ export class Phenomic extends BaseFramework implements Framework {
   dev = {
     command: 'phenomic start',
     port: 3333,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/quasar.ts
+++ b/packages/build-info/src/frameworks/quasar.ts
@@ -9,7 +9,7 @@ export class Quasar extends BaseFramework implements Framework {
   dev = {
     command: 'quasar dev -p 8081',
     port: 8081,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/react-static.ts
+++ b/packages/build-info/src/frameworks/react-static.ts
@@ -10,7 +10,7 @@ export class ReactStatic extends BaseFramework implements Framework {
   dev = {
     command: 'react-static start',
     port: 3000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/react.ts
+++ b/packages/build-info/src/frameworks/react.ts
@@ -10,7 +10,7 @@ export class CreateReactApp extends BaseFramework implements Framework {
   dev = {
     command: 'react-scripts start',
     port: 3000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/roots.ts
+++ b/packages/build-info/src/frameworks/roots.ts
@@ -9,7 +9,7 @@ export class Roots extends BaseFramework implements Framework {
   dev = {
     command: 'roots watch',
     port: 1111,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/sapper.ts
+++ b/packages/build-info/src/frameworks/sapper.ts
@@ -10,7 +10,7 @@ export class Sapper extends BaseFramework implements Framework {
   dev = {
     command: 'sapper dev',
     port: 3000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/stencil.ts
+++ b/packages/build-info/src/frameworks/stencil.ts
@@ -10,7 +10,7 @@ export class Stencil extends BaseFramework implements Framework {
   dev = {
     command: 'stencil build --dev --watch --serve',
     port: 3333,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/svelte-kit.ts
+++ b/packages/build-info/src/frameworks/svelte-kit.ts
@@ -10,7 +10,7 @@ export class SvelteKit extends BaseFramework implements Framework {
   dev = {
     command: 'vite dev',
     port: 5173,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/svelte.ts
+++ b/packages/build-info/src/frameworks/svelte.ts
@@ -11,7 +11,7 @@ export class Svelte extends BaseFramework implements Framework {
   dev = {
     command: 'npm run dev',
     port: 5000,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/vue.ts
+++ b/packages/build-info/src/frameworks/vue.ts
@@ -9,7 +9,7 @@ export class Vue extends BaseFramework implements Framework {
   dev = {
     command: 'vue-cli-service serve',
     port: 8080,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/vuepress.ts
+++ b/packages/build-info/src/frameworks/vuepress.ts
@@ -9,7 +9,7 @@ export class VuePress extends BaseFramework implements Framework {
   dev = {
     command: 'vuepress dev',
     port: 8080,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/wintersmith.ts
+++ b/packages/build-info/src/frameworks/wintersmith.ts
@@ -10,7 +10,7 @@ export class Wintersmith extends BaseFramework implements Framework {
   dev = {
     command: 'wintersmith preview',
     port: 8080,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/wmr.ts
+++ b/packages/build-info/src/frameworks/wmr.ts
@@ -9,7 +9,7 @@ export class WMR extends BaseFramework implements Framework {
   dev = {
     command: 'wmr',
     port: 8080,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/frameworks/zola.ts
+++ b/packages/build-info/src/frameworks/zola.ts
@@ -9,7 +9,7 @@ export class Zola extends BaseFramework implements Framework {
   dev = {
     command: 'zola serve',
     port: 1111,
-    pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }],
+    pollingStrategies: [{ name: 'TCP' }],
   }
 
   build = {

--- a/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
+++ b/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
@@ -68,7 +68,6 @@ exports[`should retrieve the build info for providing a rootDir 1`] = `
       "plugins_recommended": [],
       "pollingStrategies": [
         "TCP",
-        "HTTP",
       ],
     },
     {
@@ -123,9 +122,6 @@ exports[`should retrieve the build info for providing a rootDir and a nested pro
         "pollingStrategies": [
           {
             "name": "TCP",
-          },
-          {
-            "name": "HTTP",
           },
         ],
         "port": 3000,
@@ -203,7 +199,6 @@ exports[`should retrieve the build info for providing a rootDir and a nested pro
       "plugins_recommended": [],
       "pollingStrategies": [
         "TCP",
-        "HTTP",
       ],
     },
   ],
@@ -278,7 +273,6 @@ exports[`should retrieve the build info for providing a rootDir and the same pro
       "plugins_recommended": [],
       "pollingStrategies": [
         "TCP",
-        "HTTP",
       ],
     },
     {

--- a/packages/framework-info/README.md
+++ b/packages/framework-info/README.md
@@ -29,7 +29,7 @@ console.log(await listFrameworks({ projectDir: './path/to/gatsby/website' }))
 //     dev: {
 //       commands: ['gatsby develop'],
 //       port: 8000,
-//       pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }]
+//       pollingStrategies: [{ name: 'TCP' }]
 //     },
 //     build: {
 //       commands: ['gatsby build'],
@@ -50,7 +50,7 @@ console.log(await listFrameworks({ projectDir: './path/to/vue/website' }))
 //     dev: {
 //       commands: ['npm run serve'],
 //       port: 8080,
-//       pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }]
+//       pollingStrategies: [{ name: 'TCP' }]
 //     },
 //     build: {
 //       commands: ['vue-cli-service build'],
@@ -72,7 +72,7 @@ console.log(await getFramework('vue', { projectDir: './path/to/vue/website' }))
 //   dev: {
 //     commands: ['npm run serve'],
 //     port: 8080,
-//     pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }]
+//     pollingStrategies: [{ name: 'TCP' }]
 //   },
 //   build: {
 //     commands: ['vue-cli-service build'],
@@ -90,7 +90,7 @@ console.log(getFrameworkById('vue'))
 //   dev: {
 //     commands: ['npm run serve'],
 //     port: 8080,
-//     pollingStrategies: [{ name: 'TCP' }, { name: 'HTTP' }]
+//     pollingStrategies: [{ name: 'TCP' }]
 //   },
 //   build: {
 //     commands: ['vue-cli-service build'],


### PR DESCRIPTION
#### Summary

Resolves https://linear.app/netlify/issue/COM-550/cannot-boot-ntl-dev-on-astro-project-using-functions-and-edge

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
