### PR TITLE
fix: detect new TanStack Start package names

### DIFF
--- a/packages/build-info/src/frameworks/solid-js.ts
+++ b/packages/build-info/src/frameworks/solid-js.ts
@@ -4,7 +4,7 @@ export class SolidJs extends BaseFramework implements Framework {
   readonly id = 'solid-js'
   name = 'SolidJS'
   npmDependencies = ['solid-js']
-  excludedNpmDependencies = ['solid-start', '@solidjs/start']
+  excludedNpmDependencies = ['solid-start', '@solidjs/start', '@tanstack/solid-start']
   category = Category.SSG
 
   dev = {

--- a/packages/build-info/src/frameworks/tanstack-router.ts
+++ b/packages/build-info/src/frameworks/tanstack-router.ts
@@ -4,7 +4,7 @@ export class TanStackRouter extends BaseFramework implements Framework {
   readonly id = 'tanstack-router'
   name = 'TanStack Router'
   npmDependencies = ['@tanstack/react-router']
-  excludedNpmDependencies = ['@tanstack/start']
+  excludedNpmDependencies = ['@tanstack/start', '@tanstack/react-start', '@tanstack/solid-start']
   category = Category.SSG
 
   dev = {

--- a/packages/build-info/src/frameworks/tanstack-start.test.ts
+++ b/packages/build-info/src/frameworks/tanstack-start.test.ts
@@ -8,7 +8,75 @@ beforeEach((ctx) => {
   ctx.fs = new NodeFS()
 })
 
-test('detects a TanStack Start site', async ({ fs }) => {
+test('detects a TanStack Start React site', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': JSON.stringify({
+      scripts: {
+        dev: 'vinxi dev',
+        build: 'vinxi build',
+        start: 'vinxi start',
+      },
+      dependencies: {
+        '@tanstack/react-router': '^1.117.1',
+        '@tanstack/react-router-devtools': '^1.117.1',
+        '@tanstack/react-start': '^1.117.2',
+        react: '^19.0.0',
+        'react-dom': '^19.0.0',
+      },
+      devDependencies: {
+        vinxi: '0.5.3',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('vinxi')
+  expect(detectedFrameworks).not.toContain('vite')
+  expect(detectedFrameworks).not.toContain('tanstack-router')
+
+  expect(detected?.[0]?.id).toBe('tanstack-start')
+  expect(detected?.[0]?.build?.command).toBe('vinxi build')
+  expect(detected?.[0]?.build?.directory).toBe('dist')
+  expect(detected?.[0]?.dev?.command).toBe('vinxi dev')
+  expect(detected?.[0]?.dev?.port).toBe(3000)
+})
+
+test('detects a TanStack Start Solid site', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': JSON.stringify({
+      scripts: {
+        dev: 'vinxi dev',
+        build: 'vinxi build',
+        start: 'vinxi start',
+      },
+      dependencies: {
+        '@tanstack/solid-router': '^1.117.1',
+        '@tanstack/solid-router-devtools': '^1.117.1',
+        '@tanstack/solid-start': '^1.117.2',
+        'solid-js': '^1.9.5',
+      },
+      devDependencies: {
+        vinxi: '0.5.3',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('vinxi')
+  expect(detectedFrameworks).not.toContain('vite')
+  expect(detectedFrameworks).not.toContain('tanstack-router')
+  expect(detectedFrameworks).not.toContain('solid-js')
+
+  expect(detected?.[0]?.id).toBe('tanstack-start')
+  expect(detected?.[0]?.build?.command).toBe('vinxi build')
+  expect(detected?.[0]?.build?.directory).toBe('dist')
+  expect(detected?.[0]?.dev?.command).toBe('vinxi dev')
+  expect(detected?.[0]?.dev?.port).toBe(3000)
+})
+
+test('detects a pre-v1.111.10 TanStack Start site', async ({ fs }) => {
   const cwd = mockFileSystem({
     'package.json': JSON.stringify({
       scripts: {

--- a/packages/build-info/src/frameworks/tanstack-start.ts
+++ b/packages/build-info/src/frameworks/tanstack-start.ts
@@ -3,7 +3,7 @@ import { BaseFramework, Category, Framework } from './framework.js'
 export class TanStackStart extends BaseFramework implements Framework {
   readonly id = 'tanstack-start'
   name = 'TanStack Start'
-  npmDependencies = ['@tanstack/start']
+  npmDependencies = ['@tanstack/start', '@tanstack/react-start', '@tanstack/solid-start']
   category = Category.SSG
 
   dev = {


### PR DESCRIPTION
#### Summary

https://github.com/TanStack/router/pull/3563 renamed `@tanstack/start` to `@tanstack/react-start` and https://github.com/TanStack/router/pull/3522 introduced the `@tanstack/solid-start` variant

We need to keep the old name for backwards compatibility