### PR TITLE
Upgrade esbuild dependency

### DIFF
--- a/packages/zip-it-and-ship-it/package.json
+++ b/packages/zip-it-and-ship-it/package.json
@@ -50,7 +50,7 @@
     "common-path-prefix": "^3.0.0",
     "cp-file": "^10.0.0",
     "es-module-lexer": "^1.0.0",
-    "esbuild": "0.19.11",
+    "esbuild": "0.25.3",
     "execa": "^7.0.0",
     "fast-glob": "^3.3.2",
     "filter-obj": "^5.0.0",


### PR DESCRIPTION
Updated esbuild to solve an npm audit warning in other projects that rely on zip-it-and-ship-it

#### Summary

Fixes #6224 

As mentioned within the issue zip-it-and-ship-it rely on a vulnerable version of esbuild which can be fixed by upgrading the dependency.
