### PR TITLE
fix: upgrade @types/node to v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25836,7 +25836,7 @@
         "@netlify/nock-udp": "^5.0.0",
         "@opentelemetry/api": "~1.8.0",
         "@opentelemetry/sdk-trace-base": "~1.24.0",
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "atob": "^2.1.2",
         "ava": "^5.0.0",
         "c8": "^10.0.0",
@@ -25887,7 +25887,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.30.0",
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "@types/semver": "^7.3.13",
         "@vitest/ui": "^0.34.0",
         "execa": "^8.0.0",
@@ -25902,18 +25902,24 @@
       }
     },
     "packages/build-info/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/build/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/cache-utils": {
       "name": "@netlify/cache-utils",
@@ -25930,7 +25936,7 @@
         "readdirp": "^4.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "tmp-promise": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^0.34.0"
@@ -25940,11 +25946,14 @@
       }
     },
     "packages/cache-utils/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/config": {
       "name": "@netlify/config",
@@ -25979,7 +25988,7 @@
         "netlify-config": "bin.js"
       },
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "ava": "^5.0.0",
         "c8": "^10.0.0",
         "has-ansi": "^6.0.0",
@@ -25992,11 +26001,14 @@
       }
     },
     "packages/config/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/edge-bundler": {
       "name": "@netlify/edge-bundler",
@@ -26026,7 +26038,7 @@
         "uuid": "^11.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.18.32",
+        "@types/node": "^18.0.0",
         "@types/semver": "^7.3.9",
         "@types/uuid": "^10.0.0",
         "@vitest/coverage-v8": "^0.34.0",
@@ -26043,11 +26055,14 @@
       }
     },
     "packages/edge-bundler/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/edge-bundler/node_modules/nock": {
       "version": "14.0.4",
@@ -26133,7 +26148,7 @@
         "path-exists": "^5.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "typescript": "^5.0.0",
         "vitest": "^0.34.0"
       },
@@ -26142,11 +26157,14 @@
       }
     },
     "packages/git-utils/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/headers-parser": {
       "name": "@netlify/headers-parser",
@@ -26161,7 +26179,7 @@
         "path-exists": "^5.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "typescript": "^5.0.0",
         "vitest": "^0.34.0"
       },
@@ -26170,11 +26188,14 @@
       }
     },
     "packages/headers-parser/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/js-client": {
       "name": "@netlify/api",
@@ -26190,7 +26211,7 @@
       },
       "devDependencies": {
         "@types/lodash-es": "^4.17.6",
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "ava": "^5.0.0",
         "c8": "^10.0.0",
         "from2-string": "^1.1.0",
@@ -26204,18 +26225,21 @@
       }
     },
     "packages/js-client/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/nock-udp": {
       "name": "@netlify/nock-udp",
       "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "typescript": "^5.0.0",
         "vitest": "^0.34.0"
       },
@@ -26224,11 +26248,14 @@
       }
     },
     "packages/nock-udp/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/opentelemetry-sdk-setup": {
       "name": "@netlify/opentelemetry-sdk-setup",
@@ -26248,7 +26275,7 @@
       },
       "devDependencies": {
         "@opentelemetry/api": "~1.8.0",
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "@vitest/ui": "^0.34.0",
         "typescript": "^5.0.0",
         "vite": "^6.0.0",
@@ -26262,11 +26289,14 @@
       }
     },
     "packages/opentelemetry-sdk-setup/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/opentelemetry-utils": {
       "name": "@netlify/opentelemetry-utils",
@@ -26276,7 +26306,7 @@
         "@opentelemetry/api": "~1.8.0",
         "@opentelemetry/sdk-trace-base": "~1.24.0",
         "@opentelemetry/sdk-trace-node": "~1.24.0",
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "@vitest/ui": "^0.34.0",
         "typescript": "^5.0.0",
         "vite": "^6.0.0",
@@ -26290,11 +26320,14 @@
       }
     },
     "packages/opentelemetry-utils/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/redirect-parser": {
       "name": "@netlify/redirect-parser",
@@ -26308,7 +26341,7 @@
         "path-exists": "^5.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "typescript": "^5.0.0",
         "vitest": "^0.34.0"
       },
@@ -26317,11 +26350,14 @@
       }
     },
     "packages/redirect-parser/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/run-utils": {
       "name": "@netlify/run-utils",
@@ -26331,7 +26367,7 @@
         "execa": "^8.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "semver": "^7.3.8",
         "typescript": "^5.0.0",
         "vitest": "^0.34.0"
@@ -26341,11 +26377,14 @@
       }
     },
     "packages/run-utils/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/testing": {
       "name": "@netlify/testing",
@@ -26353,7 +26392,7 @@
         "@netlify/build": "*",
         "@netlify/config": "*",
         "@types/lodash-es": "^4.17.6",
-        "@types/node": "^14.18.53",
+        "@types/node": "^18.0.0",
         "ava": "^5.0.0",
         "c8": "^10.0.0",
         "cpy": "^11.0.0",
@@ -26375,11 +26414,14 @@
       }
     },
     "packages/testing/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/zip-it-and-ship-it": {
       "name": "@netlify/zip-it-and-ship-it",

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.30.0",
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "@types/semver": "^7.3.13",
     "@vitest/ui": "^0.34.0",
     "execa": "^8.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -128,7 +128,7 @@
     "@netlify/nock-udp": "^5.0.0",
     "@opentelemetry/api": "~1.8.0",
     "@opentelemetry/sdk-trace-base": "~1.24.0",
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "atob": "^2.1.2",
     "ava": "^5.0.0",
     "c8": "^10.0.0",

--- a/packages/build/src/plugins_core/blobs_upload/index.ts
+++ b/packages/build/src/plugins_core/blobs_upload/index.ts
@@ -63,8 +63,7 @@ const coreStep: CoreStepFunction = async function ({
         systemLog(`Uploading blob ${key}`)
 
         const { data, metadata } = await getFileWithMetadata(key, contentPath, metadataPath)
-        const arrayBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.length)
-        await blobStore.set(key, arrayBuffer, { metadata })
+        await blobStore.set(key, new Blob([data]), { metadata })
       },
       { concurrency: 10 },
     )

--- a/packages/build/src/plugins_core/dev_blobs_upload/index.ts
+++ b/packages/build/src/plugins_core/dev_blobs_upload/index.ts
@@ -68,8 +68,7 @@ const coreStep: CoreStepFunction = async function ({
           log(logs, `- Uploading blob ${key}`, { indent: true })
         }
         const { data, metadata } = await getFileWithMetadata(key, contentPath, metadataPath)
-        const arrayBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.length)
-        await blobStore.set(key, arrayBuffer, { metadata })
+        await blobStore.set(key, new Blob([data]), { metadata })
       },
       { concurrency: 10 },
     )

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -60,7 +60,7 @@
     "readdirp": "^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "tmp-promise": "^3.0.0",
     "typescript": "^5.0.0",
     "vitest": "^0.34.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -83,7 +83,7 @@
     "yargs": "^17.6.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "ava": "^5.0.0",
     "c8": "^10.0.0",
     "has-ansi": "^6.0.0",

--- a/packages/edge-bundler/package.json
+++ b/packages/edge-bundler/package.json
@@ -42,7 +42,7 @@
     "test": "test/node"
   },
   "devDependencies": {
-    "@types/node": "^14.18.32",
+    "@types/node": "^18.0.0",
     "@types/semver": "^7.3.9",
     "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^0.34.0",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -57,7 +57,7 @@
     "path-exists": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "typescript": "^5.0.0",
     "vitest": "^0.34.0"
   },

--- a/packages/headers-parser/package.json
+++ b/packages/headers-parser/package.json
@@ -34,7 +34,7 @@
     "path-exists": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "typescript": "^5.0.0",
     "vitest": "^0.34.0"
   },

--- a/packages/js-client/package.json
+++ b/packages/js-client/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.6",
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "ava": "^5.0.0",
     "c8": "^10.0.0",
     "from2-string": "^1.1.0",

--- a/packages/nock-udp/package.json
+++ b/packages/nock-udp/package.json
@@ -28,7 +28,7 @@
   },
   "author": "Netlify Inc.",
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "typescript": "^5.0.0",
     "vitest": "^0.34.0"
   },

--- a/packages/opentelemetry-sdk-setup/package.json
+++ b/packages/opentelemetry-sdk-setup/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "~1.8.0",
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "@vitest/ui": "^0.34.0",
     "typescript": "^5.0.0",
     "vite": "^6.0.0",

--- a/packages/opentelemetry-utils/package.json
+++ b/packages/opentelemetry-utils/package.json
@@ -34,7 +34,7 @@
     "@opentelemetry/api": "~1.8.0",
     "@opentelemetry/sdk-trace-base": "~1.24.0",
     "@opentelemetry/sdk-trace-node": "~1.24.0",
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "@vitest/ui": "^0.34.0",
     "typescript": "^5.0.0",
     "vite": "^6.0.0",

--- a/packages/redirect-parser/package.json
+++ b/packages/redirect-parser/package.json
@@ -33,7 +33,7 @@
     "path-exists": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "typescript": "^5.0.0",
     "vitest": "^0.34.0"
   },

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -53,7 +53,7 @@
     "execa": "^8.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "semver": "^7.3.8",
     "typescript": "^5.0.0",
     "vitest": "^0.34.0"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -19,7 +19,7 @@
     "@netlify/build": "*",
     "@netlify/config": "*",
     "@types/lodash-es": "^4.17.6",
-    "@types/node": "^14.18.53",
+    "@types/node": "^18.0.0",
     "ava": "^5.0.0",
     "c8": "^10.0.0",
     "cpy": "^11.0.0",


### PR DESCRIPTION
#### Summary

- Update node/types to v18
- Convert buffers into blobs before calling blobStore.set (fix a type issue)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
