### PR TITLE
test: sort setting before comparing to snapshot

### DIFF
--- a/packages/build-info/src/node/get-build-info.test.ts
+++ b/packages/build-info/src/node/get-build-info.test.ts
@@ -68,6 +68,7 @@ test.skipIf(platform() === 'win32')('should retrieve the build info for providin
   const info = await getBuildInfo({ rootDir: fixture.cwd })
 
   info.jsWorkspaces!.rootDir = '/cleaned-for-snapshot'
+  info.settings = info.settings.sort((a, b) => (a.dist < b.dist ? -1 : 1))
   expect(info).toMatchSnapshot()
 })
 


### PR DESCRIPTION
#### Summary

Fixes FRB-1563
Some runs we return the build settings in a different order. To resolve here I've opted to sort the settings before checking the snapshot.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
