### PR TITLE
feat: rename next.js adapter package

### DIFF
--- a/packages/build-info/src/build-systems/nx.test.ts
+++ b/packages/build-info/src/build-systems/nx.test.ts
@@ -197,7 +197,7 @@ describe('nx-integrated project.json based', () => {
           frameworkPort: 4200,
           name: `Nx + Next.js ${join('packages/website')}`,
           packagePath: join('packages/website'),
-          plugins_recommended: ['@netlify/plugin-nextjs'],
+          plugins_recommended: ['@opennextjs/netlify'],
         }),
       ]),
     )

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -38,7 +38,7 @@ describe('Next.js Plugin', () => {
     const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual(['@netlify/plugin-nextjs'])
+    expect(frameworks?.[0].plugins).toEqual(['@opennextjs/netlify'])
   })
 
   test('Should not detect Next.js plugin for Next.js if when Node version < 10.13.0', async ({ fs, cwd }) => {
@@ -90,7 +90,7 @@ describe('simple Next.js project', async () => {
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async ({ fs, cwd }) => {
     const detected = await new Project(fs, cwd).setEnvironment({ NODE_VERSION: '18.x' }).detectFrameworks()
     expect(detected?.[0].id).toBe('next')
-    expect(detected?.[0].plugins).toMatchObject(['@netlify/plugin-nextjs'])
+    expect(detected?.[0].plugins).toMatchObject(['@opennextjs/netlify'])
   })
 })
 
@@ -134,7 +134,7 @@ describe('Nx monorepo', () => {
       devCommand: 'nx run website:serve',
       dist: join('dist/packages/website/.next'),
       frameworkPort: 4200,
-      plugins_recommended: ['@netlify/plugin-nextjs'],
+      plugins_recommended: ['@opennextjs/netlify'],
     })
   })
 })
@@ -152,7 +152,7 @@ describe('Nx turborepo', () => {
       devCommand: 'turbo run dev --filter web',
       dist: join('apps/web/.next'),
       frameworkPort: 3000,
-      plugins_recommended: ['@netlify/plugin-nextjs'],
+      plugins_recommended: ['@opennextjs/netlify'],
     })
   })
 })

--- a/packages/build-info/src/frameworks/next.ts
+++ b/packages/build-info/src/frameworks/next.ts
@@ -33,7 +33,7 @@ export class Next extends BaseFramework implements Framework {
     if (this.detected) {
       const nodeVersion = await this.project.getCurrentNodeVersion()
       if (nodeVersion && gte(nodeVersion, '10.13.0')) {
-        this.plugins.push('@netlify/plugin-nextjs')
+        this.plugins.push('@opennextjs/netlify')
       }
       return this as DetectedFramework
     }

--- a/packages/build/src/utils/runtime.js
+++ b/packages/build/src/utils/runtime.js
@@ -1,5 +1,5 @@
 export const isRuntime = function (pluginOption) {
   const { packageName } = pluginOption
   // Make this a bit more robust in the future
-  return ['@netlify/next-runtime', '@netlify/plugin-nextjs'].includes(packageName)
+  return ['@netlify/next-runtime', '@netlify/plugin-nextjs', '@opennextjs/netlify'].includes(packageName)
 }


### PR DESCRIPTION
#### Summary

Update to use new package name for our Next.js Adapter, which is moving to the @opennextjs scope.