### PR TITLE
fix: missing type-def

### DIFF
--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -7,7 +7,7 @@
   "main": "./lib/main.js",
   "types": "./lib/main.d.ts",
   "files": [
-    "lib/**/*.{js,ts}",
+    "lib/**/*.{js,ts}"
   ],
   "author": "Netlify Inc.",
   "scripts": {

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -7,7 +7,8 @@
   "main": "./lib/main.js",
   "types": "./lib.main.d.ts",
   "files": [
-    "lib/**/*.js"
+    "lib/**/*.js",
+    "lib.main.d.ts"
   ],
   "author": "Netlify Inc.",
   "scripts": {

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -7,7 +7,7 @@
   "main": "./lib/main.js",
   "types": "./lib/main.d.ts",
   "files": [
-    "lib/**/*.{js,ts}"
+    "lib/**/*.{js,d.ts}"
   ],
   "author": "Netlify Inc.",
   "scripts": {

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -5,10 +5,9 @@
   "type": "module",
   "exports": "./lib/main.js",
   "main": "./lib/main.js",
-  "types": "./lib.main.d.ts",
+  "types": "./lib/main.d.ts",
   "files": [
-    "lib/**/*.js",
-    "lib.main.d.ts"
+    "lib/**/*.{js,ts}",
   ],
   "author": "Netlify Inc.",
   "scripts": {


### PR DESCRIPTION
`@netlify/cache-utils` does not ship with its own .d.ts file even though NPM says it does. I checked the module and the package.json seems to list the file, but I believe it might not be uploaded to NPM as the `files` array in `package.json` excludes that path. This PR adds the path to the file in the `files` array which should fix this.
