### PR TITLE
fix: reading data from spawned process

### DIFF
--- a/packages/build/src/plugins/ipc.js
+++ b/packages/build/src/plugins/ipc.js
@@ -39,8 +39,8 @@ export const getEventFromChild = async function (childProcess, callId) {
     throw getChildExitError('Could not receive event from child process because it already exited.')
   }
 
-  const messagePromise = pEvent(childProcess, 'message', { filter: ([actualCallId]) => actualCallId === callId })
-  const errorPromise = pEvent(childProcess, 'message', { filter: ([actualCallId]) => actualCallId === 'error' })
+  const messagePromise = pEvent(childProcess, 'message', { filter: (data) => data?.[0] === callId })
+  const errorPromise = pEvent(childProcess, 'message', { filter: (data) => data?.[0] === 'error' })
   const exitPromise = pEvent(childProcess, 'exit', { multiArgs: true })
   try {
     return await Promise.race([getMessage(messagePromise), getError(errorPromise), getExit(exitPromise)])

--- a/packages/build/tests/plugins/fixtures/process_send_object/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/process_send_object/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/process_send_object/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/process_send_object/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin.js"

--- a/packages/build/tests/plugins/fixtures/process_send_object/plugin.js
+++ b/packages/build/tests/plugins/fixtures/process_send_object/plugin.js
@@ -1,0 +1,5 @@
+import process from 'process';
+
+export const onPreBuild = function () {
+  process.send({});
+}

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -401,3 +401,8 @@ test('Plugins have a pre-populated Blobs context', async (t) => {
 
   t.is(netlifyConfig.build.command, `echo ""Hello there""`)
 })
+
+test('Plugins can respond anything to parent process', async (t) => {
+  const build = await new Fixture('./fixtures/process_send_object').runBuildBinary()
+  t.true(build.exitCode === 0)
+})


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Spawned processes might return a random data, while `ipc.js`, when filters messages, expects it to be in array format. 

When process sends non-array object, it produces the uncaught error and stops the build.

I've discovered this when started `netlify dev` with `plugin-visual-editor` on the site with astro and sanity. Plugin-visual-editor launches `stackbit dev`, which imports a `content-engine`, which calls `process.send(/* OBJECT */)` and crashes the build.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
