### PR TITLE
feat: log plugin initialisation error on single line

### DIFF
--- a/packages/build/src/plugins/system_log.ts
+++ b/packages/build/src/plugins/system_log.ts
@@ -15,22 +15,20 @@ export const captureStandardError = (
     }
   }
 
-  let receivedChunks = false
+  let buffer = ''
 
   const listener = (chunk: Buffer) => {
-    if (!receivedChunks) {
-      receivedChunks = true
-
-      systemLog(`Plugin failed to initialize during the "${eventName}" phase`)
-    }
-
-    systemLog(chunk.toString().trimEnd())
+    buffer += chunk.toString()
   }
 
   childProcess.stderr?.on('data', listener)
 
   const cleanup = () => {
     childProcess.stderr?.removeListener('data', listener)
+
+    if (buffer.length !== 0) {
+      systemLog(`Plugin failed to initialize during the "${eventName}" phase: ${buffer.trim()}`)
+    }
   }
 
   return cleanup

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -360,10 +360,8 @@ test('Plugin errors that occur during the loading phase are piped to system logs
 
   if (platform !== 'win32') {
     const systemLog = await fs.readFile(systemLogFile.path, { encoding: 'utf8' })
-    const lines = systemLog.split('\n')
 
-    t.is(lines[0].trim(), 'Plugin failed to initialize during the "load" phase')
-    t.is(lines[1].trim(), 'An error message thrown by Node.js')
+    t.is(systemLog.trim(), `Plugin failed to initialize during the "load" phase: An error message thrown by Node.js`)
   }
 
   t.snapshot(normalizeOutput(output))


### PR DESCRIPTION
#### Summary

Small follow-up to #5679 and #5681. After seeing the emitted logs in production, I think they would be easier to consume if they were on a single line. This PR makes it so.