### PR TITLE
fix: accept string literal keys in in-source config

### DIFF
--- a/packages/zip-it-and-ship-it/src/runtimes/node/parser/exports.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/parser/exports.ts
@@ -201,14 +201,21 @@ const parseConfigESMExport = (node: Statement) => {
  */
 const parseObject = (node: ObjectExpression) =>
   node.properties.reduce((acc, property): Record<string, unknown> => {
-    if (property.type !== 'ObjectProperty' || property.key.type !== 'Identifier') {
-      return acc
+    if (property.type === 'ObjectProperty' && property.key.type === 'Identifier') {
+      return {
+        ...acc,
+        [property.key.name]: parsePrimitive(property.value),
+      }
     }
 
-    return {
-      ...acc,
-      [property.key.name]: parsePrimitive(property.value),
+    if (property.type === 'ObjectProperty' && property.key.type === 'StringLiteral') {
+      return {
+        ...acc,
+        [property.key.value]: parsePrimitive(property.value),
+      }
     }
+
+    return acc
   }, {} as Record<string, unknown>)
 
 /**

--- a/packages/zip-it-and-ship-it/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/packages/zip-it-and-ship-it/tests/unit/runtimes/node/in_source_config.test.ts
@@ -378,6 +378,35 @@ describe('V2 API', () => {
         runtimeAPIVersion: 2,
       })
     })
+
+    test('Config export with string literal properties', () => {
+      const source = `
+      const handler = async () => ({ statusCode: 200, body: "Hello" })
+      const config = { "path": "/products/:id", excludedPath: "/products/jacket" }
+      export { config };
+      export default handler
+      `
+      const isc = parseSource(source, options)
+      expect(isc).toEqual({
+        config: { path: ['/products/:id'], excludedPath: ['/products/jacket'] },
+        excludedRoutes: [
+          {
+            literal: '/products/jacket',
+            pattern: '/products/jacket',
+          },
+        ],
+        inputModuleFormat: 'esm',
+        routes: [
+          {
+            expression: '^\\/products(?:\\/([^\\/]+?))\\/?$',
+            methods: [],
+            pattern: '/products/:id',
+            prefer_static: undefined,
+          },
+        ],
+        runtimeAPIVersion: 2,
+      })
+    })
   })
 
   describe('`scheduled` property', () => {


### PR DESCRIPTION
#### Summary

Currently, this works in a function:

```js
export const config = {
  path: "/foo"
}
```

... but this doesn't:

```js
export const config = {
  "path": "/foo"
}
```

This PR fixes that.