### PR TITLE
test(build): remove test focus

### DIFF
--- a/packages/build/tests/install/tests.js
+++ b/packages/build/tests/install/tests.js
@@ -153,7 +153,7 @@ test('Install local plugin dependencies: missing plugin in netlify.toml', async 
   t.snapshot(normalizeOutput(output))
 })
 
-test.only('In integration dev mode, install local plugins and install the integration when forcing build', async (t) => {
+test('In integration dev mode, install local plugins and install the integration when forcing build', async (t) => {
   const output = await new Fixture('./fixtures/local_missing_integration').withFlags({ context: 'dev' }).runWithBuild()
 
   t.snapshot(normalizeOutput(output))


### PR DESCRIPTION
#### Summary

This removes a test focus I accidentally committed in #5885.

I'll follow this up with an ESLint rule that catches focused tests. I'm htiting some `.eslintrc*`/`eslint.config.js` issues adding it, so putting this PR up while I get it working.