### PR TITLE
fix: [CRE-1203] adds `dev` to config mutable props

### DIFF
--- a/packages/config/src/mutations/apply.js
+++ b/packages/config/src/mutations/apply.js
@@ -77,6 +77,7 @@ const MUTABLE_PROPS = {
   images: { lastEvent: 'onPostBuild' },
   'images.remote_images': { lastEvent: 'onPostBuild' },
   redirects: { lastEvent: 'onPostBuild' },
+  dev: { lastEvent: 'onPreDev' },
   'dev.processing': { lastEvent: 'onPreDev' },
   'dev.processing.html': { lastEvent: 'onPreDev' },
   'dev.processing.html.injections': { lastEvent: 'onPreDev' },


### PR DESCRIPTION
Leftover from https://github.com/netlify/build/pull/5692.
Apparently, the `dev` needs to be in mutable props as well as it won't be present if netlify.toml doesn't have `build.publish` property.