### PR TITLE
fix: test the release flow of edge-bundler

### DIFF
--- a/packages/edge-bundler/node/bundler.ts
+++ b/packages/edge-bundler/node/bundler.ts
@@ -80,8 +80,8 @@ export const bundle = async (
   await ensureLatestTypes(deno, logger)
 
   // The name of the bundle will be the hash of its contents, which we can't
-  // compute until we run the bundle process. For now, we'll use a random ID
-  // to create the bundle artifacts and rename them later.
+  // compute until we run the bundle process.
+  // For now, we'll use a random ID to create the bundle artifacts and rename them later.
   const buildID = uuidv4()
 
   // Loading any configuration options from the deploy configuration API, if it


### PR DESCRIPTION
We've merged edge-bundler into this repo, but haven't tested the release-please flow yet. This PR tries doing a patch release of edge-bundler, let's see if that works as expected.