### PR TITLE
feat(build): support new @opennextjs/netlify plugin name

### DIFF
--- a/packages/build-info/src/build-systems/nx.test.ts
+++ b/packages/build-info/src/build-systems/nx.test.ts
@@ -197,7 +197,7 @@ describe('nx-integrated project.json based', () => {
           frameworkPort: 4200,
           name: `Nx + Next.js ${join('packages/website')}`,
           packagePath: join('packages/website'),
-          plugins_recommended: ['@netlify/plugin-nextjs'],
+          plugins_recommended: ['@opennextjs/netlify'],
         }),
       ]),
     )

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -38,7 +38,7 @@ describe('Next.js Plugin', () => {
     const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
-    expect(frameworks?.[0].plugins).toEqual(['@netlify/plugin-nextjs'])
+    expect(frameworks?.[0].plugins).toEqual(['@opennextjs/netlify'])
   })
 
   test('Should not detect Next.js plugin for Next.js if when Node version < 10.13.0', async ({ fs, cwd }) => {
@@ -90,7 +90,7 @@ describe('simple Next.js project', async () => {
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async ({ fs, cwd }) => {
     const detected = await new Project(fs, cwd).setEnvironment({ NODE_VERSION: '18.x' }).detectFrameworks()
     expect(detected?.[0].id).toBe('next')
-    expect(detected?.[0].plugins).toMatchObject(['@netlify/plugin-nextjs'])
+    expect(detected?.[0].plugins).toMatchObject(['@opennextjs/netlify'])
   })
 })
 
@@ -134,7 +134,7 @@ describe('Nx monorepo', () => {
       devCommand: 'nx run website:serve',
       dist: join('dist/packages/website/.next'),
       frameworkPort: 4200,
-      plugins_recommended: ['@netlify/plugin-nextjs'],
+      plugins_recommended: ['@opennextjs/netlify'],
     })
   })
 })
@@ -152,7 +152,7 @@ describe('Nx turborepo', () => {
       devCommand: 'turbo run dev --filter web',
       dist: join('apps/web/.next'),
       frameworkPort: 3000,
-      plugins_recommended: ['@netlify/plugin-nextjs'],
+      plugins_recommended: ['@opennextjs/netlify'],
     })
   })
 })

--- a/packages/build-info/src/frameworks/next.ts
+++ b/packages/build-info/src/frameworks/next.ts
@@ -33,7 +33,7 @@ export class Next extends BaseFramework implements Framework {
     if (this.detected) {
       const nodeVersion = await this.project.getCurrentNodeVersion()
       if (nodeVersion && gte(nodeVersion, '10.13.0')) {
-        this.plugins.push('@netlify/plugin-nextjs')
+        this.plugins.push('@opennextjs/netlify')
       }
       return this as DetectedFramework
     }

--- a/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
+++ b/packages/build-info/src/node/__snapshots__/get-build-info.test.ts.snap
@@ -85,7 +85,7 @@ exports[`should retrieve the build info for providing a rootDir 1`] = `
       "packagePath": "packages/website",
       "plugins_from_config_file": [],
       "plugins_recommended": [
-        "@netlify/plugin-nextjs",
+        "@opennextjs/netlify",
       ],
       "pollingStrategies": [
         "TCP",
@@ -290,7 +290,7 @@ exports[`should retrieve the build info for providing a rootDir and the same pro
       "packagePath": "packages/website",
       "plugins_from_config_file": [],
       "plugins_recommended": [
-        "@netlify/plugin-nextjs",
+        "@opennextjs/netlify",
       ],
       "pollingStrategies": [
         "TCP",

--- a/packages/build/src/log/messages/compatibility.ts
+++ b/packages/build/src/log/messages/compatibility.ts
@@ -1,23 +1,23 @@
 import semver from 'semver'
 
-import { isRuntime } from '../../utils/runtime.js'
+import { isNextJsAdapter } from '../../utils/runtime.js'
 import { isPreviousMajor } from '../../utils/semver.js'
 import { getPluginOrigin } from '../description.js'
 import { BufferedLogs, logArray, logSubHeader, logWarningArray, logWarningSubHeader } from '../logger.js'
 import { THEME } from '../theme.js'
 
-export const logRuntime = (logs, pluginOptions) => {
-  const runtimes = pluginOptions.filter(isRuntime)
+export const logRuntime = (logs: BufferedLogs | undefined, pluginOptions) => {
+  const runtimes = pluginOptions.filter(isNextJsAdapter)
 
   // Once we have more runtimes, this hardcoded check should be removed
   if (runtimes.length !== 0) {
     const [nextRuntime] = runtimes
 
-    logSubHeader(logs, `Using Next.js Runtime - v${nextRuntime.pluginPackageJson.version}`)
+    logSubHeader(logs, `Using Next.js adapter - v${nextRuntime.pluginPackageJson.version}`)
   }
 }
 
-export const logLoadingIntegration = (logs, pluginOptions) => {
+export const logLoadingIntegration = (logs: BufferedLogs | undefined, pluginOptions) => {
   const loadingPlugins = pluginOptions
     .filter((plugin) => plugin.isIntegration)
     .map((pluginOptions) => pluginOptions.integration?.slug ?? 'no-slug')
@@ -30,11 +30,11 @@ export const logLoadingIntegration = (logs, pluginOptions) => {
   logArray(logs, loadingPlugins)
 }
 
-export const logLoadingPlugins = function (logs, pluginsOptions, debug) {
+export const logLoadingPlugins = function (logs: BufferedLogs | undefined, pluginsOptions, debug: boolean) {
   const loadingPlugins = pluginsOptions
     .filter(isNotCorePlugin)
-    // We don't want to show runtimes as plugins
-    .filter((plugin) => !isRuntime(plugin))
+    // We log these separately
+    .filter((plugin) => !isNextJsAdapter(plugin))
     .filter((p) => !p.isIntegration)
     .map((pluginOptions) => getPluginDescription(pluginOptions, debug))
 
@@ -62,7 +62,7 @@ const getPluginDescription = function (
     expectedVersion,
     compatibleVersion,
   },
-  debug,
+  debug: boolean,
 ) {
   const versionedPackage = getVersionedPackage(version)
   const pluginOrigin = getPluginOrigin(loadedFrom, origin)
@@ -97,7 +97,7 @@ const getVersionField = function ([versionFieldName, version]) {
 
 // Print a warning message when old versions plugins are used.
 // This can only happen when they are installed to `package.json`.
-export const logOutdatedPlugins = function (logs: BufferedLogs, pluginsOptions) {
+export const logOutdatedPlugins = function (logs: BufferedLogs | undefined, pluginsOptions) {
   const outdatedPlugins = pluginsOptions.filter(hasOutdatedVersion).map(getOutdatedPlugin)
 
   if (outdatedPlugins.length === 0) {
@@ -149,7 +149,7 @@ const getUpgradeInstruction = function (loadedFrom, origin) {
 // Print a warning message when plugins are using a version that is too recent
 // and does not meet some `compatibility` expectations.
 // This can only happen when they are installed to `package.json`.
-export const logIncompatiblePlugins = function (logs, pluginsOptions) {
+export const logIncompatiblePlugins = function (logs: BufferedLogs | undefined, pluginsOptions) {
   const incompatiblePlugins = pluginsOptions.filter(hasIncompatibleVersion).map(getIncompatiblePlugin)
 
   if (incompatiblePlugins.length === 0) {

--- a/packages/build/src/log/messages/install.js
+++ b/packages/build/src/log/messages/install.js
@@ -1,8 +1,8 @@
-import { isRuntime } from '../../utils/runtime.js'
+import { isNextJsAdapter } from '../../utils/runtime.js'
 import { log, logArray, logSubHeader } from '../logger.js'
 
 export const logInstallMissingPlugins = function (logs, missingPlugins, packages) {
-  const plugins = missingPlugins.filter((pkg) => !isRuntime(pkg))
+  const plugins = missingPlugins.filter((pkg) => !isNextJsAdapter(pkg))
 
   if (plugins.length !== 0) {
     logSubHeader(logs, 'Installing plugins')

--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -48,6 +48,18 @@ const tStartPlugins = async function ({
   systemLog,
   systemLogFile,
   featureFlags,
+}: {
+  // TODO(serhalp) Add return type to `resolvePluginsPath` in `plugins/resolve.js`
+  // and `loadPluginFiles` in `plugins/options.ts`.
+  pluginsOptions: any[]
+  buildDir: string
+  childEnv: Record<string, string>
+  logs: BufferedLogs | undefined
+  debug: boolean
+  quiet: boolean
+  systemLog: SystemLogger
+  systemLogFile: number
+  featureFlags: FeatureFlags
 }) {
   if (!quiet) {
     logRuntime(logs, pluginsOptions)

--- a/packages/build/src/utils/runtime.js
+++ b/packages/build/src/utils/runtime.js
@@ -1,5 +1,0 @@
-export const isRuntime = function (pluginOption) {
-  const { packageName } = pluginOption
-  // Make this a bit more robust in the future
-  return ['@netlify/next-runtime', '@netlify/plugin-nextjs'].includes(packageName)
-}

--- a/packages/build/src/utils/runtime.ts
+++ b/packages/build/src/utils/runtime.ts
@@ -1,0 +1,12 @@
+export const isNextJsAdapter = (pluginOption: { packageName: string }) => {
+  const { packageName } = pluginOption
+  // Make this a bit more robust in the future
+  return [
+    // Name used up until v5.8.1
+    '@netlify/plugin-nextjs',
+    // Name briefly used for v5 prereleases, but then backed out of before stable
+    '@netlify/next-runtime',
+    // Renamed starting at v5.9.0
+    '@opennextjs/netlify',
+  ].includes(packageName)
+}

--- a/packages/framework-info/tests/detect.test.ts
+++ b/packages/framework-info/tests/detect.test.ts
@@ -38,7 +38,7 @@ if (nodeVersion !== 'v8.3.0') {
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async () => {
     const frameworks = await getFrameworks('next-plugin')
     expect(frameworks[0].id).toBe('next')
-    expect(frameworks[0].plugins).toEqual(['@netlify/plugin-nextjs'])
+    expect(frameworks[0].plugins).toEqual(['@opennextjs/netlify'])
   })
 }
 


### PR DESCRIPTION
#### Summary

See https://github.com/netlify/next-runtime/pull/2693.

Starting at 5.9.0 the build plugin and npm package will be renamed from `@netlify/plugin-nextjs` to `@opennextjs/netlify`.

This adds support for the new name and changes the framework detection to automatically use it going forward.

I didn't update packages/framework-info because it isn't used — see https://github.com/netlify/build/pull/5819.

Supersedes https://github.com/netlify/build/pull/5896 because I didn't know it had already been done 😁

NOTE: we shouldn't release this to buildbot and cli until the `@opennextjs/netlify` package exists.