### PR TITLE
fix: add move to options type for cache util exposed to build plugins

### DIFF
--- a/packages/build/src/types/options/netlify_plugin_cache_util.ts
+++ b/packages/build/src/types/options/netlify_plugin_cache_util.ts
@@ -7,8 +7,25 @@ export type NetlifyPluginCacheUtil = {
   save(
     path: Many<string>,
     options?: {
+      /**
+       * @default `false`
+       */
+      move?: boolean
       ttl?: number
       digests?: string[]
+      /**
+       * @default `process.cwd()`
+       */
+      cwd?: string
+    },
+  ): Promise<boolean>
+  restore(
+    path: Many<string>,
+    options?: {
+      /**
+       * @default `false`
+       */
+      move?: boolean
       /**
        * @default `process.cwd()`
        */
@@ -26,7 +43,7 @@ export type NetlifyPluginCacheUtil = {
     depth?: number
   }): Promise<string[]>
 } & Record<
-  'restore' | 'remove' | 'has',
+  'remove' | 'has',
   (
     path: Many<string>,
     options?: {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Noticed here - https://github.com/netlify/netlify-plugin-gatsby/pull/753/files#diff-d6feec7c99b0a9ddfead350e1f906b6538249944e8ceff596de691945cbdd064R25-R26 that types that build plugin options have don't have all available options - in this case `move` option that is actually there and working:
- for `save`: https://github.com/netlify/build/blob/04134491e36ab1b6ccf5990edf1885e43d8a15a0/packages/cache-utils/src/main.ts#L24
- for `restore`: https://github.com/netlify/build/blob/04134491e36ab1b6ccf5990edf1885e43d8a15a0/packages/cache-utils/src/main.ts#L57

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
