### PR TITLE
chore(deps): avoid `packages/testing`'s local deps getting out of sync after major releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29206,8 +29206,8 @@
     "packages/testing": {
       "name": "@netlify/testing",
       "devDependencies": {
-        "@netlify/build": "^31.0.0",
-        "@netlify/config": "^21.0.7",
+        "@netlify/build": "*",
+        "@netlify/config": "*",
         "@types/lodash-es": "^4.17.6",
         "@types/node": "^14.18.53",
         "ava": "^4.0.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -16,8 +16,8 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@netlify/build": "^31.0.0",
-    "@netlify/config": "^21.0.7",
+    "@netlify/build": "*",
+    "@netlify/config": "*",
     "@types/lodash-es": "^4.17.6",
     "@types/node": "^14.18.53",
     "ava": "^4.0.0",


### PR DESCRIPTION
#### Summary

See https://github.com/netlify/build/pull/6188.

The `packages/testing` package has dev dependencies on `packages/build` and `packages/config`, but these also have (undeclared) dev dependencies on `packages/testing` 🔂.

Since our release-please configuration does not include `packages/testing` at all (there's nothing to release; it's a "local package" only), major bumps to either of its dependencies does not bump its "local" dependencies, which results in `packages/testing` no longer pulling in their local versions and instead pulls in a duplicated previous published version from the NPM registry.

This in turn results in `@netlify/config` and/or `@netlify/build` not actually testing their own source, since they use `packages/testing` to test themselves...

This is a confusing mess, and [declaring the missing dependencies does not work](https://github.com/netlify/build/pull/6133) because `nx` detects the circular dependency and aborts 😭.

This prevents the problem from reoccuring.