### PR TITLE
fix: remove optional chaining operator

### DIFF
--- a/packages/build/src/log/logger.ts
+++ b/packages/build/src/log/logger.ts
@@ -51,7 +51,9 @@ export const log = function (
   const stringB = String(stringA).replace(EMPTY_LINES_REGEXP, EMPTY_LINE)
   const stringC = color === undefined ? stringB : color(stringB)
 
-  logs?.outputFlusher?.flush()
+  if (logs && logs.outputFlusher) {
+    logs.outputFlusher.flush()
+  }
 
   if (logsAreBuffered(logs)) {
     // `logs` is a stateful variable


### PR DESCRIPTION
#### Summary

The optional chaining operator is causing some build errors in old versions of Node.js. Replacing it with an explicit assertion.