### PR TITLE
fix(types): add missing `schedule` to functions config type

### DIFF
--- a/packages/build-info/src/settings/netlify-toml.ts
+++ b/packages/build-info/src/settings/netlify-toml.ts
@@ -341,6 +341,7 @@ export type Functions = {
   included_files?: IncludedFiles
   node_bundler?: NodeBundler
   directory?: Directory
+  schedule?: string
   /**
    * Options that only apply for this filter by name, including using glob patterns. If a function matches several configuration blocks containing one of these properties, the values are concatenated.
    */

--- a/packages/zip-it-and-ship-it/src/main.ts
+++ b/packages/zip-it-and-ship-it/src/main.ts
@@ -39,14 +39,6 @@ type ListedFunctionFile = ListedFunction & {
   srcFile: string
 }
 
-interface ListFunctionsOptions {
-  basePath?: string
-  config?: Config
-  configFileDirectories?: string[]
-  featureFlags?: FeatureFlags
-  parseISC?: boolean
-}
-
 interface AugmentedFunctionSource extends FunctionSource {
   staticAnalysisResult?: StaticAnalysisResult
 }


### PR DESCRIPTION
You can see it here: https://github.com/netlify/build/blob/8dc142a491c2e9db50bffba8d5d8cc0a790bbd22/packages/config/src/functions_config.js#L57. Unfortunately this repo still has a bunch of `.js` so it wasn't caught.

Also, I noticed an unrelated copy-pasted type that I cleaned up.