### PR TITLE
chore: remove ignore paths to match renovate syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
   "automerge": true,
   "dependencyDashboard": true,
   "ignorePresets": [":prHourlyLimit2"],
-  "ignorePaths": ["**/fixtures"],
+  "ignorePaths": ["**/fixtures/**"],
   "semanticCommits": "enabled"
 }


### PR DESCRIPTION
#### Summary

The ignore path wasn't done correctly, the correct way to ignore would have been `**/fixtures/**`
Evidence is that since the change we've had https://github.com/netlify/build/pull/6516 pop up which is making a change within the fixtures directory.

Follow-up to https://github.com/netlify/build/pull/6512

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
