### PR TITLE
fix: use auto_install_required_extensions_v2 instead of auto_install_required_extensions

### DIFF
--- a/packages/config/src/utils/extensions/auto-install-extensions.ts
+++ b/packages/config/src/utils/extensions/auto-install-extensions.ts
@@ -44,7 +44,7 @@ export async function handleAutoInstallExtensions({
   extensionApiBaseUrl,
   debug = false,
 }: AutoInstallOptions) {
-  if (!featureFlags?.auto_install_required_extensions) {
+  if (!featureFlags?.auto_install_required_extensions_v2) {
     return integrations
   }
   if (!accountId || !siteId || !token || !buildDir || offline) {

--- a/packages/config/tests/extensions/tests.js
+++ b/packages/config/tests/extensions/tests.js
@@ -80,7 +80,7 @@ test('Auto-install extensions: feature flag disabled returns integrations unchan
       token: 'test',
       mode: 'dev',
       featureFlags: {
-        auto_install_required_extensions: false,
+        auto_install_required_extensions_v2: false,
       },
     })
     .runConfigServer([SITE_INFO_DATA, TEAM_INSTALLATIONS_META_RESPONSE, FETCH_INTEGRATIONS_EMPTY_RESPONSE])
@@ -101,7 +101,7 @@ test('Auto-install extensions: gracefully handles missing package.json', async (
       token: 'test',
       mode: 'dev',
       featureFlags: {
-        auto_install_required_extensions: true,
+        auto_install_required_extensions_v2: true,
       },
     })
     .runConfigServer([SITE_INFO_DATA, TEAM_INSTALLATIONS_META_RESPONSE, FETCH_INTEGRATIONS_EMPTY_RESPONSE])
@@ -123,7 +123,7 @@ test('Auto-install extensions: correctly reads package.json from buildDir', asyn
       token: 'test',
       mode: 'dev',
       featureFlags: {
-        auto_install_required_extensions: true,
+        auto_install_required_extensions_v2: true,
       },
     })
     .runConfigServer([SITE_INFO_DATA, TEAM_INSTALLATIONS_META_RESPONSE, FETCH_INTEGRATIONS_EMPTY_RESPONSE])
@@ -161,7 +161,7 @@ test('Auto-install extensions: does not install when required packages are missi
       token: 'test',
       mode: 'dev',
       featureFlags: {
-        auto_install_required_extensions: true,
+        auto_install_required_extensions_v2: true,
       },
     })
     .runConfigServer([SITE_INFO_DATA, TEAM_INSTALLATIONS_META_RESPONSE, FETCH_INTEGRATIONS_EMPTY_RESPONSE])
@@ -187,7 +187,7 @@ test('Auto-install extensions: correctly reads package.json when no netlify.toml
       token: 'test',
       mode: 'dev',
       featureFlags: {
-        auto_install_required_extensions: true,
+        auto_install_required_extensions_v2: true,
       },
     })
     .runConfigServer([SITE_INFO_DATA, TEAM_INSTALLATIONS_META_RESPONSE, FETCH_INTEGRATIONS_EMPTY_RESPONSE])


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

This replaces an old feature flag with a new one. We will keep the old feature flag but turn it off. There was a bug introduced in `netlify/config@22.2.0` and also fixed. But the netlify CLI has not been patched, and it _cannot_ be patched (see linear).

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
