### PR TITLE
fix: flush output from "Deploy site" step

### DIFF
--- a/packages/build/src/plugins_core/deploy/index.js
+++ b/packages/build/src/plugins_core/deploy/index.js
@@ -28,6 +28,9 @@ const coreStep = async function ({
 }) {
   const client = createBuildbotClient(buildbotServerSocket)
   try {
+    // buildbot will emit logs. Flush the output to preserve the right order.
+    logs?.outputFlusher?.flush()
+
     await connectBuildbotClient(client)
     await saveUpdatedConfig({
       configMutations,


### PR DESCRIPTION
#### Summary

Small follow-up to #5643. In the deploy step, buildbot emits some logs of its own, so we need to flush the header before that to preserve the correct order of things.