### PR TITLE
feat: accept mixed paths in `listFunctions`

### DIFF
--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,6 +1,7 @@
 import { buildSite } from './core/main.js'
 export { NetlifyPluginConstants } from './core/constants.js'
 
+export type { GeneratedFunction } from './steps/return_values.js'
 // export the legacy types
 export type { NetlifyPlugin } from './types/netlify_plugin.js'
 export type { NetlifyPluginOptions } from './types/netlify_plugin_options.js'

--- a/packages/zip-it-and-ship-it/src/main.ts
+++ b/packages/zip-it-and-ship-it/src/main.ts
@@ -12,7 +12,8 @@ import { listFunctionsDirectories, resolveFunctionsDirectories } from './utils/f
 import type { ExtendedRoute, Route } from './utils/routes.js'
 
 export { Config, FunctionConfig } from './config.js'
-export { type FunctionsBag, zipFunction, zipFunctions, ZipFunctionOptions, ZipFunctionsOptions } from './zip.js'
+export { zipFunction, zipFunctions, ZipFunctionOptions, ZipFunctionsOptions } from './zip.js'
+export type { FunctionsBag } from './paths.js'
 
 export { ArchiveFormat, ARCHIVE_FORMAT } from './archive.js'
 export type { TrafficRules } from './rate_limit.js'

--- a/packages/zip-it-and-ship-it/src/main.ts
+++ b/packages/zip-it-and-ship-it/src/main.ts
@@ -3,6 +3,7 @@ import { extname } from 'path'
 import { Config } from './config.js'
 import { FeatureFlags, getFlags } from './feature_flags.js'
 import { FunctionSource } from './function.js'
+import { type MixedPaths, getFunctionsBag } from './paths.js'
 import { getFunctionFromPath, getFunctionsFromPaths } from './runtimes/index.js'
 import { parseFile, StaticAnalysisResult } from './runtimes/node/in_source_config/index.js'
 import { ModuleFormat } from './runtimes/node/utils/module_format.js'
@@ -69,14 +70,20 @@ interface ListFunctionsOptions {
 
 // List all Netlify Functions main entry files for a specific directory.
 export const listFunctions = async function (
-  relativeSrcFolders: string | string[],
+  input: MixedPaths,
   { featureFlags: inputFeatureFlags, config, configFileDirectories, parseISC = false }: ListFunctionsOptions = {},
 ) {
   const featureFlags = getFlags(inputFeatureFlags)
-  const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
+  const bag = getFunctionsBag(input)
+  const srcFolders = resolveFunctionsDirectories([...bag.generated.directories, ...bag.user.directories])
   const paths = await listFunctionsDirectories(srcFolders)
   const cache = new RuntimeCache()
-  const functionsMap = await getFunctionsFromPaths(paths, { cache, config, configFileDirectories, featureFlags })
+  const functionsMap = await getFunctionsFromPaths([...paths, ...bag.generated.functions, ...bag.user.functions], {
+    cache,
+    config,
+    configFileDirectories,
+    featureFlags,
+  })
   const functions = [...functionsMap.values()]
   const augmentedFunctions = parseISC
     ? await Promise.all(functions.map((func) => augmentWithStaticAnalysis(func)))

--- a/packages/zip-it-and-ship-it/src/paths.ts
+++ b/packages/zip-it-and-ship-it/src/paths.ts
@@ -1,0 +1,80 @@
+export interface FunctionsBag {
+  generated: FunctionsCategory
+  user: FunctionsCategory
+}
+
+export interface FunctionsCategory {
+  /**
+   * List of paths for directories containing one or more functions. Entries in
+   * these directories are considered functions when they are files that match
+   * one of the supported extensions or when they are sub-directories that
+   * contain a function following the sub-directory naming patterns.
+   * Paths can be relative.
+   */
+  directories: string[]
+
+  /**
+   * List of paths for specific functions. Paths can be files that match one
+   * of the supported extensions or sub-directories that contain a function
+   * following the sub-directory naming patterns. Paths can be relative.
+   */
+  functions: string[]
+}
+
+export type MixedPaths =
+  | string
+  | string[]
+  | {
+      /**
+       * Functions generated on behalf of the user by a build plugin, extension
+       * or a framework.
+       */
+      generated?: Partial<FunctionsCategory>
+
+      /**
+       * Functions authored by the user.
+       */
+      user?: Partial<FunctionsCategory>
+    }
+
+/**
+ * Normalizes the `zipFunctions` input into a `FunctionsBag` object.
+ */
+export const getFunctionsBag = (input: MixedPaths): FunctionsBag => {
+  if (typeof input === 'string') {
+    return {
+      generated: {
+        directories: [],
+        functions: [],
+      },
+      user: {
+        directories: [input],
+        functions: [],
+      },
+    }
+  }
+
+  if (Array.isArray(input)) {
+    return {
+      generated: {
+        directories: [],
+        functions: [],
+      },
+      user: {
+        directories: input,
+        functions: [],
+      },
+    }
+  }
+
+  return {
+    generated: {
+      directories: input.generated?.directories ?? [],
+      functions: input.generated?.functions ?? [],
+    },
+    user: {
+      directories: input.user?.directories ?? [],
+      functions: input.user?.functions ?? [],
+    },
+  }
+}

--- a/packages/zip-it-and-ship-it/src/zip.ts
+++ b/packages/zip-it-and-ship-it/src/zip.ts
@@ -11,6 +11,7 @@ import { FunctionSource } from './function.js'
 import { createManifest } from './manifest.js'
 import { getFunctionsFromPaths } from './runtimes/index.js'
 import { MODULE_FORMAT } from './runtimes/node/utils/module_format.js'
+import { type MixedPaths, getFunctionsBag } from './paths.js'
 import { addArchiveSize } from './utils/archive_size.js'
 import { RuntimeCache } from './utils/cache.js'
 import { formatZipResult, FunctionResult } from './utils/format_result.js'
@@ -45,91 +46,10 @@ const validateArchiveFormat = (archiveFormat: ArchiveFormat) => {
   }
 }
 
-export interface FunctionsBag {
-  generated: FunctionsCategory
-  user: FunctionsCategory
-}
-
-export interface FunctionsCategory {
-  /**
-   * List of paths for directories containing one or more functions. Entries in
-   * these directories are considered functions when they are files that match
-   * one of the supported extensions or when they are sub-directories that
-   * contain a function following the sub-directory naming patterns.
-   * Paths can be relative.
-   */
-  directories: string[]
-
-  /**
-   * List of paths for specific functions. Paths can be files that match one
-   * of the supported extensions or sub-directories that contain a function
-   * following the sub-directory naming patterns. Paths can be relative.
-   */
-  functions: string[]
-}
-
-/**
- * Normalizes the `zipFunctions` input into a `FunctionsBag` object.
- */
-export const getFunctionsBag = (input: ZipFunctionsPaths): FunctionsBag => {
-  if (typeof input === 'string') {
-    return {
-      generated: {
-        directories: [],
-        functions: [],
-      },
-      user: {
-        directories: [input],
-        functions: [],
-      },
-    }
-  }
-
-  if (Array.isArray(input)) {
-    return {
-      generated: {
-        directories: [],
-        functions: [],
-      },
-      user: {
-        directories: input,
-        functions: [],
-      },
-    }
-  }
-
-  return {
-    generated: {
-      directories: input.generated?.directories ?? [],
-      functions: input.generated?.functions ?? [],
-    },
-    user: {
-      directories: input.user?.directories ?? [],
-      functions: input.user?.functions ?? [],
-    },
-  }
-}
-
-export type ZipFunctionsPaths =
-  | string
-  | string[]
-  | {
-      /**
-       * Functions generated on behalf of the user by a build plugin, extension
-       * or a framework.
-       */
-      generated?: Partial<FunctionsCategory>
-
-      /**
-       * Functions authored by the user.
-       */
-      user?: Partial<FunctionsCategory>
-    }
-
 // Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
 // used by AWS Lambda
 export const zipFunctions = async function (
-  input: ZipFunctionsPaths,
+  input: MixedPaths,
   destFolder: string,
   {
     archiveFormat = ARCHIVE_FORMAT.ZIP,

--- a/packages/zip-it-and-ship-it/tests/helpers/main.ts
+++ b/packages/zip-it-and-ship-it/tests/helpers/main.ts
@@ -11,8 +11,9 @@ import { afterAll, expect } from 'vitest'
 import type { Config } from '../../src/config.js'
 import { ListedFunction, zipFunctions } from '../../src/main.js'
 import { listImports } from '../../src/runtimes/node/bundlers/zisi/list_imports.js'
+import { getFunctionsBag, type MixedPaths } from '../../src/paths.js'
 import type { FunctionResult } from '../../src/utils/format_result.js'
-import { getFunctionsBag, ZipFunctionsOptions, type ZipFunctionsPaths } from '../../src/zip.js'
+import { ZipFunctionsOptions } from '../../src/zip.js'
 
 export const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url))
 export const FIXTURES_ESM_DIR = fileURLToPath(new URL('../fixtures-esm', import.meta.url))
@@ -49,10 +50,7 @@ afterAll(async () => {
   cleanupDirectories = []
 })
 
-export const zipNode = async function (
-  fixture: ZipFunctionsPaths,
-  zipOptions: ZipOptions = {},
-): Promise<ZipNodeReturn> {
+export const zipNode = async function (fixture: MixedPaths, zipOptions: ZipOptions = {}): Promise<ZipNodeReturn> {
   const { files, tmpDir } = await zipFixture(fixture, zipOptions)
   const { archiveFormat } = zipOptions.opts || {}
 
@@ -67,7 +65,7 @@ export const getBundlerNameFromOptions = ({ config = {} }: { config?: Config }) 
   config['*'] && config['*'].nodeBundler
 
 export const zipFixture = async function (
-  fixture: ZipFunctionsPaths,
+  fixture: MixedPaths,
   { length, fixtureDir, opts = {} }: ZipOptions = {},
 ): Promise<ZipReturn> {
   const bundlerString = getBundlerNameFromOptions(opts) || 'default'
@@ -100,7 +98,7 @@ export const getFunctionResultsByName = (files: FunctionResult[]): Record<string
 }
 
 export const zipCheckFunctions = async function (
-  fixture: ZipFunctionsPaths,
+  fixture: MixedPaths,
   { length = 1, fixtureDir = FIXTURES_DIR, tmpDir, opts = {} }: ZipOptions & { tmpDir: string },
 ): Promise<ZipReturn> {
   const bag = getFunctionsBag(fixture)

--- a/packages/zip-it-and-ship-it/tests/list_functions.test.ts
+++ b/packages/zip-it-and-ship-it/tests/list_functions.test.ts
@@ -105,5 +105,44 @@ describe('listFunctions', () => {
 
       expect(normalizeFiles(fixtureDir, func)).toMatchSnapshot()
     })
+
+    test('Accepts an object with mixed paths', async () => {
+      const basePath = join(FIXTURES_ESM_DIR, 'v2-api-isolated')
+      const functions = await listFunctions(
+        {
+          generated: {
+            functions: [
+              join(basePath, '.netlify/plugins/node_modules/extension-buildhooks/functions/extension-func1.mjs'),
+              join(basePath, '.netlify/plugins/node_modules/extension-buildhooks/functions/extension-func2'),
+            ],
+          },
+          user: {
+            directories: [join(basePath, 'netlify/functions')],
+          },
+        },
+        {
+          basePath,
+          parseISC: true,
+        },
+      )
+
+      expect(functions.length).toBe(3)
+
+      const userFunc1 = normalizeFiles(basePath, functions[0])
+      expect(userFunc1.name).toBe('user-func1')
+      expect(userFunc1.mainFile).toBe('netlify/functions/user-func1.mjs')
+
+      const extensionFunc1 = normalizeFiles(basePath, functions[1])
+      expect(extensionFunc1.name).toBe('extension-func1')
+      expect(extensionFunc1.mainFile).toBe(
+        '.netlify/plugins/node_modules/extension-buildhooks/functions/extension-func1.mjs',
+      )
+
+      const extensionFunc2 = normalizeFiles(basePath, functions[2])
+      expect(extensionFunc2.name).toBe('extension-func2')
+      expect(extensionFunc2.mainFile).toBe(
+        '.netlify/plugins/node_modules/extension-buildhooks/functions/extension-func2/index.mjs',
+      )
+    })
   })
 })


### PR DESCRIPTION
#### Summary

Updates the signature of `listFunctions` so it accepts the same object of mixed paths introduced in #6524.

**A picture of a cute animal (not mandatory, but encouraged)**

🐔 
