### PR TITLE
fix: turn log line into system log

### DIFF
--- a/packages/build/src/plugins_core/pre_dev_cleanup/index.ts
+++ b/packages/build/src/plugins_core/pre_dev_cleanup/index.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path'
 
 import { listFrameworks } from '@netlify/framework-info'
 
-import { log } from '../../log/logger.js'
 import { CoreStep, CoreStepCondition, CoreStepFunction, CoreStepFunctionArgs } from '../types.js'
 
 const dirExists = async (path: string): Promise<boolean> => {
@@ -37,7 +36,7 @@ const coreStep: CoreStepFunction = async (input) => {
   for (const dir of dirs) {
     await rm(resolve(input.buildDir, dir), { recursive: true, force: true })
   }
-  log(input.logs, `Cleaned up ${dirs.join(', ')}.`)
+  input.systemLog(input.logs, `Cleaned up ${dirs.join(', ')}.`)
   return {}
 }
 


### PR DESCRIPTION
#### Summary

We print a log line when we clean up internal directories in Netlify Dev. This information is not at all useful or actionable by users, so it's just adding noise.

This PR transforms it into a system log line, so it's only shown when the `--debug` flag is used.

![Screenshot 2024-11-18 at 09 34 18](https://github.com/user-attachments/assets/31a71cb8-f17a-419d-8b99-c4e91dce8c57)
