### PR TITLE
feat: add used build plugins and their versions to exec-build span

### DIFF
--- a/packages/build/src/core/build.ts
+++ b/packages/build/src/core/build.ts
@@ -1,4 +1,5 @@
 import { supportedRuntimes } from '@netlify/framework-info'
+import { addAttributesToActiveSpan } from '@netlify/opentelemetry-utils'
 
 import { getErrorInfo } from '../error/info.js'
 import { startErrorMonitor } from '../error/monitor/start.js'
@@ -457,6 +458,17 @@ const initAndRunBuild = async function ({
     context,
     systemLog,
   })
+
+  if (pluginsOptionsA?.length) {
+    const buildPlugins = {}
+    for (const plugin of pluginsOptionsA) {
+      if (plugin?.pluginPackageJson?.name) {
+        buildPlugins[`build.plugins['${plugin.pluginPackageJson.name}']`] = plugin?.pluginPackageJson?.version ?? 'N/A'
+      }
+    }
+
+    addAttributesToActiveSpan(buildPlugins)
+  }
 
   errorParams.pluginsOptions = pluginsOptionsA
 


### PR DESCRIPTION
#### Summary

We are currently unable to create SLO in honeycomb that target just Next Runtime v5 to capture overall build error rates with it.

We do have individual build steps annotated with plugin name and version that is being executed, but we can't join `exec-build` span with those to extract needed information. This PR adds information about used Build Plugins to `exec-build` by adding 1 span attribute per plugin with name containing plugin name and value being its version to be able to filter `exec-build` by specific plugins (and their versions).

This will allow queries like below to be able to create actual SLO and alerting 
![image](https://github.com/netlify/build/assets/419821/38190e64-889b-4d98-9e45-355081e76164)


Related to https://linear.app/netlify/issue/FRA-367/update-build-time-metrics
Relevant slack discussion: https://netlify.slack.com/archives/C031MPNJWK1/p1712068846389239