### PR TITLE
chore: add missing dependencies on local `@netlify/testing` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28691,6 +28691,7 @@
       },
       "devDependencies": {
         "@netlify/nock-udp": "^4.0.0",
+        "@netlify/testing": "^0.0.0-local",
         "@opentelemetry/api": "~1.8.0",
         "@opentelemetry/sdk-trace-base": "~1.24.0",
         "@types/node": "^14.18.53",
@@ -29079,6 +29080,7 @@
         "netlify-config": "bin.js"
       },
       "devDependencies": {
+        "@netlify/testing": "^0.0.0-local",
         "@types/node": "^14.18.53",
         "ava": "^4.0.0",
         "c8": "^7.12.0",
@@ -29983,6 +29985,7 @@
     },
     "packages/testing": {
       "name": "@netlify/testing",
+      "version": "0.0.0-local",
       "devDependencies": {
         "@netlify/build": "^30.0.0",
         "@netlify/config": "^21.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -127,6 +127,7 @@
   },
   "devDependencies": {
     "@netlify/nock-udp": "^4.0.0",
+    "@netlify/testing": "^0.0.0-local",
     "@opentelemetry/api": "~1.8.0",
     "@opentelemetry/sdk-trace-base": "~1.24.0",
     "@types/node": "^14.18.53",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -59,6 +59,8 @@
   "license": "MIT",
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@netlify/headers-parser": "^8.0.0",
+    "@netlify/redirect-parser": "^14.5.0",
     "chalk": "^5.0.0",
     "cron-parser": "^4.1.0",
     "deepmerge": "^4.2.2",
@@ -73,8 +75,6 @@
     "js-yaml": "^4.0.0",
     "map-obj": "^5.0.0",
     "netlify": "^13.3.3",
-    "@netlify/headers-parser": "^8.0.0",
-    "@netlify/redirect-parser": "^14.5.0",
     "node-fetch": "^3.3.1",
     "omit.js": "^2.0.2",
     "p-locate": "^6.0.0",
@@ -84,6 +84,7 @@
     "yargs": "^17.6.0"
   },
   "devDependencies": {
+    "@netlify/testing": "^0.0.0-local",
     "@types/node": "^14.18.53",
     "ava": "^4.0.0",
     "c8": "^7.12.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@netlify/testing",
   "private": true,
+  "version": "0.0.0-local",
   "type": "module",
   "exports": "./lib/index.js",
   "main": "./lib/index.js",


### PR DESCRIPTION
#### Summary

`@netlify/build` and `@netlify/config` had dev dependencies on the local `@netlify/testing` package (which is a local package only, not published to NPM) but they weren't specified in its `package.json`

So, I think this is what resulted:
- These imports only sort of happened to work
- TS wasn't complaining because we've explictly remapped that import: https://github.com/netlify/build/blob/65206cf/tsconfig.base.json#L30.
- ESLint wasn't complaining because although we are using eslint-plugin-import, we aren't using the recommended ruleset and we aren't enabling [`no-extraneous-dependencies`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md)
- release-please didn't know about that part of our dependency graph, so it was opening [release PRs like this one](https://github.com/netlify/build/pull/6107) that should have bumped `@netlify/build` and `@netlify/config` in `packages/testing` but [did not](https://github.com/netlify/build/pull/6124)

pnpm and yarn support `workspace:*` to make this local dependency explicit, but we're using npm workspaces, which do not. I opted to include a `-local` prefix to make this extra explicit.

Disclaimer: I'm not 100% sure if this change will resolve the release-please issue, but it seems desirable either way.