### PR TITLE
feat(zip-it-and-ship-it): feature flag ability to dynamically import funcion inside request handler

### DIFF
--- a/packages/zip-it-and-ship-it/src/feature_flags.ts
+++ b/packages/zip-it-and-ship-it/src/feature_flags.ts
@@ -29,6 +29,9 @@ export const defaultFlags = {
 
   // Adds the `___netlify-telemetry.mjs` file to the function bundle.
   zisi_add_instrumentation_loader: true,
+
+  // Dynamically import the function handler.
+  zisi_dynamic_import_function_handler: false,
 } as const
 
 export type FeatureFlags = Partial<Record<keyof typeof defaultFlags, boolean>>

--- a/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
@@ -51,6 +51,12 @@ const getEntryFileContents = (
   const importPath = `.${mainPath.startsWith('/') ? mainPath : `/${mainPath}`}`
 
   if (runtimeAPIVersion === 2) {
+    if (featureFlags.zisi_dynamic_import_function_handler) {
+      return [
+        `import * as bootstrap from './${BOOTSTRAP_FILE_NAME}'`,
+        `export const handler = bootstrap.getLambdaHandler('${importPath}')`,
+      ].join(';')
+    }
     return [
       `import * as bootstrap from './${BOOTSTRAP_FILE_NAME}'`,
       `import * as func from '${importPath}'`,


### PR DESCRIPTION
depends on https://github.com/netlify/serverless-functions-api/pull/385

this gives us the ability to catch any errors which may arise when importing the function's code, and also allows us to prepare more within the bootstrapping phase before the functions code is executed - such as populating process.env or any bootstrapping that may require information provided by Proxy for the invocation

