### PR TITLE
fix: disable config discovery when executing "Deno code" in node_modules directory

### DIFF
--- a/packages/edge-bundler/node/config.ts
+++ b/packages/edge-bundler/node/config.ts
@@ -104,6 +104,8 @@ export const getFunctionConfig = async ({
       `--allow-write=${collector.path}`,
       '--quiet',
       `--import-map=${importMap.toDataURL()}`,
+      '--no-config',
+      '--node-modules-dir=false',
       extractorPath,
       pathToFileURL(func.path).href,
       pathToFileURL(collector.path).href,


### PR DESCRIPTION
#### Summary

Deno doesn't support https specifiers or TypeScript in node_modules directories. The `@netlify/edge-bundler` package has code with https specifiers and TypeScript in it.

Take the following directory structure:

```
-my_project
  - node_modules
    - @netlify/edge-bundler
      - package.json
      - deno
        - config.ts
  - package.json
```

When executing `my_project/node_modules/@netlify/edge-bundler/deno/config.ts`, Deno would previously resolve the project root as `my_project/node_modules/@netlify/edge-bundler` due to the package.json in that folder. In Deno 1.45, Deno has gotten smarter though and resolves the project root to `my_project`. This change fixes a lot of previously broken code when executing entrypoints in node_modules directories, but causes an error for `@netlify/edge-bundler`.

To fix this, we can disable config file resolution when executing the "Deno code" in the node_modules directory using `--no-config`. Although not really necessary since config file resolution is disabled, I've set `--node-modules-dir=false` for good measure to disable the concept of a node_modules directory for the code. This change will also cause things to be a few ms faster because Deno doesn't need to do config file/workspace discovery.

---

Can't run the build on my local machine because I'm on a Windows machine atm (it fails with non-cross platform code), so using the CI for testing.

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
