### PR TITLE
fix: update logic for plugin selection fallback

### DIFF
--- a/packages/build/src/core/feature_flags.ts
+++ b/packages/build/src/core/feature_flags.ts
@@ -20,4 +20,5 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   buildbot_zisi_system_log: false,
   edge_functions_cache_cli: false,
   edge_functions_system_logger: false,
+  netlify_build_updated_plugin_compatibility: false,
 }

--- a/packages/build/src/plugins/compatibility.test.ts
+++ b/packages/build/src/plugins/compatibility.test.ts
@@ -1,226 +1,319 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { getExpectedVersion } from './compatibility.js'
 import { PluginVersion } from './list.js'
 
-test('`getExpectedVersion` should ignore the new major version if the version is pinned', async () => {
-  const versions: PluginVersion[] = [
-    { version: '5.0.0', conditions: [] },
-    { version: '4.41.2', conditions: [] },
-  ]
-  const { version } = await getExpectedVersion({
-    versions,
-    nodeVersion: '18.19.0',
-    packageJson: {},
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+const noopSystemLog = () => {
+  // no-op
+}
+
+describe(`getExpectedVersion`, () => {
+  test('should ignore the new major version if the version is pinned', async () => {
+    const versions: PluginVersion[] = [
+      { version: '5.0.0', conditions: [] },
+      { version: '4.41.2', conditions: [] },
+    ]
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '18.19.0',
+      packageJson: {},
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+
+    expect(version).toBe('4.41.2')
   })
 
-  expect(version).toBe('4.41.2')
-})
+  test('matches prerelease versions', async () => {
+    const versions: PluginVersion[] = [
+      { version: '5.0.0', conditions: [] },
+      { version: '4.42.0-alpha.1', conditions: [] },
+      { version: '4.41.2', conditions: [] },
+    ]
 
-test('`getExpectedVersion` matches prerelease versions', async () => {
-  const versions: PluginVersion[] = [
-    { version: '5.0.0', conditions: [] },
-    { version: '4.42.0-alpha.1', conditions: [] },
-    { version: '4.41.2', conditions: [] },
-  ]
+    const { version: version1 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '18.19.0',
+      packageJson: {},
+      buildDir: '/some/path',
+      systemLog: noopSystemLog,
+    })
+    const { version: version2 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '18.19.0',
+      packageJson: {},
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
 
-  const { version: version1 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '18.19.0',
-    packageJson: {},
-    buildDir: '/some/path',
-  })
-  const { version: version2 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '18.19.0',
-    packageJson: {},
-    buildDir: '/some/path',
-    pinnedVersion: '4',
-  })
-
-  expect(version1).toBe('5.0.0')
-  expect(version2).toBe('4.42.0-alpha.1')
-})
-
-test('`getExpectedVersion`should retrieve a new major version if the overridePinnedVersion is specified', async () => {
-  const versions: PluginVersion[] = [
-    { version: '5.0.0', conditions: [], overridePinnedVersion: '>=4.0.0' },
-    { version: '4.41.2', conditions: [] },
-  ]
-
-  const { version } = await getExpectedVersion({
-    versions,
-    nodeVersion: '18.19.0',
-    packageJson: {},
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+    expect(version1).toBe('5.0.0')
+    expect(version2).toBe('4.42.0-alpha.1')
   })
 
-  expect(version).toBe('5.0.0')
-})
+  test('should retrieve a new major version if the overridePinnedVersion is specified', async () => {
+    const versions: PluginVersion[] = [
+      { version: '5.0.0', conditions: [], overridePinnedVersion: '>=4.0.0' },
+      { version: '4.41.2', conditions: [] },
+    ]
 
-test('`getExpectedVersion` should retrieve the plugin based on the condition of a nodeVersion', async () => {
-  const versions: PluginVersion[] = [
-    {
-      version: '4.42.0',
-      conditions: [{ type: 'nodeVersion', condition: '>=18.0.0' }],
-    },
-    { version: '4.41.2', conditions: [] },
-  ]
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '18.19.0',
+      packageJson: {},
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
 
-  const { version } = await getExpectedVersion({
-    versions,
-    nodeVersion: '17.19.0',
-    packageJson: {},
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+    expect(version).toBe('5.0.0')
   })
 
-  expect(version).toBe('4.41.2')
-})
+  test('should retrieve the plugin based on the condition of a nodeVersion', async () => {
+    const versions: PluginVersion[] = [
+      {
+        version: '4.42.0',
+        conditions: [{ type: 'nodeVersion', condition: '>=18.0.0' }],
+      },
+      { version: '4.41.2', conditions: [] },
+    ]
 
-test('`getExpectedVersion` should retrieve the plugin based on conditions and feature flag due to pinned version', async () => {
-  const versions: PluginVersion[] = [
-    {
-      version: '5.0.0-beta.1',
-      conditions: [
-        { type: 'nodeVersion', condition: '>= 18.0.0' },
-        { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
-      ],
-      overridePinnedVersion: '>=4.0.0',
-    },
-    {
-      version: '4.42.0',
-      conditions: [{ type: 'siteDependencies', condition: { next: '>=10.0.9' } }],
-    },
-    { version: '4.41.2', conditions: [] },
-    {
-      version: '3.9.2',
-      conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
-    },
-  ]
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '17.19.0',
+      packageJson: {},
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
 
-  const { version: version1 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '17.19.0',
-    packageJson: { dependencies: { next: '10.0.8' } },
-    buildDir: '/some/path',
-    pinnedVersion: '3',
+    expect(version).toBe('4.41.2')
   })
-  expect(version1).toBe('3.9.2')
 
-  const { version: version2 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '17.19.0',
-    packageJson: { dependencies: { next: '11.0.0' } },
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+  test('should retrieve the plugin based on conditions and feature flag due to pinned version', async () => {
+    const versions: PluginVersion[] = [
+      {
+        version: '5.0.0-beta.1',
+        conditions: [
+          { type: 'nodeVersion', condition: '>= 18.0.0' },
+          { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+        ],
+        overridePinnedVersion: '>=4.0.0',
+      },
+      {
+        version: '4.42.0',
+        conditions: [{ type: 'siteDependencies', condition: { next: '>=10.0.9' } }],
+      },
+      { version: '4.41.2', conditions: [] },
+      {
+        version: '3.9.2',
+        conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+      },
+    ]
+
+    const { version: version1 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '17.19.0',
+      packageJson: { dependencies: { next: '10.0.8' } },
+      buildDir: '/some/path',
+      pinnedVersion: '3',
+      systemLog: noopSystemLog,
+    })
+    expect(version1).toBe('3.9.2')
+
+    const { version: version2 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '17.19.0',
+      packageJson: { dependencies: { next: '11.0.0' } },
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+    expect(version2).toBe('4.42.0')
+
+    const { version: version3 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '18.19.0',
+      packageJson: { dependencies: { next: '13.5.0' } },
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+    expect(version3).toBe('5.0.0-beta.1')
   })
-  expect(version2).toBe('4.42.0')
 
-  const { version: version3 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '18.19.0',
-    packageJson: { dependencies: { next: '13.5.0' } },
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+  test('should work with rc versions inside the siteDependencies constraints', async () => {
+    const versions: PluginVersion[] = [
+      {
+        version: '5.0.0-beta.1',
+        conditions: [
+          { type: 'nodeVersion', condition: '>= 18.0.0' },
+          { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+        ],
+        overridePinnedVersion: '>=4.0.0',
+      },
+      {
+        version: '4.42.0',
+        conditions: [{ type: 'siteDependencies', condition: { next: '>=10.0.9' } }],
+      },
+      { version: '4.41.2', conditions: [] },
+      {
+        version: '3.9.2',
+        conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+      },
+    ]
+
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '18.19.0',
+      packageJson: { dependencies: { next: '14.1.1-canary.36' } },
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+    expect(version).toBe('5.0.0-beta.1')
   })
-  expect(version3).toBe('5.0.0-beta.1')
-})
 
-test('`getExpectedVersion` should work with rc versions inside the siteDependencies constraints', async () => {
-  const versions: PluginVersion[] = [
-    {
-      version: '5.0.0-beta.1',
-      conditions: [
-        { type: 'nodeVersion', condition: '>= 18.0.0' },
-        { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
-      ],
-      overridePinnedVersion: '>=4.0.0',
-    },
-    {
-      version: '4.42.0',
-      conditions: [{ type: 'siteDependencies', condition: { next: '>=10.0.9' } }],
-    },
-    { version: '4.41.2', conditions: [] },
-    {
-      version: '3.9.2',
-      conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
-    },
-  ]
+  test('should retrieve the plugin based on conditions and feature flag due to pinned version', async () => {
+    const versions: PluginVersion[] = [
+      {
+        version: '5.0.0-beta.1',
+        conditions: [
+          { type: 'nodeVersion', condition: '>= 18.0.0' },
+          { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+        ],
+        overridePinnedVersion: '>=4.0.0',
+      },
+      { version: '4.41.2', conditions: [] },
+      {
+        version: '3.9.2',
+        conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+      },
+    ]
 
-  const { version } = await getExpectedVersion({
-    versions,
-    nodeVersion: '18.19.0',
-    packageJson: { dependencies: { next: '14.1.1-canary.36' } },
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+    const { version: version1 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '20.0.0',
+      packageJson: { dependencies: { next: '14.0.0' } },
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+    expect(version1).toBe('5.0.0-beta.1')
+
+    // out of range
+    const { version: version2 } = await getExpectedVersion({
+      versions,
+      nodeVersion: '20.0.0',
+      packageJson: { dependencies: { next: '13.0.0' } },
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+    expect(version2).toBe('4.41.2')
   })
-  expect(version).toBe('5.0.0-beta.1')
-})
 
-test('`getExpectedVersion` should retrieve the plugin based on conditions and feature flag due to pinned version', async () => {
-  const versions: PluginVersion[] = [
-    {
-      version: '5.0.0-beta.1',
-      conditions: [
-        { type: 'nodeVersion', condition: '>= 18.0.0' },
-        { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
-      ],
-      overridePinnedVersion: '>=4.0.0',
-    },
-    { version: '4.41.2', conditions: [] },
-    {
-      version: '3.9.2',
-      conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
-    },
-  ]
+  test('matches the first entry that satisfies the constraints, even if it also matches another entry further down with more specific constraints', async () => {
+    const versions: PluginVersion[] = [
+      { version: '4.41.2', conditions: [] },
+      {
+        version: '5.0.0-beta.1',
+        conditions: [
+          { type: 'nodeVersion', condition: '>= 18.0.0' },
+          { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+        ],
+        overridePinnedVersion: '>=4.0.0',
+      },
+      {
+        version: '3.9.2',
+        conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+      },
+    ]
 
-  const { version: version1 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '20.0.0',
-    packageJson: { dependencies: { next: '14.0.0' } },
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '20.0.0',
+      packageJson: { dependencies: { next: '14.0.0' } },
+      buildDir: '/some/path',
+      pinnedVersion: '4',
+      systemLog: noopSystemLog,
+    })
+    expect(version).toBe('4.41.2')
   })
-  expect(version1).toBe('5.0.0-beta.1')
 
-  // out of range
-  const { version: version2 } = await getExpectedVersion({
-    versions,
-    nodeVersion: '20.0.0',
-    packageJson: { dependencies: { next: '13.0.0' } },
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+  test('if no pinned version is set, it matches the first version regardless of whether its requirements match the conditions (legacy behavior)', async () => {
+    const versions: PluginVersion[] = [
+      {
+        version: '5.0.0-beta.1',
+        conditions: [
+          { type: 'nodeVersion', condition: '>= 18.0.0' },
+          { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+        ],
+        overridePinnedVersion: '>=4.0.0',
+      },
+      { version: '4.41.2', conditions: [] },
+      {
+        version: '3.9.2',
+        conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+      },
+    ]
+
+    const logMessages: string[] = []
+
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '20.0.0',
+      packageJson: { name: '@netlify/a-cool-plugin', dependencies: { next: '12.0.0' } },
+      buildDir: '/some/path',
+      systemLog: (message: string) => {
+        logMessages.push(message)
+      },
+    })
+
+    expect(logMessages.length).toBe(1)
+    expect(logMessages[0]).toBe(
+      `Detected mismatch in selected version for plugin '@netlify/a-cool-plugin': used legacy version '5.0.0-beta.1' over new version '4.41.2'`,
+    )
+    expect(version).toBe('5.0.0-beta.1')
   })
-  expect(version2).toBe('4.41.2')
-})
 
-test('`getExpectedVersion` matches the first entry that satisfies the constraints, even if it also matches another entry further down with more specific constraints', async () => {
-  const versions: PluginVersion[] = [
-    { version: '4.41.2', conditions: [] },
-    {
-      version: '5.0.0-beta.1',
-      conditions: [
-        { type: 'nodeVersion', condition: '>= 18.0.0' },
-        { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
-      ],
-      overridePinnedVersion: '>=4.0.0',
-    },
-    {
-      version: '3.9.2',
-      conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
-    },
-  ]
+  test('if no pinned version is set, it matches the first version whose requirements match the conditions', async () => {
+    const versions: PluginVersion[] = [
+      {
+        version: '5.0.0-beta.1',
+        conditions: [
+          { type: 'nodeVersion', condition: '>= 18.0.0' },
+          { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+        ],
+        overridePinnedVersion: '>=4.0.0',
+      },
+      { version: '4.41.2', conditions: [] },
+      {
+        version: '3.9.2',
+        conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+      },
+    ]
 
-  const { version } = await getExpectedVersion({
-    versions,
-    nodeVersion: '20.0.0',
-    packageJson: { dependencies: { next: '14.0.0' } },
-    buildDir: '/some/path',
-    pinnedVersion: '4',
+    const logMessages: string[] = []
+
+    const { version } = await getExpectedVersion({
+      versions,
+      nodeVersion: '20.0.0',
+      packageJson: { name: '@netlify/a-cool-plugin', dependencies: { next: '12.0.0' } },
+      buildDir: '/some/path',
+      systemLog: (message: string) => {
+        logMessages.push(message)
+      },
+      featureFlags: {
+        netlify_build_updated_plugin_compatibility: true,
+      },
+    })
+
+    expect(logMessages.length).toBe(1)
+    expect(logMessages[0]).toBe(
+      `Detected mismatch in selected version for plugin '@netlify/a-cool-plugin': used new version of '4.41.2' over legacy version '5.0.0-beta.1'`,
+    )
+    expect(version).toBe('4.41.2')
   })
-  expect(version).toBe('4.41.2')
 })

--- a/packages/build/src/plugins/compatibility.test.ts
+++ b/packages/build/src/plugins/compatibility.test.ts
@@ -61,7 +61,7 @@ test('`getExpectedVersion`should retrieve a new major version if the overridePin
   expect(version).toBe('5.0.0')
 })
 
-test('`getExpectedVersion`should retrieve the plugin based on the condition of a nodeVersion', async () => {
+test('`getExpectedVersion` should retrieve the plugin based on the condition of a nodeVersion', async () => {
   const versions: PluginVersion[] = [
     {
       version: '4.42.0',
@@ -196,4 +196,31 @@ test('`getExpectedVersion` should retrieve the plugin based on conditions and fe
     pinnedVersion: '4',
   })
   expect(version2).toBe('4.41.2')
+})
+
+test('`getExpectedVersion` matches the first entry that satisfies the constraints, even if it also matches another entry further down with more specific constraints', async () => {
+  const versions: PluginVersion[] = [
+    { version: '4.41.2', conditions: [] },
+    {
+      version: '5.0.0-beta.1',
+      conditions: [
+        { type: 'nodeVersion', condition: '>= 18.0.0' },
+        { type: 'siteDependencies', condition: { next: '>=13.5.0' } },
+      ],
+      overridePinnedVersion: '>=4.0.0',
+    },
+    {
+      version: '3.9.2',
+      conditions: [{ type: 'siteDependencies', condition: { next: '<10.0.9' } }],
+    },
+  ]
+
+  const { version } = await getExpectedVersion({
+    versions,
+    nodeVersion: '20.0.0',
+    packageJson: { dependencies: { next: '14.0.0' } },
+    buildDir: '/some/path',
+    pinnedVersion: '4',
+  })
+  expect(version).toBe('4.41.2')
 })

--- a/packages/build/src/plugins/expected_version.ts
+++ b/packages/build/src/plugins/expected_version.ts
@@ -3,6 +3,7 @@ import semver from 'semver'
 
 import { FeatureFlags } from '../core/feature_flags.js'
 import { addErrorInfo } from '../error/info.js'
+import { SystemLogger } from '../plugins_core/types.js'
 import { importJsonFile } from '../utils/json.js'
 import { resolvePath } from '../utils/resolve.js'
 
@@ -23,6 +24,7 @@ export const addExpectedVersions = async function ({
   buildDir,
   testOpts,
   featureFlags,
+  systemLog,
 }) {
   if (!pluginsOptions.some(needsExpectedVersion)) {
     return pluginsOptions
@@ -40,6 +42,7 @@ export const addExpectedVersions = async function ({
         buildDir,
         featureFlags,
         testOpts,
+        systemLog,
       }),
     ),
   )
@@ -56,6 +59,7 @@ const addExpectedVersion = async function ({
   buildDir,
   featureFlags,
   testOpts,
+  systemLog,
 }: {
   pluginsList: PluginList
   packageJson: PackageJson
@@ -65,6 +69,7 @@ const addExpectedVersion = async function ({
   featureFlags: FeatureFlags
   testOpts: Record<string, unknown>
   autoPluginsDir: string
+  systemLog: SystemLogger
 }) {
   if (!needsExpectedVersion(pluginOptions)) {
     return pluginOptions
@@ -79,8 +84,17 @@ const addExpectedVersion = async function ({
   const versions = filterVersions(unfilteredVersions, featureFlags)
   const [{ version: latestVersion, migrationGuide }] = versions
   const [{ version: expectedVersion }, { version: compatibleVersion, compatWarning }] = await Promise.all([
-    getExpectedVersion({ versions, nodeVersion, packageJson, packagePath, buildDir, pinnedVersion }),
-    getExpectedVersion({ versions, nodeVersion, packageJson, packagePath, buildDir }),
+    getExpectedVersion({
+      versions,
+      nodeVersion,
+      packageJson,
+      packagePath,
+      buildDir,
+      pinnedVersion,
+      featureFlags,
+      systemLog,
+    }),
+    getExpectedVersion({ versions, nodeVersion, packageJson, packagePath, buildDir, featureFlags, systemLog }),
   ])
 
   const isMissing = await isMissingVersion({ autoPluginsDir, packageName, pluginPath, loadedFrom, expectedVersion })

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -58,6 +58,7 @@ export const resolvePluginsPath = async function ({
     buildDir,
     testOpts,
     featureFlags,
+    systemLog,
   })
   const pluginsOptionsE = await handleMissingPlugins({
     pluginsOptions: pluginsOptionsD,

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -6,6 +6,8 @@ import { Fixture, normalizeOutput, removeDir } from '@netlify/testing'
 import test from 'ava'
 import tmp, { tmpName } from 'tmp-promise'
 
+import { DEFAULT_FEATURE_FLAGS } from '../../lib/core/feature_flags.js'
+
 const FIXTURES_DIR = fileURLToPath(new URL('fixtures', import.meta.url))
 
 test('Pass packageJson to plugins', async (t) => {
@@ -196,18 +198,12 @@ test('Trusted plugins are passed featureflags and system log', async (t) => {
     t.true(systemLog.includes(expectedSystemLogs))
   }
 
-  t.true(
-    output.includes(
-      JSON.stringify({
-        buildbot_zisi_trace_nft: false,
-        buildbot_zisi_esbuild_parser: false,
-        buildbot_zisi_system_log: false,
-        edge_functions_cache_cli: false,
-        edge_functions_system_logger: false,
-        test_flag: true,
-      }),
-    ),
-  )
+  const expectedFlags = {
+    ...DEFAULT_FEATURE_FLAGS,
+    test_flag: true,
+  }
+
+  t.true(output.includes(JSON.stringify(expectedFlags)))
 
   const outputUntrusted = await new Fixture('./fixtures/feature_flags_untrusted')
     .withFlags({


### PR DESCRIPTION
#### Summary

Updates the logic used to determine the plugin version that should be picked when there is no pinned version for the site. Includes a feature flag that toggles between just logging whenever there's a mismatch between the legacy and new logic and actually applying the new version.