### PR TITLE
fix: convert buffers into blobs before calling blobStore.set

### DIFF
--- a/packages/build/src/plugins_core/blobs_upload/index.ts
+++ b/packages/build/src/plugins_core/blobs_upload/index.ts
@@ -72,7 +72,7 @@ const coreStep: CoreStepFunction = async function ({
         systemLog(`Uploading blob ${key}`)
 
         const { data, metadata } = await getFileWithMetadata(key, contentPath, metadataPath)
-        await blobStore.set(key, data, { metadata })
+        await blobStore.set(key, new Blob([data]), { metadata })
       },
       { concurrency: 10 },
     )

--- a/packages/build/src/plugins_core/dev_blobs_upload/index.ts
+++ b/packages/build/src/plugins_core/dev_blobs_upload/index.ts
@@ -77,7 +77,7 @@ const coreStep: CoreStepFunction = async function ({
           log(logs, `- Uploading blob ${key}`, { indent: true })
         }
         const { data, metadata } = await getFileWithMetadata(key, contentPath, metadataPath)
-        await blobStore.set(key, data, { metadata })
+        await blobStore.set(key, new Blob([data]), { metadata })
       },
       { concurrency: 10 },
     )


### PR DESCRIPTION
#### Summary

Fixes typescript issue in main branch that's blocking test runs

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
