### PR TITLE
feat: add node 22 to supported runtime versions list

### DIFF
--- a/packages/zip-it-and-ship-it/src/runtimes/node/utils/node_runtime.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/utils/node_runtime.ts
@@ -5,6 +5,7 @@ const validRuntimeMap = {
   16: 'nodejs16.x',
   18: 'nodejs18.x',
   20: 'nodejs20.x',
+  22: 'nodejs22.x',
 } as const
 
 const minimumV2Version = 18


### PR DESCRIPTION
#### Summary

Related to FRB-1505
Adds node v22 to the allowed runtime versions
If a user is using v22 via `.nvmrc`, once this is released their runtime version will match
Also supports the future default version being bumped from v18 to v22

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
