### PR TITLE
fix: use correct base path for ISC `includedFiles`

### DIFF
--- a/packages/zip-it-and-ship-it/src/runtimes/node/in_source_config/index.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/in_source_config/index.ts
@@ -231,7 +231,7 @@ export const augmentFunctionConfig = (
   // the source override any files defined in the TOML. It doesn't make a lot
   // of sense to be defining include files for a framework-generated function
   // in the TOML anyway.
-  if (inSourceConfig?.includedFiles?.length !== 0) {
+  if (inSourceConfig?.includedFiles && inSourceConfig.includedFiles.length !== 0) {
     mergedConfig.includedFiles = inSourceConfig.includedFiles
     mergedConfig.includedFilesBasePath = dirname(mainFile)
   }

--- a/packages/zip-it-and-ship-it/src/runtimes/node/index.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/index.ts
@@ -65,7 +65,7 @@ const zipFunction: ZipFunction = async function ({
 
   const staticAnalysisResult = await parseFile(mainFile, { functionName: name })
   const runtimeAPIVersion = staticAnalysisResult.runtimeAPIVersion === 2 ? 2 : 1
-  const mergedConfig = augmentFunctionConfig(config, staticAnalysisResult.config)
+  const mergedConfig = augmentFunctionConfig(mainFile, config, staticAnalysisResult.config)
   const pluginsModulesPath = await getPluginsModulesPath(srcDir)
   const bundlerName = await getBundlerName({
     config: mergedConfig,

--- a/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-included-files/netlify/functions/function.js
+++ b/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-included-files/netlify/functions/function.js
@@ -6,5 +6,5 @@ export default async () =>
   })
 
 export const config = {
-  includedFiles: ['blog/author*'],
+  includedFiles: ['../../blog/post*'],
 }

--- a/packages/zip-it-and-ship-it/tests/v2api.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2api.test.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util'
 
 import merge from 'deepmerge'
 import glob from 'glob'
+import { pathExists } from 'path-exists'
 import semver from 'semver'
 import { dir as getTmpDir } from 'tmp-promise'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -626,6 +627,10 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       resolve(FIXTURES_ESM_DIR, fixtureName, 'blog/post1.md'),
       resolve(FIXTURES_ESM_DIR, fixtureName, 'blog/post2.md'),
     ])
+
+    for (const path of includedFiles as string[]) {
+      expect(await pathExists(path)).toBeTruthy()
+    }
   })
 
   test('Uses the bundler specified in the `nodeBundler` property from the in-source configuration', async () => {

--- a/packages/zip-it-and-ship-it/tests/v2api.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2api.test.ts
@@ -598,7 +598,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     },
   )
 
-  test('Includes in the bundle files included in the function source', async (t) => {
+  test('Includes in the bundle files included in the function source', async () => {
     const fixtureName = 'v2-api-included-files'
     const { files, tmpDir } = await zipFixture(`${fixtureName}/netlify/functions`, {
       fixtureDir: FIXTURES_ESM_DIR,


### PR DESCRIPTION
#### Summary

Follow-up to #5712. When `includedFiles` is defined in-source, it resolves the globs relative to the function file.