### PR TITLE
fix: honor forced framework for Remix and Hydrogen

### DIFF
--- a/packages/build-info/src/frameworks/framework.test.ts
+++ b/packages/build-info/src/frameworks/framework.test.ts
@@ -205,6 +205,26 @@ describe('detection merging', () => {
       ]),
     ).toMatchObject({ accuracy: Accuracy.NPM, package: { name: 'a' } })
   })
+
+  test('keeps information about config and dependency from the most accurate detection that has it', () => {
+    expect(
+      mergeDetections([
+        undefined,
+        { accuracy: Accuracy.Config, config: '/absolute/path/config.js', configName: 'config.js' },
+        { accuracy: Accuracy.NPMHoisted, package: { name: 'b' } },
+        { accuracy: Accuracy.Forced },
+        { accuracy: Accuracy.NPM, package: { name: 'a' } },
+      ]),
+    ).toMatchObject({
+      // set by highest accuracy detection
+      accuracy: Accuracy.Forced,
+      // provided by the NPM detection - preferred over package provided by NPMHoisted
+      package: { name: 'a' },
+      // provided by the Config detection
+      config: '/absolute/path/config.js',
+      configName: 'config.js',
+    })
+  })
 })
 
 describe('framework sorting based on accuracy and type', () => {

--- a/packages/build-info/src/frameworks/hydrogen.ts
+++ b/packages/build-info/src/frameworks/hydrogen.ts
@@ -32,6 +32,7 @@ export class Hydrogen extends BaseFramework implements Framework {
   readonly id = 'hydrogen'
   name = 'Hydrogen'
   npmDependencies = ['@shopify/hydrogen']
+  configFiles = [...VITE_CONFIG_FILES, ...CLASSIC_COMPILER_CONFIG_FILES]
   category = Category.SSG
 
   logo = {
@@ -43,23 +44,16 @@ export class Hydrogen extends BaseFramework implements Framework {
   async detect(): Promise<DetectedFramework | undefined> {
     await super.detect()
 
-    if (this.detected) {
-      const viteDetection = await this.detectConfigFile(VITE_CONFIG_FILES)
-      if (viteDetection) {
-        this.detected = viteDetection
+    if (this.detected?.configName) {
+      if (VITE_CONFIG_FILES.includes(this.detected.configName)) {
         this.dev = VITE_DEV
         this.build = VITE_BUILD
         return this as DetectedFramework
-      }
-      const classicCompilerDetection = await this.detectConfigFile(CLASSIC_COMPILER_CONFIG_FILES)
-      if (classicCompilerDetection) {
-        this.detected = classicCompilerDetection
+      } else if (CLASSIC_COMPILER_CONFIG_FILES.includes(this.detected.configName)) {
         this.dev = CLASSIC_COMPILER_DEV
         this.build = CLASSIC_COMPILER_BUILD
         return this as DetectedFramework
       }
-      // If neither config file exists, it can't be a valid Hydrogen site for Netlify anyway.
-      return
     }
   }
 }

--- a/packages/build-info/src/frameworks/hydrogen.ts
+++ b/packages/build-info/src/frameworks/hydrogen.ts
@@ -44,12 +44,12 @@ export class Hydrogen extends BaseFramework implements Framework {
   async detect(): Promise<DetectedFramework | undefined> {
     await super.detect()
 
-    if (this.detected?.configName) {
-      if (VITE_CONFIG_FILES.includes(this.detected.configName)) {
+    if (this.detected) {
+      if (this.detected.configName && VITE_CONFIG_FILES.includes(this.detected.configName)) {
         this.dev = VITE_DEV
         this.build = VITE_BUILD
         return this as DetectedFramework
-      } else if (CLASSIC_COMPILER_CONFIG_FILES.includes(this.detected.configName)) {
+      } else {
         this.dev = CLASSIC_COMPILER_DEV
         this.build = CLASSIC_COMPILER_BUILD
         return this as DetectedFramework

--- a/packages/build-info/src/frameworks/remix.test.ts
+++ b/packages/build-info/src/frameworks/remix.test.ts
@@ -234,6 +234,28 @@ beforeEach((ctx) => {
       }),
     },
   ] as const,
+  [
+    'with no config file',
+    {
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'remix build',
+          dev: 'remix dev',
+          start: 'netlify serve',
+          typecheck: 'tsc',
+        },
+        dependencies: {
+          '@remix-run/netlify-edge': '1.7.4',
+          remix: '1.7.4',
+          react: '18.2.0',
+          'react-dom': '18.2.0',
+        },
+        devDependencies: {
+          '@netlify/functions': '^1.0.0',
+        },
+      }),
+    },
+  ] as const,
 ].forEach(([description, files]) =>
   test(`detects a Remix Classic Compiler site ${description}`, async ({ fs }) => {
     const cwd = mockFileSystem(files)
@@ -249,35 +271,3 @@ beforeEach((ctx) => {
     expect(detected?.[0]?.dev?.port).toBeUndefined()
   }),
 )
-
-test('does not detect an invalid Remix site with no config file', async ({ fs }) => {
-  const cwd = mockFileSystem({
-    'package.json': JSON.stringify({
-      scripts: {
-        build: 'remix vite:build',
-        dev: 'remix vite:dev',
-        start: 'remix-serve ./build/server/index.js',
-      },
-      dependencies: {
-        '@netlify/remix-runtime': '^2.3.0',
-        '@remix-run/node': '^2.9.2',
-        '@remix-run/react': '^2.9.2',
-        '@remix-run/serve': '^2.9.2',
-        react: '^18.2.0',
-        'react-dom': '^18.2.0',
-      },
-      devDependencies: {
-        '@netlify/remix-edge-adapter': '^3.3.0',
-        '@remix-run/dev': '^2.9.2',
-        '@types/react': '^18.2.20',
-        '@types/react-dom': '^18.2.7',
-        vite: '^5.0.0',
-        'vite-tsconfig-paths': '^4.2.1',
-      },
-    }),
-  })
-  const detected = await new Project(fs, cwd).detectFrameworks()
-
-  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
-  expect(detectedFrameworks).not.toContain('remix')
-})

--- a/packages/build-info/src/frameworks/remix.ts
+++ b/packages/build-info/src/frameworks/remix.ts
@@ -43,6 +43,7 @@ export class Remix extends BaseFramework implements Framework {
     '@remix-run/netlify-edge',
   ]
   excludedNpmDependencies = ['@shopify/hydrogen']
+  configFiles = [...VITE_CONFIG_FILES, ...CLASSIC_COMPILER_CONFIG_FILES]
   category = Category.SSG
 
   logo = {
@@ -54,23 +55,16 @@ export class Remix extends BaseFramework implements Framework {
   async detect(): Promise<DetectedFramework | undefined> {
     await super.detect()
 
-    if (this.detected) {
-      const viteDetection = await this.detectConfigFile(VITE_CONFIG_FILES)
-      if (viteDetection) {
-        this.detected = viteDetection
+    if (this.detected?.configName) {
+      if (VITE_CONFIG_FILES.includes(this.detected.configName)) {
         this.dev = VITE_DEV
         this.build = VITE_BUILD
         return this as DetectedFramework
-      }
-      const classicCompilerDetection = await this.detectConfigFile(CLASSIC_COMPILER_CONFIG_FILES)
-      if (classicCompilerDetection) {
-        this.detected = classicCompilerDetection
+      } else if (CLASSIC_COMPILER_CONFIG_FILES.includes(this.detected.configName)) {
         this.dev = CLASSIC_COMPILER_DEV
         this.build = CLASSIC_COMPILER_BUILD
         return this as DetectedFramework
       }
-      // If neither config file exists, it can't be a valid Remix site for Netlify anyway.
-      return
     }
   }
 }

--- a/packages/build-info/src/frameworks/remix.ts
+++ b/packages/build-info/src/frameworks/remix.ts
@@ -55,12 +55,12 @@ export class Remix extends BaseFramework implements Framework {
   async detect(): Promise<DetectedFramework | undefined> {
     await super.detect()
 
-    if (this.detected?.configName) {
-      if (VITE_CONFIG_FILES.includes(this.detected.configName)) {
+    if (this.detected) {
+      if (this.detected.configName && VITE_CONFIG_FILES.includes(this.detected.configName)) {
         this.dev = VITE_DEV
         this.build = VITE_BUILD
         return this as DetectedFramework
-      } else if (CLASSIC_COMPILER_CONFIG_FILES.includes(this.detected.configName)) {
+      } else {
         this.dev = CLASSIC_COMPILER_DEV
         this.build = CLASSIC_COMPILER_BUILD
         return this as DetectedFramework

--- a/packages/build-info/src/get-framework.test.ts
+++ b/packages/build-info/src/get-framework.test.ts
@@ -1,7 +1,8 @@
-import { test, expect, beforeEach } from 'vitest'
+import { describe, test, expect, beforeEach } from 'vitest'
 
 import { mockFileSystem } from '../tests/mock-file-system.js'
 
+import { frameworks } from './frameworks/index.js'
 import { getFramework } from './get-framework.js'
 import { NodeFS } from './node/file-system.js'
 import { Project } from './project.js'
@@ -51,4 +52,18 @@ test('should throw if a unknown framework was requested', async ({ fs }) => {
     expect(frameworksArray).toEqual([...frameworksArray].sort())
   }
   expect.assertions(1)
+})
+
+describe('Framework detection honors forced framework', () => {
+  for (const Framework of frameworks) {
+    test(Framework.name, async ({ fs }) => {
+      const cwd = mockFileSystem({})
+      const project = new Project(fs, cwd)
+      const framework = new Framework(project)
+
+      const detectedFramework = await getFramework(framework.id, project)
+
+      expect(detectedFramework.id).toBe(framework.id)
+    })
+  }
 })

--- a/packages/build-info/src/get-framework.ts
+++ b/packages/build-info/src/get-framework.ts
@@ -14,6 +14,9 @@ export async function getFramework(frameworkId: FrameworkName, project: Project)
     if (detected) {
       return detected
     }
+
+    // this indicate that framework's custom "detect" method doesn't honor the forced framework
+    throw new Error(`Forced framework "${frameworkId}" was not detected.`)
   }
 
   const frameworkIds = frameworkList


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://linear.app/netlify/issue/FRB-1324/fix-failing-test-related-to-remix-framework-detection-in-cli

Because of the change in https://github.com/netlify/build/pull/5820 we now have scenarios where forcing framework via `netlify.toml#dev.framework` that is not honored by framework's detection, would print quite confusing error:
> Invalid framework "remix". It should be one of: analog, angular, assemble, astro, blitz, brunch, cecil, create-react-app, docpad, docusaurus, eleventy, ember, expo, gatsby, gridsome, grunt, gulp, harp, hexo, hugo, hydrogen, jekyll, metalsmith, middleman, next, nuxt, observable, parcel, phenomic, quasar, qwik, react-static, redwoodjs, remix, roots, sapper, solid-js, solid-start, stencil, svelte, svelte-kit, vite, vue, vuepress, wintersmith, wmr, zola

It seems like we do have to ensure that if framework is forced - each framework detection need to honor it. Before Remix and Hydrogen adjustments that was actually the case (but we were not verifying it), because custom `detect()` method in frameworks was not really changing status of something being detected or not - it was just used to enrich default settings (often based on framework version etc).

This adds a generic test testing if forced framework result in it being "detected" (or rather that forcing a framework is being honored) and add fallback cases to Remix and Hydrogen to use previous defaults if framework is forced and we fail to find any of possible configuration files (for classic compiler or vite variant)

It also implements this idea https://github.com/netlify/build/pull/5820#discussion_r1757081785 instead of current one, so we avoid doing multiple detection passes and use detection information about config file to decide if Vite or Classic Compiler option should be used)

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
