### PR TITLE
fix: preserve cached config while mutating config

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
   "lint-staged": {
     "!(packages/*/tests/**/fixtures/**/*)*.+(j|t)s": "eslint --ignore-path .gitignore --cache --fix",
     "*": "prettier --write --ignore-unknown"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,5 @@
   "lint-staged": {
     "!(packages/*/tests/**/fixtures/**/*)*.+(j|t)s": "eslint --ignore-path .gitignore --cache --fix",
     "*": "prettier --write --ignore-unknown"
-  },
-  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
+  }
 }

--- a/packages/build/src/core/build.ts
+++ b/packages/build/src/core/build.ts
@@ -180,6 +180,7 @@ const tExecBuild = async function ({
   } = await runAndReportBuild({
     pluginsOptions,
     netlifyConfig,
+    cachedConfig,
     configOpts,
     siteInfo,
     configPath,
@@ -240,6 +241,7 @@ export const execBuild = measureDuration(tExecBuild, 'total', { parentTag: 'buil
 export const runAndReportBuild = async function ({
   pluginsOptions,
   netlifyConfig,
+  cachedConfig,
   configOpts,
   siteInfo,
   configPath,
@@ -295,6 +297,7 @@ export const runAndReportBuild = async function ({
     } = await initAndRunBuild({
       pluginsOptions,
       netlifyConfig,
+      cachedConfig,
       configOpts,
       siteInfo,
       configPath,
@@ -400,6 +403,7 @@ export const runAndReportBuild = async function ({
 const initAndRunBuild = async function ({
   pluginsOptions,
   netlifyConfig,
+  cachedConfig,
   configOpts,
   siteInfo,
   configPath,
@@ -508,6 +512,7 @@ const initAndRunBuild = async function ({
       childProcesses,
       pluginsOptions: pluginsOptionsA,
       netlifyConfig,
+      cachedConfig,
       configOpts,
       packageJson,
       configPath,
@@ -583,6 +588,7 @@ const runBuild = async function ({
   childProcesses,
   pluginsOptions,
   netlifyConfig,
+  cachedConfig,
   configOpts,
   packageJson,
   configPath,
@@ -671,6 +677,7 @@ const runBuild = async function ({
     deployId,
     errorParams,
     netlifyConfig,
+    cachedConfig,
     configOpts,
     logs,
     debug,

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -1,10 +1,10 @@
-import { resolveConfig, mergeConfigs, updateConfig, restoreConfig } from '@netlify/config'
+import { resolveConfig, restoreConfig, updateConfig } from '@netlify/config'
 import mapObj from 'map-obj'
 
 import { getChildEnv } from '../env/main.js'
 import { addApiErrorHandlers } from '../error/api.js'
 import { changeErrorType } from '../error/info.js'
-import { logBuildDir, logConfigPath, logConfig, logContext } from '../log/messages/config.js'
+import { logBuildDir, logConfig, logConfigPath, logContext } from '../log/messages/config.js'
 import { logConfigOnUpload, logHeadersOnUpload, logRedirectsOnUpload } from '../log/messages/mutations.js'
 import { measureDuration } from '../time/main.js'
 import { getPackageJson } from '../utils/package.js'

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -138,10 +138,14 @@ const logConfigInfo = function ({ logs, configPath, buildDir, netlifyConfig, con
 // change would create debug logs which would be too verbose.
 // Errors are propagated and assigned to the specific plugin or core step
 // which changed the configuration.
-export const resolveUpdatedConfig = async function (configOpts, configMutations, netlifyConfig) {
+export const resolveUpdatedConfig = async function (configOpts, configMutations, cachedConfig) {
   try {
-    const resolved = await resolveConfig({ ...configOpts, configMutations, debug: false })
-    return mergeConfigs([resolved, { config: netlifyConfig }], { concatenateArrays: true })
+    return await resolveConfig({
+      ...configOpts,
+      configMutations,
+      cachedConfig,
+      debug: false,
+    })
   } catch (error) {
     changeErrorType(error, 'resolveConfig', 'pluginValidation')
     throw error

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -1,4 +1,4 @@
-import { resolveConfig, updateConfig, restoreConfig } from '@netlify/config'
+import { resolveConfig, mergeConfigs, updateConfig, restoreConfig } from '@netlify/config'
 import mapObj from 'map-obj'
 
 import { getChildEnv } from '../env/main.js'
@@ -138,9 +138,10 @@ const logConfigInfo = function ({ logs, configPath, buildDir, netlifyConfig, con
 // change would create debug logs which would be too verbose.
 // Errors are propagated and assigned to the specific plugin or core step
 // which changed the configuration.
-export const resolveUpdatedConfig = async function (configOpts, configMutations) {
+export const resolveUpdatedConfig = async function (configOpts, configMutations, netlifyConfig) {
   try {
-    return await resolveConfig({ ...configOpts, configMutations, debug: false })
+    const resolved = await resolveConfig({ ...configOpts, configMutations, debug: false })
+    return mergeConfigs([resolved, { config: netlifyConfig }], { concatenateArrays: true })
   } catch (error) {
     changeErrorType(error, 'resolveConfig', 'pluginValidation')
     throw error

--- a/packages/build/src/steps/core_step.ts
+++ b/packages/build/src/steps/core_step.ts
@@ -27,6 +27,7 @@ export const fireCoreStep = async function ({
   errorParams,
   configOpts,
   netlifyConfig,
+  cachedConfig,
   configMutations,
   headersPath,
   redirectsPath,
@@ -65,6 +66,7 @@ export const fireCoreStep = async function ({
       branch,
       childEnv: childEnvA,
       netlifyConfig,
+      cachedConfig,
       nodePath,
       configMutations,
       headersPath,
@@ -86,6 +88,7 @@ export const fireCoreStep = async function ({
     } = await updateNetlifyConfig({
       configOpts,
       netlifyConfig,
+      cachedConfig,
       headersPath,
       redirectsPath,
       configMutations,

--- a/packages/build/src/steps/plugin.js
+++ b/packages/build/src/steps/plugin.js
@@ -26,6 +26,7 @@ export const firePluginStep = async function ({
   errorParams,
   configOpts,
   netlifyConfig,
+  cachedConfig,
   configMutations,
   headersPath,
   redirectsPath,
@@ -76,6 +77,7 @@ export const firePluginStep = async function ({
     } = await updateNetlifyConfig({
       configOpts,
       netlifyConfig,
+      cachedConfig,
       headersPath,
       packagePath,
       redirectsPath,

--- a/packages/build/src/steps/run_core_steps.ts
+++ b/packages/build/src/steps/run_core_steps.ts
@@ -108,6 +108,7 @@ const executeBuildStep = async function ({
 
   try {
     const { netlifyConfig: netlifyConfigA, configMutations } = await runBuildStep({
+      cachedConfig,
       netlifyConfig,
       buildDir,
       nodePath,
@@ -148,6 +149,7 @@ const executeBuildStep = async function ({
 }
 
 const runBuildStep = async function ({
+  cachedConfig,
   netlifyConfig,
   buildDir,
   nodePath,
@@ -170,6 +172,7 @@ const runBuildStep = async function ({
     nodePath,
     constants,
     netlifyConfig,
+    cachedConfig,
     logs,
     debug,
     timers: [],

--- a/packages/build/src/steps/run_step.ts
+++ b/packages/build/src/steps/run_step.ts
@@ -53,6 +53,7 @@ export const runStep = async function ({
   failedPlugins,
   configOpts,
   netlifyConfig,
+  cachedConfig,
   configMutations,
   headersPath,
   redirectsPath,
@@ -143,6 +144,7 @@ export const runStep = async function ({
       durationNs,
       metrics,
     } = await fireStep({
+      cachedConfig,
       event,
       childProcess,
       packageName,
@@ -304,6 +306,7 @@ const getFireStep = function (packageName: string, coreStepId?: string, event?: 
 }
 
 const tFireStep = function ({
+  cachedConfig,
   event,
   childProcess,
   packageName,
@@ -371,6 +374,7 @@ const tFireStep = function ({
       errorParams,
       configOpts,
       netlifyConfig,
+      cachedConfig,
       configMutations,
       headersPath,
       redirectsPath,
@@ -398,6 +402,7 @@ const tFireStep = function ({
     errorParams,
     configOpts,
     netlifyConfig,
+    cachedConfig,
     configMutations,
     headersPath,
     redirectsPath,

--- a/packages/build/src/steps/run_steps.js
+++ b/packages/build/src/steps/run_steps.js
@@ -11,6 +11,7 @@ import { runStep } from './run_step.js'
 // If an error arises, runs `onError` events.
 // Runs `onEnd` events at the end, whether an error was thrown or not.
 export const runSteps = async function ({
+  cachedConfig,
   steps,
   buildbotServerSocket,
   events,
@@ -134,6 +135,7 @@ export const runSteps = async function ({
         error,
         failedPlugins,
         configOpts,
+        cachedConfig,
         netlifyConfig: netlifyConfigA,
         configMutations,
         headersPath: headersPathA,

--- a/packages/build/src/steps/update_config.js
+++ b/packages/build/src/steps/update_config.js
@@ -13,6 +13,7 @@ import { logConfigMutations, systemLogConfigMutations } from '../log/messages/mu
 export const updateNetlifyConfig = async function ({
   configOpts,
   netlifyConfig,
+  cachedConfig,
   headersPath,
   redirectsPath,
   configMutations,
@@ -47,7 +48,7 @@ export const updateNetlifyConfig = async function ({
     config: netlifyConfigA,
     headersPath: headersPathA,
     redirectsPath: redirectsPathA,
-  } = await resolveUpdatedConfig(configOpts, mergedConfigMutations, netlifyConfig)
+  } = await resolveUpdatedConfig(configOpts, mergedConfigMutations, cachedConfig)
   logConfigOnUpdate({ logs, netlifyConfig: netlifyConfigA, debug })
 
   errorParams.netlifyConfig = netlifyConfigA

--- a/packages/build/src/steps/update_config.js
+++ b/packages/build/src/steps/update_config.js
@@ -42,18 +42,18 @@ export const updateNetlifyConfig = async function ({
     systemLogConfigMutations(systemLog, newConfigMutations)
   }
 
-  const configMutationsA = [...configMutations, ...newConfigMutations]
+  const mergedConfigMutations = [...configMutations, ...newConfigMutations]
   const {
     config: netlifyConfigA,
     headersPath: headersPathA,
     redirectsPath: redirectsPathA,
-  } = await resolveUpdatedConfig(configOpts, configMutationsA)
+  } = await resolveUpdatedConfig(configOpts, mergedConfigMutations, netlifyConfig)
   logConfigOnUpdate({ logs, netlifyConfig: netlifyConfigA, debug })
 
   errorParams.netlifyConfig = netlifyConfigA
   return {
     netlifyConfig: netlifyConfigA,
-    configMutations: configMutationsA,
+    configMutations: mergedConfigMutations,
     headersPath: headersPathA,
     redirectsPath: redirectsPathA,
   }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Needed for: https://linear.app/netlify/issue/CT-738/cli-should-use-framework-detection-and-install-runtime-for-build-and

When a build plugin did config mutations, it did not preserve the previous configuration (cachedConfig). As it read it up freshly from the `netlify.toml`


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
