### PR TITLE
fix(types): fix incompatible `redirects` types

### DIFF
--- a/packages/build/src/types/config/netlify_config.ts
+++ b/packages/build/src/types/config/netlify_config.ts
@@ -14,7 +14,7 @@ interface Redirect {
   signed?: string
   query?: Record<string, string>
   headers?: Record<string, string>
-  conditions?: Record<'Language' | 'Role' | 'Country' | 'Cookie', readonly string[]>
+  conditions?: Record<'Language' | 'Role' | 'Country' | 'Cookie', string[]>
 }
 
 interface Header {


### PR DESCRIPTION
#### Summary

The `netlify.toml` type marks the redirect `.query` values as optional but the (more or less) parsed result does not. This leads to some type errors downstream in Netlify CLI.

This makes them compatible by marking them both as required.

See
https://github.com/netlify/build/blob/1b9f2f40de7ded6285e9b7c08a1adb43550a0ccf/packages/build-info/src/settings/netlify-toml.ts#L303-L305