### PR TITLE
fix: remove problematic `omit.js` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28861,7 +28861,6 @@
         "lodash-es": "^4.17.21",
         "micro-api-client": "^3.3.0",
         "node-fetch": "^3.0.0",
-        "omit.js": "^2.0.2",
         "p-wait-for": "^5.0.0",
         "qs": "^6.9.6"
       },

--- a/packages/js-client/package.json
+++ b/packages/js-client/package.json
@@ -45,7 +45,6 @@
     "lodash-es": "^4.17.21",
     "micro-api-client": "^3.3.0",
     "node-fetch": "^3.0.0",
-    "omit.js": "^2.0.2",
     "p-wait-for": "^5.0.0",
     "qs": "^6.9.6"
   },

--- a/packages/js-client/src/methods/response.js
+++ b/packages/js-client/src/methods/response.js
@@ -1,5 +1,6 @@
 import { JSONHTTPError, TextHTTPError } from 'micro-api-client'
-import omit from 'omit.js'
+
+import omit from '../omit.js'
 
 // Read and parse the HTTP response
 export const parseResponse = async function (response) {

--- a/packages/js-client/src/methods/response.js
+++ b/packages/js-client/src/methods/response.js
@@ -44,7 +44,7 @@ const addFallbackErrorMessage = function (error, textResponse) {
 }
 
 export const getFetchError = function (error, url, opts) {
-  const data = omit.default(opts, ['Authorization'])
+  const data = omit(opts, ['Authorization'])
   if (error.name !== 'FetchError') {
     error.name = 'FetchError'
   }

--- a/packages/js-client/src/omit.test.ts
+++ b/packages/js-client/src/omit.test.ts
@@ -1,0 +1,16 @@
+import test from 'ava'
+
+import omit from './omit.js'
+
+test('creates a shallow copy', (t) => {
+  const obj = { name: 'Benjy' }
+  const copy = omit(obj, [])
+  t.not(obj, copy)
+  t.deepEqual(obj, copy)
+})
+
+test('returns an object without the specified fields', (t) => {
+  const obj = { name: 'Benjy', age: 18 }
+  t.deepEqual(omit(obj, ['age']), { name: 'Benjy' })
+  t.deepEqual(omit(obj, ['name', 'age']), {})
+})

--- a/packages/js-client/src/omit.ts
+++ b/packages/js-client/src/omit.ts
@@ -1,0 +1,10 @@
+export default function omit<T extends Record<string | number | symbol, unknown>, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Omit<T, K> {
+  const shallowCopy = { ...obj }
+  for (const key of keys) {
+    delete shallowCopy[key]
+  }
+  return shallowCopy
+}

--- a/packages/js-client/src/operations.js
+++ b/packages/js-client/src/operations.js
@@ -1,5 +1,4 @@
-import omit from 'omit.js'
-
+import omit from './omit.js'
 import { openApiSpec } from './open_api.js'
 
 // Retrieve all OpenAPI operations

--- a/packages/js-client/src/operations.js
+++ b/packages/js-client/src/operations.js
@@ -5,7 +5,7 @@ import { openApiSpec } from './open_api.js'
 // Retrieve all OpenAPI operations
 export const getOperations = function () {
   return Object.entries(openApiSpec.paths).flatMap(([path, pathItem]) => {
-    const operations = omit.default(pathItem, ['parameters'])
+    const operations = omit(pathItem, ['parameters'])
     return Object.entries(operations).map(([method, operation]) => {
       const parameters = getParameters(pathItem.parameters, operation.parameters)
       return { ...operation, verb: method, path, parameters }


### PR DESCRIPTION
#### Summary

Something about this module is off. It works with some runtimes/bundlers but not others. It seems to have issues with [webpack](https://github.com/benjycui/omit.js/issues/10) and with [bun](https://github.com/netlify/build/issues/5613).

I just inlined it. It's tiny anyway.

Fixes #5613.