### PR TITLE
feat: add `headers` to edge functions manifest validation

### DIFF
--- a/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
+++ b/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
@@ -225,6 +225,72 @@ REQUIRED must have required property 'pattern'
   12 |       "generator": "@netlify/fake-plugin@1.0.0"]
 `;
 
+exports[`route headers > should throw on additional property in headers 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+ADDTIONAL PROPERTY must NOT have additional properties
+
+  15 |         "x-custom-header": {
+  16 |           "style": "exists",
+> 17 |           "foo": "bar"
+     |           ^^^^^ 😲  foo is not expected to be here!
+  18 |         }
+  19 |       }
+  20 |     }]
+`;
+
+exports[`route headers > should throw on invalid pattern format 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+FORMAT must match format "regexPattern"
+
+  15 |         "x-custom-header": {
+  16 |           "style": "regex",
+> 17 |           "pattern": "/^Bearer .+/"
+     |                      ^^^^^^^^^^^^^^ 👈🏽  format must match format "regexPattern"
+  18 |         }
+  19 |       }
+  20 |     }]
+`;
+
+exports[`route headers > should throw on invalid style value 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+ENUM must be equal to one of the allowed values
+(exists, missing, regex)
+
+  14 |       "headers": {
+  15 |         "x-custom-header": {
+> 16 |           "style": "invalid"
+     |                    ^^^^^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
+  17 |         }
+  18 |       }
+  19 |     }]
+`;
+
+exports[`route headers > should throw on missing style property 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+REQUIRED must have required property 'style'
+
+  13 |       "generator": "@netlify/fake-plugin@1.0.0",
+  14 |       "headers": {
+> 15 |         "x-custom-header": {
+     |                            ^ ☹️  style is missing here!
+  16 |           "pattern": "^Bearer .+$"
+  17 |         }
+  18 |       }]
+`;
+
+exports[`route headers > should throw when style is regex but pattern is missing 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+REQUIRED must have required property 'pattern'
+
+  13 |       "generator": "@netlify/fake-plugin@1.0.0",
+  14 |       "headers": {
+> 15 |         "x-custom-header": {
+     |                            ^ ☹️  pattern is missing here!
+  16 |           "style": "regex"
+  17 |         }
+  18 |       }]
+`;
+
 exports[`should show multiple errors 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
 ADDTIONAL PROPERTY must NOT have additional properties

--- a/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
+++ b/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
@@ -53,6 +53,72 @@ REQUIRED must have required property 'format'
   6 |   ],]
 `;
 
+exports[`headers > should throw on additional property in headers 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+ADDTIONAL PROPERTY must NOT have additional properties
+
+  33 |     "x-custom-header": {
+  34 |       "style": "exists",
+> 35 |       "foo": "bar"
+     |       ^^^^^ 😲  foo is not expected to be here!
+  36 |     }
+  37 |   }
+  38 | }]
+`;
+
+exports[`headers > should throw on invalid pattern format 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+FORMAT must match format "regexPattern"
+
+  33 |     "x-custom-header": {
+  34 |       "style": "regex",
+> 35 |       "pattern": "/^Bearer .+/"
+     |                  ^^^^^^^^^^^^^^ 👈🏽  format must match format "regexPattern"
+  36 |     }
+  37 |   }
+  38 | }]
+`;
+
+exports[`headers > should throw on invalid style value 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+ENUM must be equal to one of the allowed values
+(exists, missing, regex)
+
+  32 |   "headers": {
+  33 |     "x-custom-header": {
+> 34 |       "style": "invalid"
+     |                ^^^^^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
+  35 |     }
+  36 |   }
+  37 | }]
+`;
+
+exports[`headers > should throw on missing style property 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+REQUIRED must have required property 'style'
+
+  31 |   "bundler_version": "1.6.0",
+  32 |   "headers": {
+> 33 |     "x-custom-header": {
+     |                        ^ ☹️  style is missing here!
+  34 |       "pattern": "^Bearer .+"
+  35 |     }
+  36 |   }]
+`;
+
+exports[`headers > should throw when style is regex but pattern is missing 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+REQUIRED must have required property 'pattern'
+
+  31 |   "bundler_version": "1.6.0",
+  32 |   "headers": {
+> 33 |     "x-custom-header": {
+     |                        ^ ☹️  pattern is missing here!
+  34 |       "style": "regex"
+  35 |     }
+  36 |   }]
+`;
+
 exports[`import map URL > should throw on wrong type 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
 TYPE must be string

--- a/packages/edge-bundler/node/validation/manifest/index.test.ts
+++ b/packages/edge-bundler/node/validation/manifest/index.test.ts
@@ -186,8 +186,8 @@ describe('headers', () => {
     const manifest = getBaseManifest()
     manifest.headers = {
       'x-custom-header': {
-        style: 'exists'
-      }
+        style: 'exists',
+      },
     }
 
     expect(() => validateManifest(manifest)).not.toThrowError()
@@ -197,8 +197,8 @@ describe('headers', () => {
     const manifest = getBaseManifest()
     manifest.headers = {
       'x-custom-header': {
-        style: 'missing'
-      }
+        style: 'missing',
+      },
     }
 
     expect(() => validateManifest(manifest)).not.toThrowError()
@@ -209,8 +209,8 @@ describe('headers', () => {
     manifest.headers = {
       'x-custom-header': {
         style: 'regex',
-        pattern: '^Bearer .+$'
-      }
+        pattern: '^Bearer .+$',
+      },
     }
 
     expect(() => validateManifest(manifest)).not.toThrowError()
@@ -220,8 +220,8 @@ describe('headers', () => {
     const manifest = getBaseManifest()
     manifest.headers = {
       'x-custom-header': {
-        pattern: '^Bearer .+'
-      }
+        pattern: '^Bearer .+',
+      },
     }
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
@@ -231,8 +231,8 @@ describe('headers', () => {
     const manifest = getBaseManifest()
     manifest.headers = {
       'x-custom-header': {
-        style: 'invalid'
-      }
+        style: 'invalid',
+      },
     }
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
@@ -242,8 +242,8 @@ describe('headers', () => {
     const manifest = getBaseManifest()
     manifest.headers = {
       'x-custom-header': {
-        style: 'regex'
-      }
+        style: 'regex',
+      },
     }
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
@@ -254,8 +254,8 @@ describe('headers', () => {
     manifest.headers = {
       'x-custom-header': {
         style: 'regex',
-        pattern: '/^Bearer .+/'
-      }
+        pattern: '/^Bearer .+/',
+      },
     }
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
@@ -266,8 +266,8 @@ describe('headers', () => {
     manifest.headers = {
       'x-custom-header': {
         style: 'exists',
-        foo: 'bar'
-      }
+        foo: 'bar',
+      },
     }
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
@@ -277,15 +277,15 @@ describe('headers', () => {
     const manifest = getBaseManifest()
     manifest.headers = {
       'x-exists-header': {
-        style: 'exists'
+        style: 'exists',
       },
       'x-missing-header': {
-        style: 'missing'
+        style: 'missing',
       },
-      'authorization': {
+      authorization: {
         style: 'regex',
-        pattern: '^Bearer [a-zA-Z0-9]+$'
-      }
+        pattern: '^Bearer [a-zA-Z0-9]+$',
+      },
     }
 
     expect(() => validateManifest(manifest)).not.toThrowError()

--- a/packages/edge-bundler/node/validation/manifest/index.test.ts
+++ b/packages/edge-bundler/node/validation/manifest/index.test.ts
@@ -181,10 +181,10 @@ describe('import map URL', () => {
   })
 })
 
-describe('headers', () => {
+describe('route headers', () => {
   test('should accept valid headers with exists style', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'exists',
       },
@@ -195,7 +195,7 @@ describe('headers', () => {
 
   test('should accept valid headers with missing style', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'missing',
       },
@@ -206,7 +206,7 @@ describe('headers', () => {
 
   test('should accept valid headers with regex style and pattern', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'regex',
         pattern: '^Bearer .+$',
@@ -218,9 +218,9 @@ describe('headers', () => {
 
   test('should throw on missing style property', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
-        pattern: '^Bearer .+',
+        pattern: '^Bearer .+$',
       },
     }
 
@@ -229,7 +229,7 @@ describe('headers', () => {
 
   test('should throw on invalid style value', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'invalid',
       },
@@ -240,7 +240,7 @@ describe('headers', () => {
 
   test('should throw when style is regex but pattern is missing', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'regex',
       },
@@ -251,7 +251,7 @@ describe('headers', () => {
 
   test('should throw on invalid pattern format', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'regex',
         pattern: '/^Bearer .+/',
@@ -263,7 +263,7 @@ describe('headers', () => {
 
   test('should throw on additional property in headers', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-custom-header': {
         style: 'exists',
         foo: 'bar',
@@ -275,7 +275,7 @@ describe('headers', () => {
 
   test('should accept multiple headers with different styles', () => {
     const manifest = getBaseManifest()
-    manifest.headers = {
+    manifest.routes[0].headers = {
       'x-exists-header': {
         style: 'exists',
       },

--- a/packages/edge-bundler/node/validation/manifest/index.test.ts
+++ b/packages/edge-bundler/node/validation/manifest/index.test.ts
@@ -180,3 +180,114 @@ describe('import map URL', () => {
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })
 })
+
+describe('headers', () => {
+  test('should accept valid headers with exists style', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'exists'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).not.toThrowError()
+  })
+
+  test('should accept valid headers with missing style', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'missing'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).not.toThrowError()
+  })
+
+  test('should accept valid headers with regex style and pattern', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'regex',
+        pattern: '^Bearer .+$'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).not.toThrowError()
+  })
+
+  test('should throw on missing style property', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        pattern: '^Bearer .+'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
+  })
+
+  test('should throw on invalid style value', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'invalid'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
+  })
+
+  test('should throw when style is regex but pattern is missing', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'regex'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
+  })
+
+  test('should throw on invalid pattern format', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'regex',
+        pattern: '/^Bearer .+/'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
+  })
+
+  test('should throw on additional property in headers', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-custom-header': {
+        style: 'exists',
+        foo: 'bar'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
+  })
+
+  test('should accept multiple headers with different styles', () => {
+    const manifest = getBaseManifest()
+    manifest.headers = {
+      'x-exists-header': {
+        style: 'exists'
+      },
+      'x-missing-header': {
+        style: 'missing'
+      },
+      'authorization': {
+        style: 'regex',
+        pattern: '^Bearer [a-zA-Z0-9]+$'
+      }
+    }
+
+    expect(() => validateManifest(manifest)).not.toThrowError()
+  })
+})

--- a/packages/edge-bundler/node/validation/manifest/schema.ts
+++ b/packages/edge-bundler/node/validation/manifest/schema.ts
@@ -60,6 +60,36 @@ const layersSchema = {
   additionalProperties: false,
 }
 
+const headersSchema = {
+  type: 'object',
+  patternProperties: {
+    '.*': {
+      type: 'object',
+      required: ['style'],
+      properties: {
+        pattern: {
+          type: 'string',
+          format: 'regexPattern',
+        },
+        style: {
+          type: 'string',
+          enum: ['exists', 'missing', 'regex'],
+        },
+      },
+      additionalProperties: false,
+      if: {
+        properties: {
+          style: { const: 'regex' },
+        },
+      },
+      then: {
+        required: ['pattern'],
+      },
+    },
+  },
+  additionalProperties: false,
+}
+
 const edgeManifestSchema = {
   type: 'object',
   required: ['bundles', 'routes', 'bundler_version'],
@@ -83,6 +113,7 @@ const edgeManifestSchema = {
     import_map: { type: 'string' },
     bundler_version: { type: 'string' },
     function_config: { type: 'object', additionalProperties: functionConfigSchema },
+    headers: headersSchema,
   },
   additionalProperties: false,
 }

--- a/packages/edge-bundler/node/validation/manifest/schema.ts
+++ b/packages/edge-bundler/node/validation/manifest/schema.ts
@@ -18,48 +18,6 @@ const excludedPatternsSchema = {
   },
 }
 
-const routesSchema = {
-  type: 'object',
-  required: ['function', 'pattern'],
-  properties: {
-    name: { type: 'string' },
-    function: { type: 'string' },
-    pattern: {
-      type: 'string',
-      format: 'regexPattern',
-      errorMessage: 'pattern must be a regex that starts with ^ and ends with $ (e.g. ^/blog/[d]{4}$)',
-    },
-    excluded_patterns: excludedPatternsSchema,
-    generator: { type: 'string' },
-    path: { type: 'string' },
-    methods: {
-      type: 'array',
-      items: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] },
-    },
-  },
-  additionalProperties: false,
-}
-
-const functionConfigSchema = {
-  type: 'object',
-  required: [],
-  properties: {
-    excluded_patterns: excludedPatternsSchema,
-    on_error: { type: 'string' },
-  },
-}
-
-const layersSchema = {
-  type: 'object',
-  required: ['flag', 'name'],
-  properties: {
-    flag: { type: 'string' },
-    name: { type: 'string' },
-    local: { type: 'string' },
-  },
-  additionalProperties: false,
-}
-
 const headersSchema = {
   type: 'object',
   patternProperties: {
@@ -90,6 +48,49 @@ const headersSchema = {
   additionalProperties: false,
 }
 
+const routesSchema = {
+  type: 'object',
+  required: ['function', 'pattern'],
+  properties: {
+    name: { type: 'string' },
+    function: { type: 'string' },
+    pattern: {
+      type: 'string',
+      format: 'regexPattern',
+      errorMessage: 'pattern must be a regex that starts with ^ and ends with $ (e.g. ^/blog/[d]{4}$)',
+    },
+    excluded_patterns: excludedPatternsSchema,
+    generator: { type: 'string' },
+    path: { type: 'string' },
+    methods: {
+      type: 'array',
+      items: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] },
+    },
+    headers: headersSchema,
+  },
+  additionalProperties: false,
+}
+
+const functionConfigSchema = {
+  type: 'object',
+  required: [],
+  properties: {
+    excluded_patterns: excludedPatternsSchema,
+    on_error: { type: 'string' },
+  },
+}
+
+const layersSchema = {
+  type: 'object',
+  required: ['flag', 'name'],
+  properties: {
+    flag: { type: 'string' },
+    name: { type: 'string' },
+    local: { type: 'string' },
+  },
+  additionalProperties: false,
+}
+
 const edgeManifestSchema = {
   type: 'object',
   required: ['bundles', 'routes', 'bundler_version'],
@@ -113,7 +114,6 @@ const edgeManifestSchema = {
     import_map: { type: 'string' },
     bundler_version: { type: 'string' },
     function_config: { type: 'object', additionalProperties: functionConfigSchema },
-    headers: headersSchema,
   },
   additionalProperties: false,
 }


### PR DESCRIPTION
#### Summary

Updates the edge functions manifest validation logic to include the new `headers` property introduced in https://github.com/netlify/build/pull/6501.