### PR TITLE
feat: parse custom rate limit info from redirects

### DIFF
--- a/packages/redirect-parser/src/normalize.js
+++ b/packages/redirect-parser/src/normalize.js
@@ -54,6 +54,7 @@ const parseRedirectObject = function (
     signing = sign,
     signed = signing,
     headers = {},
+    rate_limit,
   },
   minimal,
 ) {
@@ -82,6 +83,7 @@ const parseRedirectObject = function (
     conditions: normalizedConditions,
     signed,
     headers,
+    rate_limit,
     // If `minimal: true`, does not add additional properties that are not
     // valid in `netlify.toml`
     ...(!minimal && { scheme, host, path, proxy }),

--- a/packages/redirect-parser/tests/fixtures/netlify_config/with_ratelimit.toml
+++ b/packages/redirect-parser/tests/fixtures/netlify_config/with_ratelimit.toml
@@ -1,0 +1,20 @@
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 301
+  force = false
+  query = {path = ":path"}
+  conditions = {Language = ["en"], Country = ["US"], Role = ["admin"]}
+  [redirects.rate_limit]
+    window_limit = 40
+    aggregate_by = ["ip"]
+
+[[redirects]]
+  from = "/other/*"
+  to = "/maybe_rewritten"
+    [redirects.rate_limit]
+    action = "rewrite"
+    to = "/rewritten"
+    window_limit = 40
+    window_size = 20
+    aggregate_by = ["ip", "domain"]

--- a/packages/redirect-parser/tests/netlify-config-parser.test.ts
+++ b/packages/redirect-parser/tests/netlify-config-parser.test.ts
@@ -125,6 +125,38 @@ test.each([
       },
     ],
   ],
+  [
+    'with rate limits',
+    { netlifyConfigPath: 'with_ratelimit' },
+    [
+      {
+        from: '/old-path',
+        path: '/old-path',
+        to: '/new-path',
+        status: 301,
+        query: { path: ':path' },
+        conditions: { Country: ['US'], Language: ['en'], Role: ['admin'] },
+        rate_limit: {
+          window_limit: 40,
+          aggregate_by: ['ip'],
+        },
+      },
+      {
+        from: '/other/*',
+        path: '/other/*',
+        to: '/maybe_rewritten',
+        proxy: false,
+        force: false,
+        rate_limit: {
+          action: 'rewrite',
+          to: '/rewritten',
+          window_limit: 40,
+          window_size: 20,
+          aggregate_by: ['ip', 'domain'],
+        },
+      },
+    ],
+  ],
 ])(`Parses netlify.toml redirects | %s`, async (_, input, output) => {
   const { redirects } = await parseRedirects(input)
   const normalized = output.map((redirect) => normalizeRedirect(redirect, input))


### PR DESCRIPTION
#### Summary

Related to ADN-294

Need that extra info to be parsed so custom rate limits work correctly with the CLI. Sorry for the tag @eduardoboucas, but you're the closest person that has been following the project that also knows `build`.