### PR TITLE
fix: stop changing `logs` if flusher is not set

### DIFF
--- a/packages/build/src/log/logger.ts
+++ b/packages/build/src/log/logger.ts
@@ -190,11 +190,7 @@ export const getSystemLogger = function (
   return (...args) => fileDescriptor.write(`${reduceLogLines(args)}\n`)
 }
 
-export const addOutputFlusher = (logs: Logs, outputFlusher?: OutputFlusher): Logs => {
-  if (!outputFlusher) {
-    return logs
-  }
-
+export const addOutputFlusher = (logs: Logs, outputFlusher: OutputFlusher): Logs => {
   if (logsAreBuffered(logs)) {
     return {
       ...logs,

--- a/packages/build/src/log/logger.ts
+++ b/packages/build/src/log/logger.ts
@@ -190,7 +190,11 @@ export const getSystemLogger = function (
   return (...args) => fileDescriptor.write(`${reduceLogLines(args)}\n`)
 }
 
-export const addOutputGate = (logs: Logs, outputFlusher: OutputFlusher): Logs => {
+export const addOutputFlusher = (logs: Logs, outputFlusher?: OutputFlusher): Logs => {
+  if (!outputFlusher) {
+    return logs
+  }
+
   if (logsAreBuffered(logs)) {
     return {
       ...logs,

--- a/packages/build/src/steps/core_step.ts
+++ b/packages/build/src/steps/core_step.ts
@@ -40,7 +40,7 @@ export const fireCoreStep = async function ({
   deployId,
   outputFlusher,
 }) {
-  const logsA = addOutputFlusher(logs, outputFlusher)
+  const logsA = outputFlusher ? addOutputFlusher(logs, outputFlusher) : logs
 
   try {
     const configSideFiles = await listConfigSideFiles([headersPath, redirectsPath])

--- a/packages/build/src/steps/core_step.ts
+++ b/packages/build/src/steps/core_step.ts
@@ -1,6 +1,6 @@
 import { setEnvChanges } from '../env/changes.js'
 import { addErrorInfo, isBuildError } from '../error/info.js'
-import { addOutputGate } from '../log/logger.js'
+import { addOutputFlusher } from '../log/logger.js'
 
 import { updateNetlifyConfig, listConfigSideFiles } from './update_config.js'
 
@@ -40,7 +40,7 @@ export const fireCoreStep = async function ({
   deployId,
   outputFlusher,
 }) {
-  const logsA = addOutputGate(logs, outputFlusher)
+  const logsA = addOutputFlusher(logs, outputFlusher)
 
   try {
     const configSideFiles = await listConfigSideFiles([headersPath, redirectsPath])

--- a/packages/build/src/steps/plugin.js
+++ b/packages/build/src/steps/plugin.js
@@ -1,7 +1,7 @@
 import { context, propagation } from '@opentelemetry/api'
 
 import { addErrorInfo } from '../error/info.js'
-import { addOutputGate } from '../log/logger.js'
+import { addOutputFlusher } from '../log/logger.js'
 import { logStepCompleted } from '../log/messages/ipc.js'
 import { pipePluginOutput, unpipePluginOutput } from '../log/stream.js'
 import { callChild } from '../plugins/ipc.js'
@@ -43,7 +43,7 @@ export const firePluginStep = async function ({
   const otelCarrier = {}
   propagation.inject(context.active(), otelCarrier)
 
-  const logsA = addOutputGate(logs, outputFlusher)
+  const logsA = addOutputFlusher(logs, outputFlusher)
 
   try {
     const configSideFiles = await listConfigSideFiles([headersPath, redirectsPath])


### PR DESCRIPTION
#### Summary

If `outputFlusher` isn't set, stop changing the `logs` reference that is sent to the logic that calls plugins.

This shouldn't make a difference, but trying to be super defensive about this code path.