### PR TITLE
feat: remove references to removed flag and always produce manfiest

### DIFF
--- a/packages/build/tests/functions/tests.js
+++ b/packages/build/tests/functions/tests.js
@@ -209,7 +209,6 @@ test('Functions: creates metadata file', async (t) => {
     .withFlags({
       branch: 'my-branch',
       cwd: fixture.repositoryRoot,
-      featureFlags: { zisi_add_metadata_file: true },
     })
     .runWithBuildAndIntrospect()
 

--- a/packages/zip-it-and-ship-it/src/feature_flags.ts
+++ b/packages/zip-it-and-ship-it/src/feature_flags.ts
@@ -29,9 +29,6 @@ export const defaultFlags = {
 
   // Adds the `___netlify-telemetry.mjs` file to the function bundle.
   zisi_add_instrumentation_loader: true,
-
-  // Adds a `___netlify-metadata.json` file to the function bundle.
-  zisi_add_metadata_file: false,
 } as const
 
 export type FeatureFlags = Partial<Record<keyof typeof defaultFlags, boolean>>

--- a/packages/zip-it-and-ship-it/src/runtimes/node/utils/zip.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/utils/zip.ts
@@ -255,14 +255,12 @@ const createZipArchive = async function ({
   if (runtimeAPIVersion === 2) {
     const bootstrapPath = addBootstrapFile(srcFiles, aliases)
 
-    if (featureFlags.zisi_add_metadata_file === true) {
-      const { version } = await getPackageJsonIfAvailable(bootstrapPath)
-      const payload = JSON.stringify(getMetadataFile(version, branch))
+    const { version } = await getPackageJsonIfAvailable(bootstrapPath)
+    const payload = JSON.stringify(getMetadataFile(version, branch))
 
-      bootstrapVersion = version
+    bootstrapVersion = version
 
-      addZipContent(archive, payload, METADATA_FILE_NAME)
-    }
+    addZipContent(archive, payload, METADATA_FILE_NAME)
   }
 
   const deduplicatedSrcFiles = [...new Set(srcFiles)]

--- a/packages/zip-it-and-ship-it/src/zip.ts
+++ b/packages/zip-it-and-ship-it/src/zip.ts
@@ -128,9 +128,7 @@ export const zipFunctions = async function (
     }),
   )
 
-  if (manifest !== undefined) {
-    await createManifest({ functions: formattedResults, path: resolve(manifest) })
-  }
+  await createManifest({ functions: formattedResults, path: resolve(manifest) })
 
   return formattedResults
 }

--- a/packages/zip-it-and-ship-it/src/zip.ts
+++ b/packages/zip-it-and-ship-it/src/zip.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs'
-import { resolve } from 'path'
+import { join, resolve } from 'path'
 
 import isPathInside from 'is-path-inside'
 import pMap from 'p-map'
@@ -128,7 +128,7 @@ export const zipFunctions = async function (
     }),
   )
 
-  await createManifest({ functions: formattedResults, path: resolve(manifest) })
+  await createManifest({ functions: formattedResults, path: resolve(manifest || join(destFolder, 'manifest.json')) })
 
   return formattedResults
 }

--- a/packages/zip-it-and-ship-it/tests/symlinked_included_files.test.ts
+++ b/packages/zip-it-and-ship-it/tests/symlinked_included_files.test.ts
@@ -60,6 +60,7 @@ test.skipIf(platform() === 'win32')('Symlinked directories from `includedFiles` 
     '___netlify-bootstrap.mjs': false,
     '___netlify-entry-point.mjs': false,
     '___netlify-telemetry.mjs': false,
+    '___netlify-metadata.json': false,
     'function.mjs': false,
     [join('node_modules/.pnpm/crazy-dep/package.json')]: false,
     [join('node_modules/crazy-dep')]: true,

--- a/packages/zip-it-and-ship-it/tests/telemetry.test.ts
+++ b/packages/zip-it-and-ship-it/tests/telemetry.test.ts
@@ -36,6 +36,7 @@ test('The telemetry file should be added by default to the function bundle', asy
   expect(files.sort()).toEqual([
     '___netlify-bootstrap.mjs',
     '___netlify-entry-point.mjs',
+    '___netlify-metadata.json',
     '___netlify-telemetry.mjs',
     'function.mjs',
     'package.json',
@@ -98,6 +99,7 @@ test('The telemetry file should not be added to the bundle if the feature flag i
   expect(files.sort()).toEqual([
     '___netlify-bootstrap.mjs',
     '___netlify-entry-point.mjs',
+    '___netlify-metadata.json',
     'function.mjs',
     'package.json',
   ])

--- a/packages/zip-it-and-ship-it/tests/v2api.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2api.test.ts
@@ -714,11 +714,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       const fixtureName = 'v2-api'
       const { files } = await zipFixture(fixtureName, {
         fixtureDir: FIXTURES_ESM_DIR,
-        opts: {
-          featureFlags: {
-            zisi_add_metadata_file: true,
-          },
-        },
       })
       const [unzippedFunction] = await unzipFiles(files)
       const bootstrapPath = getBootstrapPath()
@@ -735,9 +730,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
         fixtureDir: FIXTURES_ESM_DIR,
         opts: {
           branch: 'main',
-          featureFlags: {
-            zisi_add_metadata_file: true,
-          },
         },
       })
       const [unzippedFunction] = await unzipFiles(files)
@@ -765,9 +757,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     const { files } = await zipFixture('v2-api', {
       fixtureDir: FIXTURES_ESM_DIR,
       opts: {
-        featureFlags: {
-          zisi_add_metadata_file: true,
-        },
         manifest: manifestPath,
       },
     })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary
We have found that locally deployed functions do not always pass a bootstrap_version to our API. To ensure this is included, we are unconditionally creating amanifest.json, which is where this value is drawn from.

This PR also removes the zisi_add_metadata_file flag, which has been switched on in production for a while.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
