### PR TITLE
fix: detect `bun.lock` files in addition to `bun.lockb` files

### DIFF
--- a/packages/build-info/src/runtime/bun.test.ts
+++ b/packages/build-info/src/runtime/bun.test.ts
@@ -17,6 +17,15 @@ test('detects node when bunfig.toml is present', async ({ fs }) => {
   expect(detected[0].name).toBe('Bun')
 })
 
+test('detects node when bun.lock is present', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'bun.lock': '',
+  })
+
+  const detected = await new Project(fs, cwd).detectRuntime()
+  expect(detected[0].name).toBe('Bun')
+})
+
 test('detects node when bun.lockb is present', async ({ fs }) => {
   const cwd = mockFileSystem({
     'bun.lockb': '',

--- a/packages/build-info/src/runtime/bun.ts
+++ b/packages/build-info/src/runtime/bun.ts
@@ -3,5 +3,5 @@ import { LangRuntime } from './runtime.js'
 export class Bun extends LangRuntime {
   id = 'bun'
   name = 'Bun'
-  configFiles = ['bun.lockb', 'bunfig.toml']
+  configFiles = ['bun.lock', 'bun.lockb', 'bunfig.toml']
 }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes FRB-1355
Feature is not released yet so we can wait to merge if we'd like, but it doesn't hurt to get ahead
See: https://github.com/oven-sh/bun/issues/11863

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
