### PR TITLE
fix: update DENO_VERSION_RANGE

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,11 +52,11 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         node-version: ['*']
         # Must include the minimum deno version from the `DENO_VERSION_RANGE` constant in `node/bridge.ts`.
-        deno-version: ['v1.37.0', 'v1.44.4']
+        deno-version: ['v1.39.0', 'v1.46.3']
         include:
           - os: ubuntu-latest
             node-version: '14.16.0'
-            deno-version: 'v1.44.4'
+            deno-version: 'v1.46.3'
       fail-fast: false
     steps:
       # Increasing the maximum number of open files. See:
@@ -192,7 +192,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.44.4
+          deno-version: v1.46.3
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/packages/edge-bundler/node/bridge.ts
+++ b/packages/edge-bundler/node/bridge.ts
@@ -12,7 +12,7 @@ import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
-const DENO_VERSION_RANGE = '1.37.0 - 1.46.3'
+const DENO_VERSION_RANGE = '1.39.0 - 1.46.3'
 
 type OnBeforeDownloadHook = () => void | Promise<void>
 type OnAfterDownloadHook = (error?: Error) => void | Promise<void>

--- a/packages/edge-bundler/node/bridge.ts
+++ b/packages/edge-bundler/node/bridge.ts
@@ -12,6 +12,10 @@ import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
+
+// When updating DENO_VERSION_RANGE, ensure that the deno version
+// on the netlify/buildbot build image satisfies this range!
+// https://github.com/netlify/buildbot/blob/f9c03c9dcb091d6570e9d0778381560d469e78ad/build-image/noble/Dockerfile#L410
 const DENO_VERSION_RANGE = '1.39.0 - 1.46.3'
 
 type OnBeforeDownloadHook = () => void | Promise<void>

--- a/packages/edge-bundler/node/bridge.ts
+++ b/packages/edge-bundler/node/bridge.ts
@@ -12,12 +12,7 @@ import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
-
-// When updating DENO_VERSION_RANGE, ensure that the deno version installed in the
-// build-image/buildbot does satisfy this range!
-// We're pinning the range because of an issue with v1.45.0 of the Deno CLI:
-// https://linear.app/netlify/issue/FRP-775/deno-cli-v1450-causing-issues
-const DENO_VERSION_RANGE = '1.37.0 - 1.44.4'
+const DENO_VERSION_RANGE = '1.37.0 - 1.46.3'
 
 type OnBeforeDownloadHook = () => void | Promise<void>
 type OnAfterDownloadHook = (error?: Error) => void | Promise<void>


### PR DESCRIPTION
#### Summary

- The new noble image uses the latest deno version
- The removed comment is out of date, because the linked ticket mentions a fix was made in 1.46.0
- We are bumping the low end of the version because we rely on a fix for `AbortSignal` made in 1.39.0

TODO:
- [x] Before merging update required test list

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
