### PR TITLE
ci: add e2e testing pipeline to the reopsitory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ workflows:
                 packages:
                   '@netlify/config': packages/config
                   '@netlify/build': packages/build
-                  '@netlify/zip-it-and-ship-it': packages/zip-it-and-ship-it
                   '@netlify/build-info': packages/build-info
                 installCommands:
                   - npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  e2e: netlify/e2e@1
+
 workflows:
   release:
     jobs:
@@ -30,6 +33,19 @@ workflows:
   'Test & Check 🕵️‍♀️':
     jobs:
       - formatting
+      - e2e/test:
+          context: [shared-secrets, clone-repo, netlify-e2e]
+          config_yml: |
+            links:
+              - repo: netlify/build
+                branch: << pipeline.git.branch >>
+                packages:
+                  '@netlify/config': packages/config
+                  '@netlify/build': packages/build
+                  '@netlify/zip-it-and-ship-it': packages/zip-it-and-ship-it
+                  '@netlify/build-info': packages/build-info
+                installCommands:
+                  - npm run build
 
 executors:
   node:


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://linear.app/netlify/issue/FRP-770/lack-of-runtime-integration-tests-for-the-build-pipeline

Depends on: https://github.com/netlify/run/pull/2

This adds the netlify e2e test pipeline to the build repository using remlink to mock out the npm packages (hot-swapping) on a Pull Request. 

This deploys sites with the modified (hot-swapped dependencies) and tests against them. The tests are git cloned from the `netlify/run` repository main branch using the private CircleCI orb.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
