### PR TITLE
fix: multiple plugin versions in a monorepo setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24264,6 +24264,8 @@
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -28669,7 +28671,7 @@
         "ps-list": "^8.0.0",
         "read-package-up": "^11.0.0",
         "readdirp": "^3.4.0",
-        "resolve": "^2.0.0-next.1",
+        "resolve": "^2.0.0-next.5",
         "rfdc": "^1.3.0",
         "safe-json-stringify": "^1.2.0",
         "semver": "^7.3.8",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -112,7 +112,7 @@
     "ps-list": "^8.0.0",
     "read-package-up": "^11.0.0",
     "readdirp": "^3.4.0",
-    "resolve": "^2.0.0-next.1",
+    "resolve": "^2.0.0-next.5",
     "rfdc": "^1.3.0",
     "safe-json-stringify": "^1.2.0",
     "semver": "^7.3.8",

--- a/packages/build/src/plugins/resolve.js
+++ b/packages/build/src/plugins/resolve.js
@@ -37,7 +37,7 @@ export const resolvePluginsPath = async function ({
 }) {
   const autoPluginsDir = getAutoPluginsDir(buildDir, packagePath)
   const pluginsOptionsA = await Promise.all(
-    pluginsOptions.map((pluginOptions) => resolvePluginPath({ pluginOptions, buildDir, autoPluginsDir })),
+    pluginsOptions.map((pluginOptions) => resolvePluginPath({ pluginOptions, buildDir, packagePath, autoPluginsDir })),
   )
   const pluginsOptionsB = await addPluginsNodeVersion({
     featureFlags,
@@ -100,6 +100,7 @@ const resolvePluginPath = async function ({
   pluginOptions,
   pluginOptions: { packageName, loadedFrom },
   buildDir,
+  packagePath,
   autoPluginsDir,
 }) {
   // Core plugins
@@ -107,9 +108,8 @@ const resolvePluginPath = async function ({
     return pluginOptions
   }
 
-  const localPackageName = normalizeLocalPackageName(packageName)
-
   // Local plugins
+  const localPackageName = normalizeLocalPackageName(packageName)
   if (localPackageName.startsWith('.')) {
     const { path: localPath, error } = await tryResolvePath(localPackageName, buildDir)
     validateLocalPluginPath(error, localPackageName)
@@ -117,7 +117,8 @@ const resolvePluginPath = async function ({
   }
 
   // Plugin added to `package.json`
-  const { path: manualPath } = await tryResolvePath(packageName, buildDir)
+  const packageDir = join(buildDir, packagePath || '')
+  const { path: manualPath } = await tryResolvePath(packageName, packageDir)
   if (manualPath !== undefined) {
     return { ...pluginOptions, pluginPath: manualPath, loadedFrom: 'package.json' }
   }

--- a/packages/build/tests/plugins/fixtures/monorepo/apps/pinned/package.json
+++ b/packages/build/tests/plugins/fixtures/monorepo/apps/pinned/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module_plugin",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test",
+  "dependencies": {
+    "netlify-plugin-test": "8.2.0"
+  }
+}

--- a/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/netlify.toml
+++ b/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+publish = "/"
+
+[[plugins]]
+package = "netlify-plugin-test"

--- a/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/node_modules/netlify-plugin-test/index.js
@@ -1,0 +1,3 @@
+export const onPreBuild = function () {
+    console.log('test')
+}

--- a/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/node_modules/netlify-plugin-test/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/node_modules/netlify-plugin-test/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/node_modules/netlify-plugin-test/package.json
+++ b/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/node_modules/netlify-plugin-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "netlify-plugin-test",
+  "version": "8.5.3",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test"
+}

--- a/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/package.json
+++ b/packages/build/tests/plugins/fixtures/monorepo/apps/unpinned/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module_plugin",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test",
+  "dependencies": {
+    "netlify-plugin-test": "^8.5.3"
+  }
+}

--- a/packages/build/tests/plugins/fixtures/monorepo/node_modules/netlify-plugin-test/index.js
+++ b/packages/build/tests/plugins/fixtures/monorepo/node_modules/netlify-plugin-test/index.js
@@ -1,0 +1,3 @@
+export const onPreBuild = function () {
+    console.log('test')
+}

--- a/packages/build/tests/plugins/fixtures/monorepo/node_modules/netlify-plugin-test/manifest.yml
+++ b/packages/build/tests/plugins/fixtures/monorepo/node_modules/netlify-plugin-test/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/plugins/fixtures/monorepo/node_modules/netlify-plugin-test/package.json
+++ b/packages/build/tests/plugins/fixtures/monorepo/node_modules/netlify-plugin-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "netlify-plugin-test",
+  "version": "8.2.0",
+  "type": "module",
+  "description": "test",
+  "license": "MIT",
+  "repository": "test"
+}

--- a/packages/build/tests/plugins/fixtures/monorepo/node_modules/unpinned
+++ b/packages/build/tests/plugins/fixtures/monorepo/node_modules/unpinned
@@ -1,0 +1,1 @@
+../apps/unpinned

--- a/packages/build/tests/plugins/fixtures/monorepo/package.json
+++ b/packages/build/tests/plugins/fixtures/monorepo/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "module_multiple",
+    "workspaces": [
+      "apps/*"
+    ]
+}

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -86,6 +86,12 @@ test('Resolution is relative to the build directory', async (t) => {
   t.snapshot(normalizeOutput(output))
 })
 
+test('Resolution respects monorepo node module resolution rules', async (t) => {
+  const fixture = await new Fixture('./fixtures/monorepo')
+  const output = await fixture.withFlags({ packagePath: 'apps/unpinned' }).runWithBuild()
+  t.assert(output.indexOf('@8.5.3') > 0)
+})
+
 test('Non-existing plugins', async (t) => {
   const output = await new Fixture('./fixtures/non_existing').runWithBuild()
   t.snapshot(normalizeOutput(output))

--- a/packages/build/tests/plugins/tests.js
+++ b/packages/build/tests/plugins/tests.js
@@ -89,6 +89,9 @@ test('Resolution is relative to the build directory', async (t) => {
 test('Resolution respects monorepo node module resolution rules', async (t) => {
   const fixture = await new Fixture('./fixtures/monorepo')
   const output = await fixture.withFlags({ packagePath: 'apps/unpinned' }).runWithBuild()
+  // fixture has 2 versions of the same build plugin used by different workspaces
+  // this ensures version used by apps/unpinned is used instead of version that
+  // is hoisted in shared monorepo node_modules
   t.assert(output.indexOf('@8.5.3') > 0)
 })
 


### PR DESCRIPTION
#### Summary

Patch the system to support multiple version of plugins (e.g. next-runtime) in a monorepo context
Bonus: Package version bump for resolve

Fixes FRB-1641

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
