### PR TITLE
feat: default `zisi_add_metadata_file` flag to true

### DIFF
--- a/packages/zip-it-and-ship-it/src/feature_flags.ts
+++ b/packages/zip-it-and-ship-it/src/feature_flags.ts
@@ -31,7 +31,7 @@ export const defaultFlags = {
   zisi_add_instrumentation_loader: true,
 
   // Adds a `___netlify-metadata.json` file to the function bundle.
-  zisi_add_metadata_file: false,
+  zisi_add_metadata_file: true,
 } as const
 
 export type FeatureFlags = Partial<Record<keyof typeof defaultFlags, boolean>>


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary
When running `ntl deploy --prod` this flag is not being fetched and therefore has been defaulting to `false`. However, when running `ntl deploy --prod --build` this flag is fetched.

This sets the default to `true` as this refers to a feature that is now in production.

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
