### PR TITLE
fix(build-info): fix detection of Remix and Hydrogen sites

### DIFF
--- a/packages/build-info/src/frameworks/hydrogen.test.ts
+++ b/packages/build-info/src/frameworks/hydrogen.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, expect, test } from 'vitest'
+
+import { mockFileSystem } from '../../tests/mock-file-system.js'
+import { NodeFS } from '../node/file-system.js'
+import { Project } from '../project.js'
+
+beforeEach((ctx) => {
+  ctx.fs = new NodeFS()
+})
+
+test('detects a Hydrogen v2 site using the Remix Classic Compiler', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'remix.config.js': '',
+    'package.json': JSON.stringify({
+      scripts: {
+        build: 'remix build',
+        dev: 'remix dev --manual -c "netlify dev"',
+        preview: 'netlify serve',
+      },
+      dependencies: {
+        '@netlify/edge-functions': '^2.2.0',
+        '@netlify/remix-edge-adapter': '^3.1.0',
+        '@netlify/remix-runtime': '^2.1.0',
+        '@remix-run/react': '^2.2.0',
+        '@shopify/cli': '3.50.0',
+        '@shopify/cli-hydrogen': '^6.0.0',
+        '@shopify/hydrogen': '^2023.10.0',
+        react: '^18.2.0',
+        'react-dom': '^18.2.0',
+      },
+      devDependencies: {
+        '@remix-run/dev': '^2.2.0',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('remix')
+  expect(detectedFrameworks).not.toContain('vite')
+
+  expect(detected?.[0]?.id).toBe('hydrogen')
+  expect(detected?.[0]?.build?.command).toBe('remix build')
+  expect(detected?.[0]?.build?.directory).toBe('public')
+  expect(detected?.[0]?.dev?.command).toBe('remix dev --manual -c "netlify dev"')
+  expect(detected?.[0]?.dev?.port).toBeUndefined()
+})
+
+test('detects a Hydrogen v2 site using Remix Vite', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'vite.config.ts': '',
+    'package.json': JSON.stringify({
+      scripts: {
+        build: 'remix vite:build',
+        dev: 'shopify hydrogen dev --codegen',
+        preview: 'netlify serve',
+      },
+      dependencies: {
+        '@netlify/edge-functions': '^2.10.0',
+        '@netlify/remix-edge-adapter': '^3.4.0',
+        '@netlify/remix-runtime': '^2.3.0',
+        '@remix-run/react': '^2.11.2',
+        '@shopify/hydrogen': '^2024.7.4',
+        react: '^18.2.0',
+        'react-dom': '^18.2.0',
+      },
+      devDependencies: {
+        '@remix-run/dev': '^2.11.2',
+        '@shopify/cli': '^3.66.1',
+        '@shopify/hydrogen-codegen': '^0.3.1',
+        vite: '^5.4.3',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('remix')
+  expect(detectedFrameworks).not.toContain('vite')
+
+  expect(detected?.[0]?.id).toBe('hydrogen')
+  expect(detected?.[0]?.build?.command).toBe('remix vite:build')
+  expect(detected?.[0]?.build?.directory).toBe('dist/client')
+  expect(detected?.[0]?.dev?.command).toBe('shopify hydrogen dev')
+  expect(detected?.[0]?.dev?.port).toBe(5173)
+})

--- a/packages/build-info/src/frameworks/hydrogen.ts
+++ b/packages/build-info/src/frameworks/hydrogen.ts
@@ -22,6 +22,8 @@ const VITE_DEV = {
   port: 5173,
 }
 const VITE_BUILD = {
+  // This should be `shopify hydrogen build` but we use this as a workaround for
+  // https://github.com/Shopify/hydrogen/issues/2496 and https://github.com/Shopify/hydrogen/issues/2497.
   command: 'remix vite:build',
   directory: 'dist/client',
 }

--- a/packages/build-info/src/frameworks/hydrogen.ts
+++ b/packages/build-info/src/frameworks/hydrogen.ts
@@ -44,18 +44,14 @@ export class Hydrogen extends BaseFramework implements Framework {
     if (this.detected) {
       const viteDetection = await this.detectConfigFile(VITE_CONFIG_FILES)
       if (viteDetection) {
-        // This site will otherwise get detected as both Remix (Vite) and Hydrogen (Vite). There is no other mechanism
-        // we can use to prioritize Hydrogen. TODO(serhalp) Add more fine-grained levels to `Accuracy`, such as
-        // `Framework`, `MetaFramework`, and `MetaMetaFramework`?
-        this.detected = { ...viteDetection, accuracy: Accuracy.Forced }
+        this.detected = viteDetection
         this.dev = VITE_DEV
         this.build = VITE_BUILD
         return this as DetectedFramework
       }
       const classicCompilerDetection = await this.detectConfigFile(CLASSIC_COMPILER_CONFIG_FILES)
       if (classicCompilerDetection) {
-        // See comment above.
-        this.detected = { ...classicCompilerDetection, accuracy: Accuracy.Forced }
+        this.detected = classicCompilerDetection
         this.dev = CLASSIC_COMPILER_DEV
         this.build = CLASSIC_COMPILER_BUILD
         return this as DetectedFramework

--- a/packages/build-info/src/frameworks/hydrogen.ts
+++ b/packages/build-info/src/frameworks/hydrogen.ts
@@ -1,4 +1,30 @@
-import { BaseFramework, Category, Framework } from './framework.js'
+import { Accuracy, BaseFramework, Category, DetectedFramework, Framework } from './framework.js'
+
+const CLASSIC_COMPILER_CONFIG_FILES = ['remix.config.js']
+const CLASSIC_COMPILER_DEV = {
+  command: 'remix dev --manual -c "netlify dev"',
+}
+const CLASSIC_COMPILER_BUILD = {
+  command: 'remix build',
+  directory: 'public',
+}
+
+const VITE_CONFIG_FILES = [
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.cjs',
+  'vite.config.ts',
+  'vite.config.mts',
+  'vite.config.cts',
+]
+const VITE_DEV = {
+  command: 'shopify hydrogen dev',
+  port: 5173,
+}
+const VITE_BUILD = {
+  command: 'remix vite:build',
+  directory: 'dist/client',
+}
 
 export class Hydrogen extends BaseFramework implements Framework {
   readonly id = 'hydrogen'
@@ -6,20 +32,36 @@ export class Hydrogen extends BaseFramework implements Framework {
   npmDependencies = ['@shopify/hydrogen']
   category = Category.SSG
 
-  dev = {
-    command: 'vite',
-    port: 3000,
-    pollingStrategies: [{ name: 'TCP' }],
-  }
-
-  build = {
-    command: 'npm run build',
-    directory: 'dist/client',
-  }
-
   logo = {
     default: '/logos/hydrogen/default.svg',
     light: '/logos/hydrogen/default.svg',
     dark: '/logos/hydrogen/default.svg',
+  }
+
+  async detect(): Promise<DetectedFramework | undefined> {
+    await super.detect()
+
+    if (this.detected) {
+      const viteDetection = await this.detectConfigFile(VITE_CONFIG_FILES)
+      if (viteDetection) {
+        // This site will otherwise get detected as both Remix (Vite) and Hydrogen (Vite). There is no other mechanism
+        // we can use to prioritize Hydrogen. TODO(serhalp) Add more fine-grained levels to `Accuracy`, such as
+        // `Framework`, `MetaFramework`, and `MetaMetaFramework`?
+        this.detected = { ...viteDetection, accuracy: Accuracy.Forced }
+        this.dev = VITE_DEV
+        this.build = VITE_BUILD
+        return this as DetectedFramework
+      }
+      const classicCompilerDetection = await this.detectConfigFile(CLASSIC_COMPILER_CONFIG_FILES)
+      if (classicCompilerDetection) {
+        // See comment above.
+        this.detected = { ...classicCompilerDetection, accuracy: Accuracy.Forced }
+        this.dev = CLASSIC_COMPILER_DEV
+        this.build = CLASSIC_COMPILER_BUILD
+        return this as DetectedFramework
+      }
+      // If neither config file exists, it can't be a valid Hydrogen site for Netlify anyway.
+      return
+    }
   }
 }

--- a/packages/build-info/src/frameworks/hydrogen.ts
+++ b/packages/build-info/src/frameworks/hydrogen.ts
@@ -1,4 +1,4 @@
-import { Accuracy, BaseFramework, Category, DetectedFramework, Framework } from './framework.js'
+import { BaseFramework, Category, DetectedFramework, Framework } from './framework.js'
 
 const CLASSIC_COMPILER_CONFIG_FILES = ['remix.config.js']
 const CLASSIC_COMPILER_DEV = {

--- a/packages/build-info/src/frameworks/remix.test.ts
+++ b/packages/build-info/src/frameworks/remix.test.ts
@@ -7,8 +7,7 @@ import { Project } from '../project.js'
 beforeEach((ctx) => {
   ctx.fs = new NodeFS()
 })
-
-test.each([
+;[
   [
     'with origin SSR',
     {
@@ -36,7 +35,7 @@ test.each([
         },
       }),
     },
-  ],
+  ] as const,
   [
     'with edge SSR',
     {
@@ -65,9 +64,9 @@ test.each([
         },
       }),
     },
-  ],
-])('detects a Remix Vite site %s', (_, files) => {
-  test(async ({ fs }) => {
+  ] as const,
+].forEach(([description, files]) =>
+  test(`detects a Remix Vite site ${description}`, async ({ fs }) => {
     const cwd = mockFileSystem(files)
     const detected = await new Project(fs, cwd).detectFrameworks()
 
@@ -79,10 +78,9 @@ test.each([
     expect(detected?.[0]?.build?.directory).toBe('build/client')
     expect(detected?.[0]?.dev?.command).toBe('remix vite:dev')
     expect(detected?.[0]?.dev?.port).toBe(5173)
-  })
-})
-
-test.each([
+  }),
+)
+;[
   [
     'with origin SSR',
     {
@@ -109,7 +107,7 @@ test.each([
         },
       }),
     },
-  ],
+  ] as const,
   [
     'with edge SSR',
     {
@@ -137,7 +135,7 @@ test.each([
         },
       }),
     },
-  ],
+  ] as const,
   [
     'with origin SSR via our legacy packages',
     {
@@ -163,7 +161,7 @@ test.each([
         },
       }),
     },
-  ],
+  ] as const,
   [
     'with edge SSR via our legacy packages',
     {
@@ -189,7 +187,7 @@ test.each([
         },
       }),
     },
-  ],
+  ] as const,
   [
     'with origin SSR and the legacy remix package',
     {
@@ -212,7 +210,7 @@ test.each([
         },
       }),
     },
-  ],
+  ] as const,
   [
     'with edge SSR and the legacy remix package',
     {
@@ -235,9 +233,9 @@ test.each([
         },
       }),
     },
-  ],
-])('detects a Remix Classic Compiler site %s', (_, files) => {
-  test(async ({ fs }) => {
+  ] as const,
+].forEach(([description, files]) =>
+  test(`detects a Remix Classic Compiler site ${description}`, async ({ fs }) => {
     const cwd = mockFileSystem(files)
     const detected = await new Project(fs, cwd).detectFrameworks()
 
@@ -249,8 +247,8 @@ test.each([
     expect(detected?.[0]?.build?.directory).toBe('public')
     expect(detected?.[0]?.dev?.command).toBe('remix watch')
     expect(detected?.[0]?.dev?.port).toBeUndefined()
-  })
-})
+  }),
+)
 
 test('does not detect an invalid Remix site with no config file', async ({ fs }) => {
   const cwd = mockFileSystem({

--- a/packages/build-info/src/frameworks/remix.test.ts
+++ b/packages/build-info/src/frameworks/remix.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, expect, test } from 'vitest'
+
+import { mockFileSystem } from '../../tests/mock-file-system.js'
+import { NodeFS } from '../node/file-system.js'
+import { Project } from '../project.js'
+
+beforeEach((ctx) => {
+  ctx.fs = new NodeFS()
+})
+
+test.each([
+  [
+    'with origin SSR',
+    {
+      'vite.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix vite:build',
+          dev: 'remix vite:dev',
+          start: 'remix-serve ./build/server/index.js',
+        },
+        dependencies: {
+          '@remix-run/node': '^2.9.2',
+          '@remix-run/react': '^2.9.2',
+          '@remix-run/serve': '^2.9.2',
+          react: '^18.2.0',
+          'react-dom': '^18.2.0',
+        },
+        devDependencies: {
+          '@netlify/remix-adapter': '^2.4.0',
+          '@remix-run/dev': '^2.9.2',
+          '@types/react': '^18.2.20',
+          '@types/react-dom': '^18.2.7',
+          vite: '^5.0.0',
+          'vite-tsconfig-paths': '^4.2.1',
+        },
+      }),
+    },
+  ],
+  [
+    'with edge SSR',
+    {
+      'vite.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix vite:build',
+          dev: 'remix vite:dev',
+          start: 'remix-serve ./build/server/index.js',
+        },
+        dependencies: {
+          '@netlify/remix-runtime': '^2.3.0',
+          '@remix-run/node': '^2.9.2',
+          '@remix-run/react': '^2.9.2',
+          '@remix-run/serve': '^2.9.2',
+          react: '^18.2.0',
+          'react-dom': '^18.2.0',
+        },
+        devDependencies: {
+          '@netlify/remix-edge-adapter': '^3.3.0',
+          '@remix-run/dev': '^2.9.2',
+          '@types/react': '^18.2.20',
+          '@types/react-dom': '^18.2.7',
+          vite: '^5.0.0',
+          'vite-tsconfig-paths': '^4.2.1',
+        },
+      }),
+    },
+  ],
+])('detects a Remix Vite site %s', (_, files) => {
+  test(async ({ fs }) => {
+    const cwd = mockFileSystem(files)
+    const detected = await new Project(fs, cwd).detectFrameworks()
+
+    const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+    expect(detectedFrameworks).not.toContain('vite')
+
+    expect(detected?.[0]?.id).toBe('remix')
+    expect(detected?.[0]?.build?.command).toBe('remix vite:build')
+    expect(detected?.[0]?.build?.directory).toBe('build/client')
+    expect(detected?.[0]?.dev?.command).toBe('remix vite:dev')
+    expect(detected?.[0]?.dev?.port).toBe(5173)
+  })
+})
+
+test.each([
+  [
+    'with origin SSR',
+    {
+      'remix.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@netlify/functions': '^2.8.1',
+          '@remix-run/css-bundle': '^2.9.2',
+          '@remix-run/node': '^2.9.2',
+          '@remix-run/react': '^2.9.2',
+          react: '^18.2.0',
+          'react-dom': '^18.2.0',
+        },
+        devDependencies: {
+          '@netlify/remix-adapter': '^2.4.0',
+          '@remix-run/dev': '^2.9.2',
+          '@remix-run/serve': '^2.9.2',
+        },
+      }),
+    },
+  ],
+  [
+    'with edge SSR',
+    {
+      'remix.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@netlify/functions': '^2.8.1',
+          '@netlify/remix-runtime': '^2.3.0',
+          '@remix-run/css-bundle': '^2.9.2',
+          '@remix-run/node': '^2.9.2',
+          '@remix-run/react': '^2.9.2',
+          react: '^18.2.0',
+          'react-dom': '^18.2.0',
+        },
+        devDependencies: {
+          '@netlify/remix-edge-adapter': '^3.3.0',
+          '@remix-run/dev': '^2.9.2',
+          '@remix-run/serve': '^2.9.2',
+        },
+      }),
+    },
+  ],
+  [
+    'with origin SSR via our legacy packages',
+    {
+      'remix.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@remix-run/netlify': '1.7.4',
+          '@remix-run/node': '1.7.4',
+          '@remix-run/react': '1.7.4',
+          react: '18.2.0',
+          'react-dom': '18.2.0',
+        },
+        devDependencies: {
+          '@netlify/functions': '^1.0.0',
+          '@remix-run/dev': '1.7.4',
+          '@remix-run/serve': '1.7.4',
+        },
+      }),
+    },
+  ],
+  [
+    'with edge SSR via our legacy packages',
+    {
+      'remix.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@remix-run/netlify-edge': '1.7.4',
+          '@remix-run/node': '1.7.4',
+          '@remix-run/react': '1.7.4',
+          react: '18.2.0',
+          'react-dom': '18.2.0',
+        },
+        devDependencies: {
+          '@netlify/functions': '^1.0.0',
+          '@remix-run/dev': '1.7.4',
+          '@remix-run/serve': '1.7.4',
+        },
+      }),
+    },
+  ],
+  [
+    'with origin SSR and the legacy remix package',
+    {
+      'remix.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@remix-run/netlify': '1.7.4',
+          remix: '1.7.4',
+          react: '18.2.0',
+          'react-dom': '18.2.0',
+        },
+        devDependencies: {
+          '@netlify/functions': '^1.0.0',
+        },
+      }),
+    },
+  ],
+  [
+    'with edge SSR and the legacy remix package',
+    {
+      'remix.config.js': '',
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@remix-run/netlify-edge': '1.7.4',
+          remix: '1.7.4',
+          react: '18.2.0',
+          'react-dom': '18.2.0',
+        },
+        devDependencies: {
+          '@netlify/functions': '^1.0.0',
+        },
+      }),
+    },
+  ],
+])('detects a Remix Classic Compiler site %s', (_, files) => {
+  test(async ({ fs }) => {
+    const cwd = mockFileSystem(files)
+    const detected = await new Project(fs, cwd).detectFrameworks()
+
+    const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+    expect(detectedFrameworks).not.toContain('vite')
+
+    expect(detected?.[0]?.id).toBe('remix')
+    expect(detected?.[0]?.build?.command).toBe('remix build')
+    expect(detected?.[0]?.build?.directory).toBe('public')
+    expect(detected?.[0]?.dev?.command).toBe('remix watch')
+    expect(detected?.[0]?.dev?.port).toBeUndefined()
+  })
+})
+
+test('does not detect an invalid Remix site with no config file', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': JSON.stringify({
+      scripts: {
+        build: 'remix vite:build',
+        dev: 'remix vite:dev',
+        start: 'remix-serve ./build/server/index.js',
+      },
+      dependencies: {
+        '@netlify/remix-runtime': '^2.3.0',
+        '@remix-run/node': '^2.9.2',
+        '@remix-run/react': '^2.9.2',
+        '@remix-run/serve': '^2.9.2',
+        react: '^18.2.0',
+        'react-dom': '^18.2.0',
+      },
+      devDependencies: {
+        '@netlify/remix-edge-adapter': '^3.3.0',
+        '@remix-run/dev': '^2.9.2',
+        '@types/react': '^18.2.20',
+        '@types/react-dom': '^18.2.7',
+        vite: '^5.0.0',
+        'vite-tsconfig-paths': '^4.2.1',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('remix')
+})

--- a/packages/build-info/src/frameworks/remix.ts
+++ b/packages/build-info/src/frameworks/remix.ts
@@ -42,6 +42,7 @@ export class Remix extends BaseFramework implements Framework {
     '@remix-run/netlify',
     '@remix-run/netlify-edge',
   ]
+  excludedNpmDependencies = ['@shopify/hydrogen']
   category = Category.SSG
 
   logo = {

--- a/packages/build-info/src/frameworks/remix.ts
+++ b/packages/build-info/src/frameworks/remix.ts
@@ -1,24 +1,75 @@
-import { BaseFramework, Category, Framework } from './framework.js'
+import { BaseFramework, Category, DetectedFramework, Framework } from './framework.js'
+
+const CLASSIC_COMPILER_CONFIG_FILES = ['remix.config.js']
+const CLASSIC_COMPILER_DEV = {
+  command: 'remix watch',
+}
+const CLASSIC_COMPILER_BUILD = {
+  command: 'remix build',
+  directory: 'public',
+}
+
+const VITE_CONFIG_FILES = [
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.cjs',
+  'vite.config.ts',
+  'vite.config.mts',
+  'vite.config.cts',
+]
+const VITE_DEV = {
+  command: 'remix vite:dev',
+  port: 5173,
+}
+const VITE_BUILD = {
+  command: 'remix vite:build',
+  directory: 'build/client',
+}
 
 export class Remix extends BaseFramework implements Framework {
   readonly id = 'remix'
   name = 'Remix'
-  npmDependencies = ['remix', '@remix-run/netlify', '@remix-run/netlify-edge']
-  configFiles = ['remix.config.js']
+  npmDependencies = [
+    '@remix-run/react',
+    '@remix-run/dev',
+    '@remix-run/server-runtime',
+    '@netlify/remix-adapter',
+    '@netlify/remix-edge-adapter',
+    '@netlify/remix-runtime',
+    // Deprecated package name (deprecated in 1.6, removed in 2.0)
+    'remix',
+    // Deprecated Netlify packages
+    '@remix-run/netlify',
+    '@remix-run/netlify-edge',
+  ]
   category = Category.SSG
-
-  dev = {
-    command: 'remix watch',
-  }
-
-  build = {
-    command: 'remix build',
-    directory: 'public',
-  }
 
   logo = {
     default: '/logos/remix/default.svg',
     light: '/logos/remix/light.svg',
     dark: '/logos/remix/dark.svg',
+  }
+
+  async detect(): Promise<DetectedFramework | undefined> {
+    await super.detect()
+
+    if (this.detected) {
+      const viteDetection = await this.detectConfigFile(VITE_CONFIG_FILES)
+      if (viteDetection) {
+        this.detected = viteDetection
+        this.dev = VITE_DEV
+        this.build = VITE_BUILD
+        return this as DetectedFramework
+      }
+      const classicCompilerDetection = await this.detectConfigFile(CLASSIC_COMPILER_CONFIG_FILES)
+      if (classicCompilerDetection) {
+        this.detected = classicCompilerDetection
+        this.dev = CLASSIC_COMPILER_DEV
+        this.build = CLASSIC_COMPILER_BUILD
+        return this as DetectedFramework
+      }
+      // If neither config file exists, it can't be a valid Remix site for Netlify anyway.
+      return
+    }
   }
 }

--- a/packages/build-info/src/frameworks/vite.ts
+++ b/packages/build-info/src/frameworks/vite.ts
@@ -5,6 +5,9 @@ export class Vite extends BaseFramework implements Framework {
   name = 'Vite'
   npmDependencies = ['vite']
   excludedNpmDependencies = [
+    '@remix-run/react',
+    '@remix-run/dev',
+    '@remix-run/server-runtime',
     '@shopify/hydrogen',
     '@builder.io/qwik',
     'solid-start',


### PR DESCRIPTION
We noticed recently that the framework detection wasn't working correctly for all Remix sites. This leads to poor DX but it also affects our reporting that informs framework usage on the platform.

So, this has gotten pretty complex 😓:
- Remix sites can either use Vite or the Remix Classic Compiler
  - These use different config files, different dev and build config, but almost identical npm dependencies (plus `vite` in the Remix Vite case)
- Hydrogen (v2) uses Remix and, as of a few months ago, it supports Remix Vite in addition to the Remix Classic Compiler (it only supported this previously)
- Netlify's Remix packages were renamed in late 2023, but the Remix detection code only listed the old names
  - Luckily, this still happened to work because it also listed the right config file, but only for Remix Classic Compiler sites
  - However this means that in the Remix Vite case we were failing to detect Remix. Sites were categorized as Vite instead.
- The `remix` package itself was renamed to `@remix-run/dev`, `@remix-run/serve`, etc. in 2023. We hadn't updated this here either, which exarcerbated the above issues.

I added test fixtures from real sites for every case I could identify.