### PR TITLE
fix: opt into new entrypoint only if using fixed version of serverless-functions-api

### DIFF
--- a/packages/zip-it-and-ship-it/src/feature_flags.ts
+++ b/packages/zip-it-and-ship-it/src/feature_flags.ts
@@ -31,7 +31,7 @@ export const defaultFlags = {
   zisi_add_instrumentation_loader: true,
 
   // Dynamically import the function handler.
-  zisi_dynamic_import_function_handler: false,
+  zisi_dynamic_import_function_handler_entry_point: false,
 } as const
 
 export type FeatureFlags = Partial<Record<keyof typeof defaultFlags, boolean>>

--- a/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
@@ -51,7 +51,7 @@ const getEntryFileContents = (
   const importPath = `.${mainPath.startsWith('/') ? mainPath : `/${mainPath}`}`
 
   if (runtimeAPIVersion === 2) {
-    if (featureFlags.zisi_dynamic_import_function_handler) {
+    if (featureFlags.zisi_dynamic_import_function_handler_entry_point) {
       return [
         `import * as bootstrap from './${BOOTSTRAP_FILE_NAME}'`,
         `export const handler = bootstrap.getLambdaHandler('${importPath}')`,


### PR DESCRIPTION
we need to rename the flag because of previous versions of zip-it-and-ship-it which are used in old cli installs contain a buggy version of serverless-functions-api which does not work correctly with some typescript projects. renaming the flag means only future versions of zip-it-and-ship-it will be optied into the new entrypoint, and we know that future versions of zip-it-and-ship-it are using a fixed version of serverless-functions-api