### PR TITLE
feat: pass output flusher to `callChild`

### DIFF
--- a/packages/build/src/log/output_flusher.ts
+++ b/packages/build/src/log/output_flusher.ts
@@ -1,3 +1,4 @@
+import { stdout, stderr } from 'process'
 import { Transform } from 'stream'
 
 const flusherSymbol = Symbol.for('@netlify/output-gate')
@@ -44,5 +45,20 @@ export class OutputFlusherTransform extends Transform {
     this.push(chunk)
 
     callback()
+  }
+}
+
+export const getStandardStreams = (outputFlusher?: OutputFlusher) => {
+  if (!outputFlusher) {
+    return {
+      stdout,
+      stderr,
+    }
+  }
+
+  return {
+    outputFlusher,
+    stdout: new OutputFlusherTransform(outputFlusher).pipe(stdout),
+    stderr: new OutputFlusherTransform(outputFlusher).pipe(stderr),
   }
 }

--- a/packages/build/src/log/output_flusher.ts
+++ b/packages/build/src/log/output_flusher.ts
@@ -1,6 +1,8 @@
 import { stdout, stderr } from 'process'
 import { Transform } from 'stream'
 
+import type { StandardStreams } from './stream.js'
+
 const flusherSymbol = Symbol.for('@netlify/output-gate')
 
 /**
@@ -48,7 +50,7 @@ export class OutputFlusherTransform extends Transform {
   }
 }
 
-export const getStandardStreams = (outputFlusher?: OutputFlusher) => {
+export const getStandardStreams = (outputFlusher?: OutputFlusher): StandardStreams => {
   if (!outputFlusher) {
     return {
       stdout,

--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -22,6 +22,8 @@ import { callChild, getEventFromChild } from './ipc.js'
 import { PluginsOptions } from './node_version.js'
 import { getSpawnInfo } from './options.js'
 
+export type ChildProcess = ExecaChildProcess<string>
+
 const CHILD_MAIN_FILE = fileURLToPath(new URL('child/main.js', import.meta.url))
 
 const require = createRequire(import.meta.url)

--- a/packages/build/src/steps/plugin.js
+++ b/packages/build/src/steps/plugin.js
@@ -3,6 +3,7 @@ import { context, propagation } from '@opentelemetry/api'
 import { addErrorInfo } from '../error/info.js'
 import { addOutputFlusher } from '../log/logger.js'
 import { logStepCompleted } from '../log/messages/ipc.js'
+import { getStandardStreams } from '../log/output_flusher.js'
 import { pipePluginOutput, unpipePluginOutput } from '../log/stream.js'
 import { callChild } from '../plugins/ipc.js'
 import { getSuccessStatus } from '../status/success.js'
@@ -38,12 +39,13 @@ export const firePluginStep = async function ({
   debug,
   verbose,
 }) {
-  const listeners = pipePluginOutput(childProcess, logs, outputFlusher)
+  const standardStreams = getStandardStreams(outputFlusher)
+  const listeners = pipePluginOutput(childProcess, logs, standardStreams)
 
   const otelCarrier = {}
   propagation.inject(context.active(), otelCarrier)
 
-  const logsA = addOutputFlusher(logs, outputFlusher)
+  const logsA = outputFlusher ? addOutputFlusher(logs, outputFlusher) : logs
 
   try {
     const configSideFiles = await listConfigSideFiles([headersPath, redirectsPath])
@@ -63,7 +65,7 @@ export const firePluginStep = async function ({
         constants,
         otelCarrier,
       },
-      logs,
+      logs: logsA,
       verbose,
     })
     const {
@@ -104,7 +106,7 @@ export const firePluginStep = async function ({
     })
     return { newError }
   } finally {
-    await unpipePluginOutput(childProcess, logs, listeners)
+    await unpipePluginOutput(childProcess, logs, listeners, standardStreams)
     logStepCompleted(logs, verbose)
   }
 }


### PR DESCRIPTION
#### Summary

Follow-up to #5643 with a couple of small changes:

- https://github.com/netlify/build/pull/5677/commits/b4f9a10e856ee28865b34a89d0ef6dc7d1da5f4b: passes the output flusher to the `callChild` method, and ensures that we call `unpipe` on the streams that have been wrapped with the transform

- https://github.com/netlify/build/pull/5677/commits/6586800f3426b1b364661b153fdbedd339e2093c: refactored the `stream` to use TypeScript.