### PR TITLE
test: failing test for duplicate function names

### DIFF
--- a/packages/build/tests/core/fixtures/functions_duplicate_names/netlify/functions/function_one.js
+++ b/packages/build/tests/core/fixtures/functions_duplicate_names/netlify/functions/function_one.js
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/packages/build/tests/core/fixtures/functions_duplicate_names/netlify/functions/function_one.ts
+++ b/packages/build/tests/core/fixtures/functions_duplicate_names/netlify/functions/function_one.ts
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -589,6 +589,12 @@ test('Bundles functions from the `.netlify/functions-internal` directory even if
   t.snapshot(normalizeOutput(output))
 })
 
+test('Removes duplicate function names from the list of processed functions', async (t) => {
+  const output = await new Fixture('./fixtures/functions_duplicate_names').runWithBuild()
+  t.true(normalizeOutput(output).includes(`- function_one.js`))
+  t.false(normalizeOutput(output).includes(`- function_one.ts`))
+})
+
 test.serial('`rustTargetDirectory` is passed to zip-it-and-ship-it only when running in buildbot', async (t) => {
   const runCount = 4
   const mockZipFunctions = sinon.stub().resolves()


### PR DESCRIPTION
#### Summary

Recreating #3795

> When printing the list of bundled functions, Netlify Build uses zip-it-and-ship-it's listFunctions method, which includes functions that have not been bundled due to a naming conflict (e.g. when both function.js and function.ts are found). Because of this, Netlify Build was incorrectly reporting that both functions were bundled, when in fact only function.js was.

This PR removes those duplicate functions from the list

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
