### PR TITLE
chore: fix intermittent timeouts in osx test runners

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,12 +60,6 @@ jobs:
             deno-version: 'v1.46.3'
       fail-fast: false
     steps:
-      # Increasing the maximum number of open files. See:
-      # https://github.com/actions/virtual-environments/issues/268
-      - name: Increase open file limit
-        run: sudo ulimit -Sn 65536
-        if: "${{ matrix.os == 'macos-14' }}"
-      - run: git config --global core.symlinks true
       # Sets an output parameter if this is a release PR
       - name: Check for release
         id: release-check

--- a/packages/build/ava.config.js
+++ b/packages/build/ava.config.js
@@ -1,8 +1,14 @@
+import { platform } from 'node:os'
+import { env } from 'node:process'
+
 import baseConfig from '../../ava.base.js'
 
 const config = {
   ...baseConfig,
   files: ['tests/**/tests.{cjs,mjs,js}'],
+  // github action runners for osx have lower memory than windows/linux
+  // https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  serial: env.GITHUB_ACTIONS && platform() === 'darwin',
 }
 
 export default config

--- a/packages/testing/src/fixture.ts
+++ b/packages/testing/src/fixture.ts
@@ -4,6 +4,7 @@ import { normalize, delimiter } from 'path'
 import { env } from 'process'
 import { fileURLToPath } from 'url'
 
+import { default as build, startDev } from '@netlify/build'
 import test from 'ava'
 import cpy from 'cpy'
 import { execa, execaCommand } from 'execa'
@@ -194,7 +195,6 @@ export class Fixture {
 
   /** Runs @netlify/build main function programmatic with the provided flags  */
   async runBuildProgrammatic(): Promise<object> {
-    const { default: build } = await import('@netlify/build')
     return await build(this.getBuildFlags())
   }
 
@@ -204,7 +204,6 @@ export class Fixture {
   }
 
   async runWithBuildAndIntrospect() {
-    const { default: build } = await import('@netlify/build')
     const buildResult = await build(this.getBuildFlags())
     const output = [buildResult.logs?.stdout.join('\n'), buildResult.logs?.stderr.join('\n')]
       .filter(Boolean)
@@ -218,7 +217,6 @@ export class Fixture {
 
   // TODO: provide better typing if we know what's possible
   async runDev(devCommand: unknown): Promise<string> {
-    const { startDev } = await import('@netlify/build')
     const entryPoint = startDev.bind(null, devCommand)
     const { logs } = await entryPoint(this.getBuildFlags())
     return [logs.stdout.join('\n'), logs.stderr.join('\n')].filter(Boolean).join('\n\n')


### PR DESCRIPTION
#### Summary

Fixes FRB-1555
OSX has less memory than the other test runners and the tests seem to be crawling to a halt when running with any concurrency. This update forces the tests to be run serially (no concurrency) on osx runners, but only in GithubActions (we didn't want to affect local development)