### PR TITLE
fix: no-op change to test release process after merging ZISI into monorepo

### DIFF
--- a/packages/zip-it-and-ship-it/src/main.ts
+++ b/packages/zip-it-and-ship-it/src/main.ts
@@ -68,7 +68,7 @@ interface ListFunctionsOptions {
   parseISC?: boolean
 }
 
-// List all Netlify Functions main entry files for a specific directory
+// List all Netlify Functions main entry files for a specific directory.
 export const listFunctions = async function (
   relativeSrcFolders: string | string[],
   { featureFlags: inputFeatureFlags, config, configFileDirectories, parseISC = false }: ListFunctionsOptions = {},


### PR DESCRIPTION
Tiny no-op change to check if after #5644 we're still able to release correctly.