### PR TITLE
feat: write a file with the bootstrap version

### DIFF
--- a/packages/zip-it-and-ship-it/src/feature_flags.ts
+++ b/packages/zip-it-and-ship-it/src/feature_flags.ts
@@ -32,6 +32,9 @@ export const defaultFlags = {
 
   // Adds the `___netlify-telemetry.mjs` file to the function bundle.
   zisi_add_instrumentation_loader: true,
+
+  // Adds a `___netlify-bootstrap-version` file to the function bundle.
+  zisi_add_version_file: false,
 } as const
 
 export type FeatureFlags = Partial<Record<keyof typeof defaultFlags, boolean>>

--- a/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
@@ -17,6 +17,7 @@ import { normalizeFilePath } from './normalize_path.js'
 
 export const ENTRY_FILE_NAME = '___netlify-entry-point'
 export const BOOTSTRAP_FILE_NAME = '___netlify-bootstrap.mjs'
+export const BOOTSTRAP_VERSION_FILE_NAME = '___netlify-bootstrap-version'
 export const TELEMETRY_FILE_NAME = '___netlify-telemetry.mjs'
 
 const require = createRequire(import.meta.url)


### PR DESCRIPTION
#### Summary

Places a file at the root of the Lambda containing the version of the bootstrap layer. Behind a feature flag.

Part of https://linear.app/netlify/issue/RUN-858/spike-on-the-mechanism-for-extracting-the-metadata-needed-within-the.