### PR TITLE
fix: remove node-fetch from js-client package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18184,6 +18184,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
       "funding": [
         {
           "type": "github",
@@ -26822,7 +26823,6 @@
         "@netlify/open-api": "^2.37.0",
         "lodash-es": "^4.17.21",
         "micro-api-client": "^3.3.0",
-        "node-fetch": "^3.0.0",
         "p-wait-for": "^5.0.0",
         "qs": "^6.9.6"
       },

--- a/packages/js-client/README.md
+++ b/packages/js-client/README.md
@@ -94,8 +94,8 @@ const params = {
 }
 ```
 
-Optional `opts` can include any property you want passed to [`node-fetch`](https://github.com/bitinn/node-fetch). The
-`headers` property is merged with some `defaultHeaders`.
+Optional `opts` can include any property you want passed to `fetch`. The `headers` property is merged with some
+`defaultHeaders`.
 
 ```js
 // example opts
@@ -105,7 +105,7 @@ const opts = {
     'User-agent': 'netlify-js-client',
     accept: 'application/json',
   },
-  // any other properties for node-fetch
+  // any other properties for fetch
 }
 ```
 

--- a/packages/js-client/package.json
+++ b/packages/js-client/package.json
@@ -44,7 +44,6 @@
     "@netlify/open-api": "^2.37.0",
     "lodash-es": "^4.17.21",
     "micro-api-client": "^3.3.0",
-    "node-fetch": "^3.0.0",
     "p-wait-for": "^5.0.0",
     "qs": "^6.9.6"
   },

--- a/packages/js-client/src/types.ts
+++ b/packages/js-client/src/types.ts
@@ -1,7 +1,6 @@
 import type { ReadStream } from 'node:fs'
 
 import type { operations } from '@netlify/open-api'
-import type { RequestInit } from 'node-fetch'
 
 /**
  * Determines whether all keys in T are optional.
@@ -206,7 +205,7 @@ export type DynamicMethods = {
   [K in keyof operations]: (
     params: OperationParams<K>,
     /**
-     * Any properties you want passed to `node-fetch`.
+     * Any properties you want passed to `fetch`.
      *
      * The `headers` property is merged with some `defaultHeaders`:
      * ```ts


### PR DESCRIPTION
#### Summary

Now that we use node >18 we can drop the node-fetch polyfill from the package
Part of FRB-1833

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
