### PR TITLE
fix: add `excludedRoutes` to functions manifest

### DIFF
--- a/packages/zip-it-and-ship-it/src/manifest.ts
+++ b/packages/zip-it-and-ship-it/src/manifest.ts
@@ -53,6 +53,7 @@ export const createManifest = async ({ functions, path }: { functions: FunctionR
 const formatFunctionForManifest = ({
   bundler,
   displayName,
+  excludedRoutes,
   generator,
   invocationMode,
   mainFile,
@@ -86,6 +87,10 @@ const formatFunctionForManifest = ({
 
   if (routes?.length !== 0) {
     manifestFunction.routes = routes
+  }
+
+  if (excludedRoutes && excludedRoutes.length !== 0) {
+    manifestFunction.excludedRoutes = excludedRoutes
   }
 
   return manifestFunction

--- a/packages/zip-it-and-ship-it/tests/v2api.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2api.test.ts
@@ -478,6 +478,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       if (expectedRoutes[file.name].excludedRoutes) {
         expect(file.excludedRoutes).toEqual(expectedRoutes[file.name].excludedRoutes)
+      } else {
+        expect(file.excludedRoutes).toEqual([])
       }
     }
 
@@ -486,10 +488,18 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
     for (const entry of manifest.functions) {
       const match = Object.keys(expectedRoutes).find((key) => key === entry.name)
-
       expect(match).not.toBeUndefined()
-      expect(entry.routes).toEqual(expectedRoutes[match!].routes)
+
+      const expected = expectedRoutes[match!]
+
+      expect(entry.routes).toEqual(expected.routes)
       expect(entry.buildData.runtimeAPIVersion).toEqual(2)
+
+      if (expected.excludedRoutes) {
+        expect(entry.excludedRoutes).toEqual(expected.excludedRoutes)
+      } else {
+        expect(entry.excludedRoutes).toBeUndefined()
+      }
     }
   })
 


### PR DESCRIPTION
#### Summary

Follow-up to #5717, adding `excludedRoutes` to the functions manifest.

Part of https://linear.app/netlify/issue/COM-724/excludedpath-in-functions-v2.