### PR TITLE
fix: only log auto install extension errors with debug flag

### DIFF
--- a/packages/config/src/main.ts
+++ b/packages/config/src/main.ts
@@ -181,6 +181,7 @@ export const resolveConfig = async function (opts): Promise<Config> {
     testOpts,
     offline,
     mode,
+    debug,
   })
 
   const mergedIntegrations = await mergeIntegrations({

--- a/packages/config/src/utils/extensions/auto-install-extensions.ts
+++ b/packages/config/src/utils/extensions/auto-install-extensions.ts
@@ -28,6 +28,7 @@ interface AutoInstallOptions {
   testOpts: any
   mode: ModeOption
   extensionApiBaseUrl: string
+  debug?: boolean
 }
 
 export async function handleAutoInstallExtensions({
@@ -41,58 +42,31 @@ export async function handleAutoInstallExtensions({
   testOpts = {},
   mode,
   extensionApiBaseUrl,
+  debug = false,
 }: AutoInstallOptions) {
   if (!featureFlags?.auto_install_required_extensions) {
     return integrations
   }
-  if (!accountId) {
-    console.error("Failed to auto install extension(s): Missing 'accountId'", {
-      accountId,
-      siteId,
-      buildDir,
-      offline,
-      mode,
-    })
-    return integrations
-  }
-  if (!siteId) {
-    console.error("Failed to auto install extension(s): Missing 'siteId'", {
-      accountId,
-      siteId,
-      buildDir,
-      offline,
-      mode,
-    })
-    return integrations
-  }
-  if (!token) {
-    console.error("Failed to auto install extension(s): Missing 'token'", {
-      accountId,
-      siteId,
-      buildDir,
-      offline,
-      mode,
-    })
-    return integrations
-  }
-  if (!buildDir) {
-    console.error("Failed to auto install extension(s): Missing 'buildDir'", {
-      accountId,
-      siteId,
-      buildDir,
-      offline,
-      mode,
-    })
-    return integrations
-  }
-  if (offline) {
-    console.error("Failed to auto install extension(s): Running as 'offline'", {
-      accountId,
-      siteId,
-      buildDir,
-      offline,
-      mode,
-    })
+  if (!accountId || !siteId || !token || !buildDir || offline) {
+    const reason = !accountId
+      ? 'Missing accountId'
+      : !siteId
+        ? 'Missing siteId'
+        : !token
+          ? 'Missing token'
+          : !buildDir
+            ? 'Missing buildDir'
+            : 'Running as offline'
+
+    if (debug) {
+      console.error(`Failed to auto install extension(s): ${reason}`, {
+        accountId,
+        siteId,
+        buildDir,
+        offline,
+        mode,
+      })
+    }
     return integrations
   }
 

--- a/packages/config/src/utils/extensions/utils.ts
+++ b/packages/config/src/utils/extensions/utils.ts
@@ -65,11 +65,16 @@ type AutoInstallableExtensionMeta = {
  * @returns Array of extensions with their associated packages
  */
 export async function fetchAutoInstallableExtensionsMeta(): Promise<AutoInstallableExtensionMeta[]> {
-  const url = new URL(`/meta/auto-installable`, process.env.EXTENSION_API_BASE_URL ?? EXTENSION_API_BASE_URL)
-  const response = await fetch(url.toString())
-  if (!response.ok) {
-    throw new Error(`Failed to fetch extensions meta`)
+  try {
+    const url = new URL(`/meta/auto-installable`, process.env.EXTENSION_API_BASE_URL ?? EXTENSION_API_BASE_URL)
+    const response = await fetch(url.toString())
+    if (!response.ok) {
+      throw new Error(`Failed to fetch extensions meta`)
+    }
+    const data = await response.json()
+    return data as AutoInstallableExtensionMeta[]
+  } catch (error) {
+    console.error(`Failed to fetch auto-installable extensions meta: ${error.message}`, error)
+    return []
   }
-  const data = await response.json()
-  return data as AutoInstallableExtensionMeta[]
 }


### PR DESCRIPTION
## Clean up error logging in auto-install extensions

### Problem

The auto-install extensions feature had verbose error logging that would show confusing error messages to users during normal `netlify dev` usage. The error handling code was also repetitive and lengthy. This is caused by resolve config running in the cli base command and working correctly, but when the dev command calls `startDev` from `build`, it is not populating the same config values that auto install extension handler expects. 

### Solution

- **Cleaned up error logging**: Consolidated repetitive error handling
- **Made error logging conditional**: Error messages now only appear when the `debug` flag is enabled
- **Improved user experience**: Users no longer see confusing "Failed to auto install extension(s): Missing 'accountId'" messages during normal usage

### Changes

1. **Added `debug` parameter** to `AutoInstallOptions` interface and `handleAutoInstallExtensions` function
2. **Consolidated error checking** into a single conditional block with cleaner logic
3. **Made error logging conditional** on the `debug` flag
4. **Passed `debug` flag** from main config resolution to auto-install function

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
