### PR TITLE
fix: use staging url for extensions on staging

### DIFF
--- a/packages/config/src/api/integrations.ts
+++ b/packages/config/src/api/integrations.ts
@@ -4,19 +4,17 @@ import { TestOptions } from '../types/options.js'
 
 type AvailableIntegration = { slug: string; hostSiteUrl: string; hasBuild?: boolean }
 
-type GetAvailableIntegrationsOpts = { testOpts: TestOptions; offline: boolean; netlifyApiHost: string }
+type GetAvailableIntegrationsOpts = { testOpts: TestOptions; offline: boolean; extensionApiBaseUrl: string }
 
 export const getAvailableIntegrations = async function ({
   testOpts,
   offline,
-  netlifyApiHost,
+  extensionApiBaseUrl,
 }: GetAvailableIntegrationsOpts): Promise<AvailableIntegration[]> {
   if (offline) {
     return []
   }
   const { host } = testOpts
-  const extensionApiBaseUrl =
-    netlifyApiHost === 'api.netlify.com' ? 'https://api.netlifysdk.com/' : `https://api-staging.netlifysdk.com/`
   const baseUrl = new URL(host ? `http://${host}/` : extensionApiBaseUrl)
 
   try {

--- a/packages/config/src/api/integrations.ts
+++ b/packages/config/src/api/integrations.ts
@@ -2,26 +2,22 @@ import fetch from 'node-fetch'
 
 import { TestOptions } from '../types/options.js'
 
-type AvailableIntegration = {
-  slug: string
-  hostSiteUrl: string
-  hasBuild?: boolean
-}
+type AvailableIntegration = { slug: string; hostSiteUrl: string; hasBuild?: boolean }
 
-type GetAvailableIntegrationsOpts = {
-  testOpts: TestOptions
-  offline: boolean
-}
+type GetAvailableIntegrationsOpts = { testOpts: TestOptions; offline: boolean; netlifyApiHost: string }
 
 export const getAvailableIntegrations = async function ({
   testOpts,
   offline,
+  netlifyApiHost,
 }: GetAvailableIntegrationsOpts): Promise<AvailableIntegration[]> {
   if (offline) {
     return []
   }
   const { host } = testOpts
-  const baseUrl = new URL(host ? `http://${host}/` : `https://api.netlifysdk.com/`)
+  const extensionApiBaseUrl =
+    netlifyApiHost === 'api.netlify.com' ? 'https://api.netlifysdk.com/' : `https://api-staging.netlifysdk.com/`
+  const baseUrl = new URL(host ? `http://${host}/` : extensionApiBaseUrl)
 
   try {
     const response = await fetch(`${baseUrl}integrations`)

--- a/packages/config/src/api/site_info.ts
+++ b/packages/config/src/api/site_info.ts
@@ -19,7 +19,7 @@ type GetSiteInfoOpts = {
   testOpts?: TestOptions
   siteFeatureFlagPrefix: string
   token: string
-  netlifyApiHost: string
+  extensionApiBaseUrl: string
 }
 /**
  * Retrieve Netlify Site information, if available.
@@ -41,7 +41,7 @@ export const getSiteInfo = async function ({
   siteFeatureFlagPrefix,
   token,
   featureFlags = {},
-  netlifyApiHost,
+  extensionApiBaseUrl,
 }: GetSiteInfoOpts) {
   const { env: testEnv = false } = testOpts
 
@@ -53,7 +53,7 @@ export const getSiteInfo = async function ({
 
     const integrations =
       mode === 'buildbot' && !offline
-        ? await getIntegrations({ siteId, testOpts, offline, accountId, token, featureFlags, netlifyApiHost })
+        ? await getIntegrations({ siteId, testOpts, offline, accountId, token, featureFlags, extensionApiBaseUrl })
         : []
 
     return { siteInfo, accounts: [], addons: [], integrations }
@@ -63,7 +63,7 @@ export const getSiteInfo = async function ({
     getSite(api, siteId, siteFeatureFlagPrefix),
     getAccounts(api),
     getAddons(api, siteId),
-    getIntegrations({ siteId, testOpts, offline, accountId, token, featureFlags, netlifyApiHost }),
+    getIntegrations({ siteId, testOpts, offline, accountId, token, featureFlags, extensionApiBaseUrl }),
   ]
 
   const [siteInfo, accounts, addons, integrations] = await Promise.all(promises)
@@ -119,7 +119,7 @@ type GetIntegrationsOpts = {
   offline: boolean
   token?: string
   featureFlags?: Record<string, boolean>
-  netlifyApiHost: string
+  extensionApiBaseUrl: string
 }
 
 const getIntegrations = async function ({
@@ -129,15 +129,13 @@ const getIntegrations = async function ({
   offline,
   token,
   featureFlags,
-  netlifyApiHost,
+  extensionApiBaseUrl,
 }: GetIntegrationsOpts): Promise<IntegrationResponse[]> {
   if (!siteId || offline) {
     return []
   }
   const sendBuildBotTokenToJigsaw = featureFlags?.send_build_bot_token_to_jigsaw
   const { host } = testOpts
-  const extensionApiBaseUrl =
-    netlifyApiHost === 'api.netlify.com' ? 'https://api.netlifysdk.com' : `https://api-staging.netlifysdk.com `
   const baseUrl = new URL(host ? `http://${host}` : extensionApiBaseUrl)
 
   // if accountId isn't present, use safe v1 endpoint

--- a/packages/config/src/integrations.ts
+++ b/packages/config/src/integrations.ts
@@ -9,6 +9,7 @@ type MergeIntegrationsOpts = {
   context: string
   testOpts?: TestOptions
   offline: boolean
+  netlifyApiHost: string
 }
 
 export const mergeIntegrations = async function ({
@@ -17,8 +18,9 @@ export const mergeIntegrations = async function ({
   context,
   testOpts = {},
   offline,
+  netlifyApiHost,
 }: MergeIntegrationsOpts): Promise<Integration[]> {
-  const availableIntegrations = await getAvailableIntegrations({ testOpts, offline })
+  const availableIntegrations = await getAvailableIntegrations({ testOpts, offline, netlifyApiHost })
 
   // Include all API integrations, unless they have a `dev` property and we are in the `dev` context
   const resolvedApiIntegrations = apiIntegrations.filter(

--- a/packages/config/src/integrations.ts
+++ b/packages/config/src/integrations.ts
@@ -9,7 +9,7 @@ type MergeIntegrationsOpts = {
   context: string
   testOpts?: TestOptions
   offline: boolean
-  netlifyApiHost: string
+  extensionApiBaseUrl: string
 }
 
 export const mergeIntegrations = async function ({
@@ -18,9 +18,9 @@ export const mergeIntegrations = async function ({
   context,
   testOpts = {},
   offline,
-  netlifyApiHost,
+  extensionApiBaseUrl,
 }: MergeIntegrationsOpts): Promise<Integration[]> {
-  const availableIntegrations = await getAvailableIntegrations({ testOpts, offline, netlifyApiHost })
+  const availableIntegrations = await getAvailableIntegrations({ testOpts, offline, extensionApiBaseUrl })
 
   // Include all API integrations, unless they have a `dev` property and we are in the `dev` context
   const resolvedApiIntegrations = apiIntegrations.filter(

--- a/packages/config/src/main.ts
+++ b/packages/config/src/main.ts
@@ -51,7 +51,7 @@ export const resolveConfig = async function (opts) {
 
   // TODO(kh): remove this mapping and get the extensionApiHost from the opts
   const extensionApiBaseUrl =
-    host === 'api.netlify.com' ? 'https://api.netlifysdk.com' : `https://api-staging.netlifysdk.com `
+    host === 'api-staging.netlify.com' ? 'https://api-staging.netlifysdk.com' : 'https://api.netlifysdk.com'
 
   const {
     config: configOpt,

--- a/packages/config/src/main.ts
+++ b/packages/config/src/main.ts
@@ -81,6 +81,7 @@ export const resolveConfig = async function (opts) {
     featureFlags,
     testOpts,
     token,
+    netlifyApiHost: host,
   })
 
   const { defaultConfig: defaultConfigA, baseRelDir: baseRelDirA } = parseDefaultConfig({
@@ -131,6 +132,7 @@ export const resolveConfig = async function (opts) {
     context: context,
     testOpts,
     offline,
+    netlifyApiHost: host,
   })
 
   const result = {

--- a/packages/config/src/main.ts
+++ b/packages/config/src/main.ts
@@ -49,6 +49,10 @@ export const resolveConfig = async function (opts) {
     return parsedCachedConfig
   }
 
+  // TODO(kh): remove this mapping and get the extensionApiHost from the opts
+  const extensionApiBaseUrl =
+    host === 'api.netlify.com' ? 'https://api.netlifysdk.com' : `https://api-staging.netlifysdk.com `
+
   const {
     config: configOpt,
     defaultConfig,
@@ -81,7 +85,7 @@ export const resolveConfig = async function (opts) {
     featureFlags,
     testOpts,
     token,
-    netlifyApiHost: host,
+    extensionApiBaseUrl,
   })
 
   const { defaultConfig: defaultConfigA, baseRelDir: baseRelDirA } = parseDefaultConfig({
@@ -132,7 +136,7 @@ export const resolveConfig = async function (opts) {
     context: context,
     testOpts,
     offline,
-    netlifyApiHost: host,
+    extensionApiBaseUrl,
   })
 
   const result = {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

This ensures that we align our extension API with the right environment.

We use the netlify api host to check if we are on production or staging. This determines the extension api url.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
