### PR TITLE
fix: only auto-install extensions when required packages are present

### DIFF
--- a/packages/config/src/utils/extensions/auto-install-extensions.ts
+++ b/packages/config/src/utils/extensions/auto-install-extensions.ts
@@ -102,9 +102,19 @@ export async function handleAutoInstallExtensions({
     }
 
     const autoInstallableExtensions = await fetchAutoInstallableExtensionsMeta()
-    const extensionsToInstall = autoInstallableExtensions.filter((ext) => {
-      return !integrations?.some((integration) => integration.slug === ext.slug)
+    const enabledExtensionSlugs = new Set((integrations ?? []).map(({ slug }) => slug))
+    const extensionsToInstallCandidates = autoInstallableExtensions.filter(
+      ({ slug }) => !enabledExtensionSlugs.has(slug),
+    )
+    const extensionsToInstall = extensionsToInstallCandidates.filter(({ packages }) => {
+      for (const pkg of packages) {
+        if (Object.hasOwn(packageJson.dependencies, pkg)) {
+          return true
+        }
+      }
+      return false
     })
+
     if (extensionsToInstall.length === 0) {
       return integrations
     }


### PR DESCRIPTION
Previously, extensions were being auto-installed on all sites with the feature flag enabled, regardless of whether the required packages were present in package.json. This caused mass installations of extensions like Neon on accounts that didn't need them.

Now properly filters extensions to only install when:
1. Extension is not already installed, AND
2. At least one required package exists in project dependencies

Fixes the logic in handleAutoInstallExtensions to check package.json dependencies before attempting installation.

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
