### PR TITLE
chore: match versions in package.json to lockfile

### DIFF
--- a/packages/zip-it-and-ship-it/package.json
+++ b/packages/zip-it-and-ship-it/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/netlify/build/issues"
   },
   "dependencies": {
-    "@babel/parser": "^7.22.5",
+    "@babel/parser": "^7.28.0",
     "@babel/types": "7.28.0",
     "@netlify/binary-info": "^1.0.0",
     "@netlify/serverless-functions-api": "^2.1.3",
@@ -73,7 +73,7 @@
     "unixify": "^1.0.0",
     "urlpattern-polyfill": "8.0.2",
     "yargs": "^17.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.25.69"
   },
   "devDependencies": {
     "@types/archiver": "6.0.3",


### PR DESCRIPTION
#### Summary

Matches the version of packages in `package.json` to what is already in the lockfile
(Note that there are no changes to the `package-lock.json` when running `npm install` on this branch)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
