### PR TITLE
fix: drop node-fetch from config package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26621,7 +26621,6 @@
         "is-plain-obj": "^4.0.0",
         "js-yaml": "^4.0.0",
         "map-obj": "^5.0.0",
-        "node-fetch": "^3.3.1",
         "omit.js": "^2.0.2",
         "p-locate": "^6.0.0",
         "path-type": "^6.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -75,7 +75,6 @@
     "@netlify/api": "^14.0.1",
     "@netlify/headers-parser": "^9.0.0",
     "@netlify/redirect-parser": "^15.0.1",
-    "node-fetch": "^3.3.1",
     "omit.js": "^2.0.2",
     "p-locate": "^6.0.0",
     "path-type": "^6.0.0",

--- a/packages/config/src/api/site_info.ts
+++ b/packages/config/src/api/site_info.ts
@@ -1,6 +1,4 @@
 import { NetlifyAPI } from '@netlify/api'
-import fetch from 'node-fetch'
-import type { RequestInit } from 'node-fetch'
 
 import { getEnvelope } from '../env/envelope.js'
 import { throwUserError } from '../error.js'


### PR DESCRIPTION
#### Summary

Now that we use node >18 we can drop the node-fetch polyfill from the package
Part of FRB-1833

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
