### PR TITLE
fix: leverage the internal config inside the getEnv as well

### DIFF
--- a/packages/config/src/env/main.ts
+++ b/packages/config/src/env/main.ts
@@ -125,7 +125,7 @@ const getGeneralEnv = async function ({
 /**
  * Retrieve internal environment variables (needed for the CLI).
  * Based on the cached environment, it returns the internal environment variables.
- * Internal environment variables are those that are set by the CLI and are not retrieved by the envelope or the API.
+ * Internal environment variables are those that are set by the CLI and are not retrieved by Envelope or the API.
  */
 const getInternalEnv = function (
   cachedEnv: Record<string, { sources: string[]; value: string }>,

--- a/packages/config/src/env/main.ts
+++ b/packages/config/src/env/main.ts
@@ -24,11 +24,13 @@ export const getEnv = async function ({
   deployId,
   buildId,
   context,
+  cachedEnv,
 }) {
   if (mode === 'buildbot') {
     return {}
   }
 
+  const internalEnv = getInternalEnv(cachedEnv)
   const generalEnv = await getGeneralEnv({ siteInfo, buildDir, branch, deployId, buildId, context })
   const [accountEnv, addonsEnv, uiEnv, configFileEnv] = await getUserEnv({
     api,
@@ -46,6 +48,7 @@ export const getEnv = async function ({
     { key: 'addons', values: addonsEnv },
     { key: 'account', values: accountEnv },
     { key: 'general', values: generalEnv },
+    { key: 'internal', values: internalEnv },
   ]
 
   // A hash mapping names of environment variables to objects containing the following properties:
@@ -117,6 +120,22 @@ const getGeneralEnv = async function ({
     GATSBY_TELEMETRY_DISABLED: '1',
     NEXT_TELEMETRY_DISABLED: '1',
   })
+}
+
+/**
+ * Retrieve internal environment variables (needed for the CLI).
+ * Based on the cached environment, it returns the internal environment variables.
+ * Internal environment variables are those that are set by the CLI and are not retrieved by the envelope or the API.
+ */
+const getInternalEnv = function (
+  cachedEnv: Record<string, { sources: string[]; value: string }>,
+): Record<string, string> {
+  return Object.entries(cachedEnv).reduce((prev, [key, { sources, value }]) => {
+    if (sources.includes('internal')) {
+      prev[key] = value
+    }
+    return prev
+  }, {} as Record<string, string>)
 }
 
 const getDeployUrls = function ({

--- a/packages/config/src/main.ts
+++ b/packages/config/src/main.ts
@@ -118,7 +118,7 @@ export const resolveConfig = async function (opts) {
     deployId,
     buildId,
     context,
-    cachedEnv: parsedCachedConfig.env,
+    cachedEnv: parsedCachedConfig?.env || {},
   })
 
   // @todo Remove in the next major version.

--- a/packages/config/src/main.ts
+++ b/packages/config/src/main.ts
@@ -118,6 +118,7 @@ export const resolveConfig = async function (opts) {
     deployId,
     buildId,
     context,
+    cachedEnv: parsedCachedConfig.env,
   })
 
   // @todo Remove in the next major version.


### PR DESCRIPTION

🎉 Thanks for submitting a pull request! 🎉

#### Summary

leverage the internal config inside the getEnv as well, the internal config is set through the cached config by the CLI


Needed for: https://linear.app/netlify/issue/CT-738/cli-should-use-framework-detection-and-install-runtime-for-build-and

This is needed in addition to: https://github.com/netlify/build/pull/5761

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
