### PR TITLE
feat(config): return account id from config in offline mode

### DIFF
--- a/packages/config/src/api/site_info.ts
+++ b/packages/config/src/api/site_info.ts
@@ -44,7 +44,10 @@ export const getSiteInfo = async function ({
 
   if (useV2Endpoint) {
     if (api === undefined || mode === 'buildbot' || testEnv) {
-      const siteInfo = siteId === undefined ? {} : { id: siteId }
+      const siteInfo: { id?: string; account_id?: string } = {}
+
+      if (siteId !== undefined) siteInfo.id = siteId
+      if (accountId !== undefined) siteInfo.account_id = accountId
 
       const integrations =
         mode === 'buildbot' && !offline
@@ -73,7 +76,10 @@ export const getSiteInfo = async function ({
   }
 
   if (api === undefined || mode === 'buildbot' || testEnv) {
-    const siteInfo = siteId === undefined ? {} : { id: siteId }
+    const siteInfo: { id?: string; account_id?: string } = {}
+
+    if (siteId !== undefined) siteInfo.id = siteId
+    if (accountId !== undefined) siteInfo.account_id = accountId
 
     const integrations = mode === 'buildbot' && !offline ? await getIntegrations({ siteId, testOpts, offline }) : []
 

--- a/packages/config/tests/api/tests.js
+++ b/packages/config/tests/api/tests.js
@@ -121,6 +121,15 @@ test('--site-id', async (t) => {
   t.snapshot(normalizeOutput(output))
 })
 
+test('--account-id in offline and buildbot mode', async (t) => {
+  const output = await new Fixture('./fixtures/empty')
+    .withFlags({ accountId: 'test-account', offline: true, mode: 'buildbot' })
+    .runWithConfig([FETCH_INTEGRATIONS_EMPTY_RESPONSE])
+  const config = JSON.parse(output)
+
+  t.is(config.siteInfo.account_id, 'test-account')
+})
+
 test('NETLIFY_SITE_ID environment variable', async (t) => {
   const output = await new Fixture('./fixtures/empty')
     .withEnv({ NETLIFY_SITE_ID: 'test' })
@@ -333,7 +342,7 @@ test('Integrations are not returned if offline', async (t) => {
   t.assert(config.integrations.length === 0)
 })
 
-test('Integrations are returned if feature flag is false and mode is buildbot', async (t) => {
+test('Integrations and account id are returned if feature flag is false and mode is buildbot', async (t) => {
   const { output } = await new Fixture('./fixtures/base')
     .withFlags({
       siteId: 'test',
@@ -346,10 +355,14 @@ test('Integrations are returned if feature flag is false and mode is buildbot', 
   const config = JSON.parse(output)
 
   t.assert(config.integrations)
-  t.assert(config.integrations.length === 1)
-  t.assert(config.integrations[0].slug === 'test')
-  t.assert(config.integrations[0].version === 'so-cool')
-  t.assert(config.integrations[0].has_build === true)
+  t.is(config.integrations.length, 1)
+  t.is(config.integrations[0].slug, 'test')
+  t.is(config.integrations[0].version, 'so-cool')
+  t.is(config.integrations[0].has_build, true)
+
+  // account id is also available
+  t.assert(config.siteInfo)
+  t.is(config.siteInfo.account_id, 'account1')
 })
 
 test('Integrations are returned if feature flag is false and mode is dev', async (t) => {
@@ -370,7 +383,7 @@ test('Integrations are returned if feature flag is false and mode is dev', async
   t.assert(config.integrations[0].has_build === true)
 })
 
-test('Integrations are returned if flag is true for site and mode is buildbot', async (t) => {
+test('Integrations and account id are returned if flag is true for site and mode is buildbot', async (t) => {
   const { output } = await new Fixture('./fixtures/base')
     .withFlags({
       siteId: 'test',
@@ -386,10 +399,14 @@ test('Integrations are returned if flag is true for site and mode is buildbot', 
   const config = JSON.parse(output)
 
   t.assert(config.integrations)
-  t.assert(config.integrations.length === 1)
-  t.assert(config.integrations[0].slug === 'test')
-  t.assert(config.integrations[0].version === 'so-cool')
-  t.assert(config.integrations[0].has_build === true)
+  t.is(config.integrations.length, 1)
+  t.is(config.integrations[0].slug, 'test')
+  t.is(config.integrations[0].version, 'so-cool')
+  t.is(config.integrations[0].has_build, true)
+
+  // account id is also available
+  t.assert(config.siteInfo)
+  t.is(config.siteInfo.account_id, 'account1')
 })
 
 test('Integrations are returned if flag is true for site and mode is dev', async (t) => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes FRP-1269 - https://linear.app/netlify/issue/FRP-1269/information-request-is-the-account-id-available-for-build-plugins.

By default, when running in offline/buildbot mode netlify/config doesn't issue any requests to the get site endpoint. This means that until now the resulting `@netlify/config` didn't have anything else besides the `siteId` under the `siteInfo` object. This change will make sure we also return the `account_id` in accordance with the `getSite` operation - https://open-api.netlify.com/#tag/site/operation/getSite - if `@netlify/config` has been provided with an `account-id` through cli param.

The most important outcome of this change is that it will allow plugins to access `account_id` at execution time in buildbot through the `netlifyConfig` object:
- https://github.com/netlify/build/blob/d5ef4079308264d6175731fd9d3ff1c2ae1e1200/packages/build/src/plugins/child/run.js#L29

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
