### PR TITLE
[do not merge] fix(deps): upgrade `glob` from v8 to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9086,26 +9086,10 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
     },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/glob-to-regexp": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.4.tgz",
       "integrity": "sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==",
-      "dev": true
-    },
-    "node_modules/@types/glob/node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
@@ -22867,6 +22851,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
     "node_modules/pacote": {
       "version": "13.6.2",
       "dev": true,
@@ -23039,15 +23028,15 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -30341,7 +30330,7 @@
         "fast-glob": "^3.3.2",
         "filter-obj": "^5.0.0",
         "find-up": "^6.0.0",
-        "glob": "^8.0.3",
+        "glob": "^10.4.5",
         "is-builtin-module": "^3.1.0",
         "is-path-inside": "^4.0.0",
         "junk": "^4.0.0",
@@ -30367,7 +30356,6 @@
       },
       "devDependencies": {
         "@types/archiver": "6.0.3",
-        "@types/glob": "8.1.0",
         "@types/is-ci": "3.0.4",
         "@types/node": "20.12.11",
         "@types/normalize-path": "3.0.2",
@@ -30819,6 +30807,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/zip-it-and-ship-it/node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/zip-it-and-ship-it/node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -30832,32 +30846,22 @@
       }
     },
     "packages/zip-it-and-ship-it/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": ">=12"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/zip-it-and-ship-it/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/zip-it-and-ship-it/node_modules/hosted-git-info": {
@@ -30885,6 +30889,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "packages/zip-it-and-ship-it/node_modules/normalize-package-data": {

--- a/packages/zip-it-and-ship-it/package.json
+++ b/packages/zip-it-and-ship-it/package.json
@@ -55,7 +55,7 @@
     "fast-glob": "^3.3.2",
     "filter-obj": "^5.0.0",
     "find-up": "^6.0.0",
-    "glob": "^8.0.3",
+    "glob": "^10.4.5",
     "is-builtin-module": "^3.1.0",
     "is-path-inside": "^4.0.0",
     "junk": "^4.0.0",
@@ -78,7 +78,6 @@
   },
   "devDependencies": {
     "@types/archiver": "6.0.3",
-    "@types/glob": "8.1.0",
     "@types/is-ci": "3.0.4",
     "@types/node": "20.12.11",
     "@types/normalize-path": "3.0.2",

--- a/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -62,6 +62,7 @@ const includedFilesToEsbuildExternals = async (includedFiles: string[], baseDir:
       const resolved = await glob(pattern, {
         noglobstar: true,
         cwd: baseDir,
+        dotRelative: true,
       })
 
       result.push(...resolved)

--- a/packages/zip-it-and-ship-it/src/utils/matching.ts
+++ b/packages/zip-it-and-ship-it/src/utils/matching.ts
@@ -1,28 +1,30 @@
-import { promisify } from 'util'
-
-import globFunction from 'glob'
-import { minimatch as minimatchFunction, MinimatchOptions } from 'minimatch'
+import { glob as originalGlob, type GlobOptions } from 'glob'
+import { minimatch as minimatchFunction, type MinimatchOptions } from 'minimatch'
 import normalizePath from 'normalize-path'
 
-const pGlob = promisify(globFunction)
+// We don't use this. Specifying that we don't makes typing easier, since otherwise `glob` returns
+// either `string[]` or `Path[]` depending on this passed option.
+type Options = Omit<GlobOptions, 'withFileTypes'>
 
 /**
  * Both glob and minimatch only support unix style slashes in patterns
- * For this reason we wrap them and ensure all patters are always unixified
+ * For this reason we wrap them and ensure all patterns are always unixified
  * We use `normalize-path` here instead of `unixify` because we do not want to remove drive letters
  */
-
-export const glob = function (pattern: string, options: globFunction.IOptions): Promise<string[]> {
-  let normalizedIgnore
+export const glob = function (pattern: string, options: Options): Promise<string[]> {
+  let normalizedIgnore: string | undefined
 
   if (options.ignore) {
-    normalizedIgnore =
-      typeof options.ignore === 'string'
-        ? normalizePath(options.ignore)
-        : options.ignore.map((expression) => normalizePath(expression))
+    if (typeof options.ignore === 'string') {
+      normalizedIgnore = normalizePath(options.ignore)
+    } else if (Array.isArray(options.ignore)) {
+      options.ignore.map((expression) => normalizePath(expression))
+    } else {
+      throw new Error('Custom glob ignore is not supported')
+    }
   }
 
-  return pGlob(normalizePath(pattern), { ...options, ignore: normalizedIgnore })
+  return originalGlob(normalizePath(pattern), { ...options, ignore: normalizedIgnore })
 }
 
 export const minimatch = function (target: string, pattern: string, options?: MinimatchOptions): boolean {

--- a/packages/zip-it-and-ship-it/tests/v2api.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2api.test.ts
@@ -1,11 +1,10 @@
 import { readFile } from 'fs/promises'
 import { join, resolve } from 'path'
 import { platform, version as nodeVersion } from 'process'
-import { promisify } from 'util'
 
 import { getPath as getBootstrapPath } from '@netlify/serverless-functions-api'
 import merge from 'deepmerge'
-import glob from 'glob'
+import glob from 'fast-glob'
 import { pathExists } from 'path-exists'
 import semver from 'semver'
 import { dir as getTmpDir } from 'tmp-promise'
@@ -17,8 +16,6 @@ import { DEFAULT_NODE_VERSION } from '../src/runtimes/node/utils/node_version.js
 import { invokeLambda, readAsBuffer } from './helpers/lambda.js'
 import { zipFixture, unzipFiles, importFunctionFile, FIXTURES_ESM_DIR, FIXTURES_DIR } from './helpers/main.js'
 import { testMany } from './helpers/test_many.js'
-
-const pGlob = promisify(glob)
 
 vi.mock('../src/utils/shell.js', () => ({ shellUtils: { runCommand: vi.fn() } }))
 
@@ -132,7 +129,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       const [{ name: archive, entryFilename, path }] = files
 
-      const untranspiledFiles = await pGlob(`${path}/**/*.ts`)
+      const untranspiledFiles = await glob(`${path}/**/*.ts`)
       expect(untranspiledFiles).toEqual([])
 
       const func = await importFunctionFile(`${tmpDir}/${archive}/${entryFilename}`)


### PR DESCRIPTION
#### Summary

glob@8 prints deprecation warnings on install, which is visible to all users of the Netlify CLI.

Unfortunately we can't even upgrade to glob@9 until we drop support for node 14 here (glob@9 requires node 16).

#### Related

See also alternative PR removing `glob` entirely: https://github.com/netlify/build/pull/6094.