### PR TITLE
fix(config): retry fetching extensions on failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24341,7 +24341,8 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
         "node": ">= 4"
       }
@@ -29071,6 +29072,7 @@
         "omit.js": "^2.0.2",
         "p-locate": "^6.0.0",
         "path-type": "^5.0.0",
+        "retry": "^0.13.1",
         "tomlify-j0.4": "^3.0.0",
         "validate-npm-package-name": "^4.0.0",
         "yargs": "^17.6.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -59,6 +59,8 @@
   "license": "MIT",
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@netlify/headers-parser": "^8.0.0",
+    "@netlify/redirect-parser": "^14.5.0",
     "chalk": "^5.0.0",
     "cron-parser": "^4.1.0",
     "deepmerge": "^4.2.2",
@@ -73,12 +75,11 @@
     "js-yaml": "^4.0.0",
     "map-obj": "^5.0.0",
     "netlify": "^13.3.3",
-    "@netlify/headers-parser": "^8.0.0",
-    "@netlify/redirect-parser": "^14.5.0",
     "node-fetch": "^3.3.1",
     "omit.js": "^2.0.2",
     "p-locate": "^6.0.0",
     "path-type": "^5.0.0",
+    "retry": "^0.13.1",
     "tomlify-j0.4": "^3.0.0",
     "validate-npm-package-name": "^4.0.0",
     "yargs": "^17.6.0"

--- a/packages/config/src/api/site_info.ts
+++ b/packages/config/src/api/site_info.ts
@@ -7,7 +7,7 @@ import { throwUserError } from '../error.js'
 import { ERROR_CALL_TO_ACTION } from '../log/messages.js'
 import { IntegrationResponse } from '../types/api.js'
 import { ModeOption, TestOptions } from '../types/options.js'
-import retry from "retry"
+import retry from 'retry'
 
 type GetSiteInfoOpts = {
   siteId: string
@@ -165,10 +165,10 @@ const getIntegrations = async function ({
       if (!response.ok) {
         throw new Error(`Unexpected status code ${response.status} from fetching extensions`)
       }
-      
+
       bodyText = await response.text()
     })
-    
+
     if (bodyText === '') {
       return []
     }


### PR DESCRIPTION
#### Summary

Retry fetch to get extensions from jigsaw. If this call fails the build will fail.

Jigsaw calls BB, and we see that there's the occasionally blip in the request there, so this will make fetching extensions succeed more consistently.
