### PR TITLE
chore: match version of @playwright/test to version in lockfile

### DIFF
--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -56,7 +56,7 @@
     "yargs": "^17.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.30.0",
+    "@playwright/test": "^1.53.1",
     "@types/node": "^18.19.111",
     "@types/semver": "^7.3.13",
     "@vitest/ui": "^3.0.0",


### PR DESCRIPTION
#### Summary

When you run `npm i` on the main branch, the lockfile will be updated.
We don't want the update to keep popping up, so I'm fixing the root cause (a mismatch of versions between the lockfile and the package.json)
https://github.com/netlify/build/blob/main/package-lock.json#L4600-L4602

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
