### PR TITLE
fix(js-client): add type definitions for operation method `opts` argument

### DIFF
--- a/packages/js-client/src/types.ts
+++ b/packages/js-client/src/types.ts
@@ -181,7 +181,7 @@ type CombinedParamsAndRequestBody<K extends keyof operations> =
     ? ExtractPathAndQueryParameters<K> & RequestBodyParam<K>
     : ExtractPathAndQueryParameters<K>
 
-export type OperationParams<K extends keyof operations> =
+type OperationParams<K extends keyof operations> =
   IsParamsOrRequestBodyRequired<K> extends false
     ? CombinedParamsAndRequestBody<K> | void | undefined
     : CombinedParamsAndRequestBody<K>

--- a/packages/js-client/src/types.ts
+++ b/packages/js-client/src/types.ts
@@ -55,20 +55,100 @@ type HasRequestBody<K extends keyof operations> = 'requestBody' extends keyof op
     : false
   : false
 
+/**
+ * Extracts the request body type from the operation.
+ */
 type RequestBody<K extends keyof operations> = 'requestBody' extends keyof operations[K]
   ? operations[K]['requestBody'] extends { content: any }
     ? 'application/json' extends keyof operations[K]['requestBody']['content']
       ? operations[K]['requestBody']['content']['application/json']
       : 'application/octet-stream' extends keyof operations[K]['requestBody']['content']
-        ? any // TODO: handle types for binary data (Blob, File, Buffer, etc.)
+        ? ReadStream | (() => ReadStream)
         : never
     : never
   : never
 
+type IsRequestBodyJson<K extends keyof operations> = 'requestBody' extends keyof operations[K]
+  ? operations[K]['requestBody'] extends { content: any }
+    ? 'application/json' extends keyof operations[K]['requestBody']['content']
+      ? true
+      : false
+    : false
+  : false
+
+type IsRequestBodyOctetStream<K extends keyof operations> = 'requestBody' extends keyof operations[K]
+  ? operations[K]['requestBody'] extends { content: any }
+    ? 'application/octet-stream' extends keyof operations[K]['requestBody']['content']
+      ? true
+      : false
+    : false
+  : false
+
+type RequestBodyParam<K extends keyof operations> =
+  HasRequestBody<K> extends true
+    ? IsRequestBodyOptional<K> extends true
+      ? RequestBodyDecoratorOptional<K>
+      : RequestBodyDecorator<K>
+    : never
+
+type RequestBodyDecorator<K extends keyof operations> =
+  IsRequestBodyJson<K> extends true
+    ? {
+        /**
+         * The request body for `application/json`.
+         * Automatically serialized to JSON based on the operation.
+         * Can be a JSON object or a function returning one.
+         */
+        body: RequestBody<K> | (() => RequestBody<K>)
+      }
+    : IsRequestBodyOctetStream<K> extends true
+      ? {
+          /**
+           * The request body for `application/octet-stream`.
+           * Can be a Node.js readable stream or a function returning one
+           * @example
+           * fs.createReadStream('./file')
+           * @example
+           * () => fs.createReadStream('./file')
+           */
+          body: ReadStream | (() => ReadStream)
+        }
+      : never
+
+type RequestBodyDecoratorOptional<K extends keyof operations> =
+  IsRequestBodyJson<K> extends true
+    ? {
+        /**
+         * The request body for `application/json`.
+         * Automatically serialized to JSON based on the operation.
+         * Can be a JSON object or a function returning one.
+         */
+        body?: RequestBody<K> | (() => RequestBody<K>)
+      }
+    : IsRequestBodyOctetStream<K> extends true
+      ? {
+          /**
+           * The request body for `application/octet-stream`.
+           * Can be a Node.js readable stream or a function returning one
+           * @example
+           * fs.createReadStream('./file')
+           * @example
+           * () => fs.createReadStream('./file')
+           */
+          body?: ReadStream | (() => ReadStream)
+        }
+      : never
+
+/**
+ * Determines whether all properties in the request body are optional.
+ */
 type IsRequestBodyOptional<K extends keyof operations> =
   HasRequestBody<K> extends true ? (AreAllOptional<RequestBody<K>> extends true ? true : false) : true
 
-type IsAnythingRequired<K extends keyof operations> = 'parameters' extends keyof operations[K]
+/**
+ * Determines whether any parameters or request body are required.
+ */
+type IsParamsOrRequestBodyRequired<K extends keyof operations> = 'parameters' extends keyof operations[K]
   ? IsPathAndQueryOptional<K> extends true
     ? IsRequestBodyOptional<K> extends true
       ? false
@@ -92,22 +172,18 @@ type ExtractPathAndQueryParameters<K extends keyof operations> = 'parameters' ex
       : undefined
   : undefined
 
+/**
+ * Combines path, query, and request body parameters into a single type.
+ */
 type CombinedParamsAndRequestBody<K extends keyof operations> =
   HasRequestBody<K> extends true
-    ? ExtractPathAndQueryParameters<K> & {
-        body: RequestBody<K>
-      }
+    ? ExtractPathAndQueryParameters<K> & RequestBodyParam<K>
     : ExtractPathAndQueryParameters<K>
 
-type OperationParams<K extends keyof operations> = 'parameters' extends keyof operations[K]
-  ? IsAnythingRequired<K> extends false
+type OperationParams<K extends keyof operations> =
+  IsParamsOrRequestBodyRequired<K> extends false
     ? CombinedParamsAndRequestBody<K> | void
     : CombinedParamsAndRequestBody<K>
-  : HasRequestBody<K> extends true
-    ? IsRequestBodyOptional<K> extends true
-      ? { body: RequestBody<K> } | void
-      : { body: RequestBody<K> }
-    : void
 
 type SuccessHttpStatusCodes = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 208 | 226
 /**

--- a/packages/js-client/src/types.ts
+++ b/packages/js-client/src/types.ts
@@ -87,11 +87,11 @@ type IsRequestBodyOctetStream<K extends keyof operations> = 'requestBody' extend
 type RequestBodyParam<K extends keyof operations> =
   HasRequestBody<K> extends true
     ? IsRequestBodyOptional<K> extends true
-      ? RequestBodyDecoratorOptional<K>
-      : RequestBodyDecorator<K>
+      ? DetailedRequestBodyOptional<K>
+      : DetailedRequestBody<K>
     : never
 
-type RequestBodyDecorator<K extends keyof operations> =
+type DetailedRequestBody<K extends keyof operations> =
   IsRequestBodyJson<K> extends true
     ? {
         /**
@@ -115,7 +115,7 @@ type RequestBodyDecorator<K extends keyof operations> =
         }
       : never
 
-type RequestBodyDecoratorOptional<K extends keyof operations> =
+type DetailedRequestBodyOptional<K extends keyof operations> =
   IsRequestBodyJson<K> extends true
     ? {
         /**

--- a/packages/js-client/src/types.ts
+++ b/packages/js-client/src/types.ts
@@ -1,6 +1,7 @@
 import type { ReadStream } from 'node:fs'
 
 import type { operations } from '@netlify/open-api'
+import type { RequestInit } from 'node-fetch'
 
 /**
  * Determines whether all keys in T are optional.
@@ -180,9 +181,9 @@ type CombinedParamsAndRequestBody<K extends keyof operations> =
     ? ExtractPathAndQueryParameters<K> & RequestBodyParam<K>
     : ExtractPathAndQueryParameters<K>
 
-type OperationParams<K extends keyof operations> =
+export type OperationParams<K extends keyof operations> =
   IsParamsOrRequestBodyRequired<K> extends false
-    ? CombinedParamsAndRequestBody<K> | void
+    ? CombinedParamsAndRequestBody<K> | void | undefined
     : CombinedParamsAndRequestBody<K>
 
 type SuccessHttpStatusCodes = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 208 | 226
@@ -202,5 +203,31 @@ type OperationResponse<K extends keyof operations> = 'responses' extends keyof o
   : never
 
 export type DynamicMethods = {
-  [K in keyof operations]: (params: OperationParams<K>) => Promise<OperationResponse<K>>
+  [K in keyof operations]: (
+    params: OperationParams<K>,
+    /**
+     * Any properties you want passed to `node-fetch`.
+     *
+     * The `headers` property is merged with some `defaultHeaders`:
+     * ```ts
+     * {
+     *  'User-agent': 'netlify-js-client',
+     *  'accept': 'application/json',
+     * }
+     * ```
+     *
+     * @example
+     * ```ts
+     * const site = await client.getSite(
+     *  { site_id: 'YOUR_SITE_ID' },
+     *  {
+     *    headers: {
+     *      'X-Example-Header': 'Example Value',
+     *    },
+     *  },
+     * )
+     * ```
+     */
+    opts?: RequestInit | void | undefined,
+  ) => Promise<OperationResponse<K>>
 }


### PR DESCRIPTION
#### Summary

All dynamic operation methods can have a second arg `opts` to pass any additional properties to `node-fetch` `RequestInit`. This change adds the type definition for the `opts` argument.

Also allow passing `undefined` for `params` argument for methods that don't accept any `params` but still might want to pass `opts`.

example:
```ts
const user = await client.getCurrentUser(undefined, {
  headers: {
    'X-Some-Header': 'custom value',
  },
})
```


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
