### PR TITLE
chore: remove unused build:logos command and related dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23995,7 +23995,6 @@
         "memfs": "^4.0.0",
         "typescript": "^5.0.0",
         "unionfs": "^4.4.0",
-        "vite": "^7.0.0",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -24988,7 +24987,6 @@
         "@types/node": "^18.19.111",
         "@vitest/ui": "^3.0.0",
         "typescript": "^5.0.0",
-        "vite": "^7.0.0",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -25233,7 +25231,6 @@
         "@types/node": "^18.19.111",
         "@vitest/ui": "^3.0.0",
         "typescript": "^5.0.0",
-        "vite": "^7.0.0",
         "vitest": "^3.0.0"
       },
       "engines": {

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -27,7 +27,6 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "build:logos": "vite build",
     "e2e": "playwright test",
     "test": "vitest run",
     "test:dev": "vitest --ui",
@@ -64,7 +63,6 @@
     "memfs": "^4.0.0",
     "typescript": "^5.0.0",
     "unionfs": "^4.4.0",
-    "vite": "^7.0.0",
     "vitest": "^3.0.0"
   },
   "engines": {

--- a/packages/opentelemetry-sdk-setup/package.json
+++ b/packages/opentelemetry-sdk-setup/package.json
@@ -13,7 +13,6 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:logos": "vite build",
     "test": "vitest run",
     "test:dev": "vitest --ui",
     "test:ci": "vitest run --reporter=default"
@@ -47,7 +46,6 @@
     "@types/node": "^18.19.111",
     "@vitest/ui": "^3.0.0",
     "typescript": "^5.0.0",
-    "vite": "^7.0.0",
     "vitest": "^3.0.0"
   },
   "engines": {

--- a/packages/opentelemetry-utils/package.json
+++ b/packages/opentelemetry-utils/package.json
@@ -11,7 +11,6 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:logos": "vite build",
     "test": "vitest run",
     "test:dev": "vitest --ui",
     "test:ci": "vitest run --reporter=default"
@@ -37,7 +36,6 @@
     "@types/node": "^18.19.111",
     "@vitest/ui": "^3.0.0",
     "typescript": "^5.0.0",
-    "vite": "^7.0.0",
     "vitest": "^3.0.0"
   },
   "engines": {


### PR DESCRIPTION
#### Summary

The `vite` dependency appears to only be used in the seemingly unused `build:logos` command, so I'm removing both

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
