### PR TITLE
feat: add `bootstrapVersion` field to manifest

### DIFF
--- a/packages/zip-it-and-ship-it/src/manifest.ts
+++ b/packages/zip-it-and-ship-it/src/manifest.ts
@@ -9,20 +9,20 @@ import type { ExtendedRoute, Route } from './utils/routes.js'
 
 interface ManifestFunction {
   buildData?: Record<string, unknown>
+  bundler?: string
+  displayName?: string
+  excludedRoutes?: Route[]
+  generator?: string
   invocationMode?: InvocationMode
   mainFile: string
   name: string
   path: string
+  priority?: number
   routes?: ExtendedRoute[]
-  excludedRoutes?: Route[]
   runtime: string
   runtimeVersion?: string
   schedule?: string
-  displayName?: string
-  bundler?: string
-  generator?: string
   timeout?: number
-  priority?: number
   trafficRules?: TrafficRules
 }
 
@@ -51,6 +51,7 @@ export const createManifest = async ({ functions, path }: { functions: FunctionR
 }
 
 const formatFunctionForManifest = ({
+  bootstrapVersion,
   bundler,
   displayName,
   excludedRoutes,
@@ -74,7 +75,7 @@ const formatFunctionForManifest = ({
     generator,
     timeout,
     invocationMode,
-    buildData: { runtimeAPIVersion },
+    buildData: { bootstrapVersion, runtimeAPIVersion },
     mainFile,
     name,
     priority,

--- a/packages/zip-it-and-ship-it/src/runtimes/node/index.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/index.ts
@@ -110,7 +110,7 @@ const zipFunction: ZipFunction = async function ({
   createPluginsModulesPathAliases(srcFiles, pluginsModulesPath, aliases, finalBasePath)
 
   const generator = mergedConfig?.generator || getInternalValue(isInternal)
-  const zipPath = await zipNodeJs({
+  const zipResult = await zipNodeJs({
     aliases,
     archiveFormat,
     basePath: finalBasePath,
@@ -152,11 +152,12 @@ const zipFunction: ZipFunction = async function ({
   const trafficRules = mergedConfig?.rateLimit ? getTrafficRulesConfig(mergedConfig.rateLimit) : undefined
 
   return {
+    bootstrapVersion: zipResult.bootstrapVersion,
     bundler: bundlerName,
     bundlerWarnings,
     config: mergedConfig,
     displayName: mergedConfig?.name,
-    entryFilename: zipPath.entryFilename,
+    entryFilename: zipResult.entryFilename,
     generator,
     timeout: mergedConfig?.timeout,
     inputs,
@@ -165,7 +166,7 @@ const zipFunction: ZipFunction = async function ({
     invocationMode,
     outputModuleFormat,
     nativeNodeModules,
-    path: zipPath.path,
+    path: zipResult.path,
     priority,
     trafficRules,
     runtimeVersion:

--- a/packages/zip-it-and-ship-it/src/utils/format_result.ts
+++ b/packages/zip-it-and-ship-it/src/utils/format_result.ts
@@ -5,6 +5,7 @@ import { removeUndefined } from './remove_undefined.js'
 import type { ExtendedRoute, Route } from './routes.js'
 
 export type FunctionResult = Omit<FunctionArchive, 'runtime'> & {
+  bootstrapVersion?: string
   routes?: ExtendedRoute[]
   excludedRoutes?: Route[]
   runtime: RuntimeName

--- a/packages/zip-it-and-ship-it/tests/v2api.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2api.test.ts
@@ -753,4 +753,35 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       })
     })
   })
+
+  test('Adds a `buildData` object to each function entry in the manifest file', async () => {
+    const bootstrapPath = getBootstrapPath()
+    const bootstrapPackageJson = await readFile(resolve(bootstrapPath, '..', '..', 'package.json'), 'utf8')
+    const { version: bootstrapVersion } = JSON.parse(bootstrapPackageJson)
+
+    const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
+    const manifestPath = join(tmpDir, 'manifest.json')
+
+    const { files } = await zipFixture('v2-api', {
+      fixtureDir: FIXTURES_ESM_DIR,
+      opts: {
+        featureFlags: {
+          zisi_add_metadata_file: true,
+        },
+        manifest: manifestPath,
+      },
+    })
+
+    expect(files.length).toBe(1)
+    expect(files[0].name).toBe('function')
+    expect(files[0].bootstrapVersion).toBe(bootstrapVersion)
+    expect(files[0].runtimeAPIVersion).toBe(2)
+
+    const manifestString = await readFile(manifestPath, { encoding: 'utf8' })
+    const manifest = JSON.parse(manifestString)
+
+    expect(manifest.functions.length).toBe(1)
+    expect(manifest.functions[0].name).toBe('function')
+    expect(manifest.functions[0].buildData).toEqual({ bootstrapVersion, runtimeAPIVersion: 2 })
+  })
 })


### PR DESCRIPTION
#### Summary

Part of https://linear.app/netlify/issue/RUN-1060/add-the-boostrap-layer-version-to-the-proxy-log-line.