### PR TITLE
fix: use correct plugin name in system log

### DIFF
--- a/packages/build/src/plugins/compatibility.test.ts
+++ b/packages/build/src/plugins/compatibility.test.ts
@@ -17,6 +17,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '18.19.0',
       packageJson: {},
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -36,6 +37,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '18.19.0',
       packageJson: {},
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       systemLog: noopSystemLog,
     })
@@ -43,6 +45,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '18.19.0',
       packageJson: {},
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -62,6 +65,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '18.19.0',
       packageJson: {},
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -83,6 +87,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '17.19.0',
       packageJson: {},
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -116,6 +121,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '17.19.0',
       packageJson: { dependencies: { next: '10.0.8' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '3',
       systemLog: noopSystemLog,
@@ -126,6 +132,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '17.19.0',
       packageJson: { dependencies: { next: '11.0.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -136,6 +143,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '18.19.0',
       packageJson: { dependencies: { next: '13.5.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -168,6 +176,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '18.19.0',
       packageJson: { dependencies: { next: '14.1.1-canary.36' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -196,6 +205,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '20.0.0',
       packageJson: { dependencies: { next: '14.0.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -207,6 +217,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '20.0.0',
       packageJson: { dependencies: { next: '13.0.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -235,6 +246,7 @@ describe(`getExpectedVersion`, () => {
       versions,
       nodeVersion: '20.0.0',
       packageJson: { dependencies: { next: '14.0.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       pinnedVersion: '4',
       systemLog: noopSystemLog,
@@ -264,7 +276,8 @@ describe(`getExpectedVersion`, () => {
     const { version } = await getExpectedVersion({
       versions,
       nodeVersion: '20.0.0',
-      packageJson: { name: '@netlify/a-cool-plugin', dependencies: { next: '12.0.0' } },
+      packageJson: { dependencies: { next: '12.0.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       systemLog: (message: string) => {
         logMessages.push(message)
@@ -273,7 +286,7 @@ describe(`getExpectedVersion`, () => {
 
     expect(logMessages.length).toBe(1)
     expect(logMessages[0]).toBe(
-      `Detected mismatch in selected version for plugin '@netlify/a-cool-plugin': used legacy version '5.0.0-beta.1' over new version '4.41.2'`,
+      `Detected mismatch in selected version for plugin '@netlify/cool-plugin': used legacy version '5.0.0-beta.1' over new version '4.41.2'`,
     )
     expect(version).toBe('5.0.0-beta.1')
   })
@@ -300,7 +313,8 @@ describe(`getExpectedVersion`, () => {
     const { version } = await getExpectedVersion({
       versions,
       nodeVersion: '20.0.0',
-      packageJson: { name: '@netlify/a-cool-plugin', dependencies: { next: '12.0.0' } },
+      packageJson: { dependencies: { next: '12.0.0' } },
+      packageName: '@netlify/cool-plugin',
       buildDir: '/some/path',
       systemLog: (message: string) => {
         logMessages.push(message)
@@ -312,7 +326,7 @@ describe(`getExpectedVersion`, () => {
 
     expect(logMessages.length).toBe(1)
     expect(logMessages[0]).toBe(
-      `Detected mismatch in selected version for plugin '@netlify/a-cool-plugin': used new version of '4.41.2' over legacy version '5.0.0-beta.1'`,
+      `Detected mismatch in selected version for plugin '@netlify/cool-plugin': used new version of '4.41.2' over legacy version '5.0.0-beta.1'`,
     )
     expect(version).toBe('4.41.2')
   })

--- a/packages/build/src/plugins/compatibility.ts
+++ b/packages/build/src/plugins/compatibility.ts
@@ -27,6 +27,7 @@ export const getExpectedVersion = async function ({
   versions,
   nodeVersion,
   packageJson,
+  packageName,
   packagePath,
   buildDir,
   pinnedVersion,
@@ -36,6 +37,7 @@ export const getExpectedVersion = async function ({
   versions: PluginVersion[]
   /** The package.json of the repository */
   packageJson: PackageJson
+  packageName: string
   packagePath?: string
   buildDir: string
   nodeVersion: string
@@ -47,6 +49,7 @@ export const getExpectedVersion = async function ({
     versions,
     nodeVersion,
     packageJson,
+    packageName,
     packagePath,
     buildDir,
     pinnedVersion,
@@ -79,6 +82,7 @@ const getCompatibleEntry = async function ({
   versions,
   nodeVersion,
   packageJson,
+  packageName,
   packagePath,
   buildDir,
   pinnedVersion,
@@ -89,6 +93,7 @@ const getCompatibleEntry = async function ({
   packageJson: PackageJson
   buildDir: string
   nodeVersion: string
+  packageName: string
   packagePath?: string
   pinnedVersion?: string
   featureFlags?: FeatureFlags
@@ -134,7 +139,7 @@ const getCompatibleEntry = async function ({
   if (featureFlags?.netlify_build_updated_plugin_compatibility) {
     if (legacyFallback.version !== fallback.version) {
       systemLog(
-        `Detected mismatch in selected version for plugin '${packageJson?.name}': used new version of '${fallback.version}' over legacy version '${legacyFallback.version}'`,
+        `Detected mismatch in selected version for plugin '${packageName}': used new version of '${fallback.version}' over legacy version '${legacyFallback.version}'`,
       )
     }
 
@@ -143,7 +148,7 @@ const getCompatibleEntry = async function ({
 
   if (legacyFallback.version !== fallback.version) {
     systemLog(
-      `Detected mismatch in selected version for plugin '${packageJson?.name}': used legacy version '${legacyFallback.version}' over new version '${fallback.version}'`,
+      `Detected mismatch in selected version for plugin '${packageName}': used legacy version '${legacyFallback.version}' over new version '${fallback.version}'`,
     )
   }
 

--- a/packages/build/src/plugins/expected_version.ts
+++ b/packages/build/src/plugins/expected_version.ts
@@ -88,13 +88,23 @@ const addExpectedVersion = async function ({
       versions,
       nodeVersion,
       packageJson,
+      packageName,
       packagePath,
       buildDir,
       pinnedVersion,
       featureFlags,
       systemLog,
     }),
-    getExpectedVersion({ versions, nodeVersion, packageJson, packagePath, buildDir, featureFlags, systemLog }),
+    getExpectedVersion({
+      versions,
+      nodeVersion,
+      packageJson,
+      packageName,
+      packagePath,
+      buildDir,
+      featureFlags,
+      systemLog,
+    }),
   ])
 
   const isMissing = await isMissingVersion({ autoPluginsDir, packageName, pluginPath, loadedFrom, expectedVersion })


### PR DESCRIPTION
#### Summary

Small follow-up to #5575. We were incorrectly logging the name of the project package (if set) as the name of the plugin.