### PR TITLE
fix: rename edge functions manifest property

### DIFF
--- a/packages/edge-bundler/node/config.test.ts
+++ b/packages/edge-bundler/node/config.test.ts
@@ -293,14 +293,14 @@ test('Loads function paths from the in-source `config` function', async () => {
     path: '/user-func1',
     headers: {
       'x-must-be-there': {
-        style: 'exists',
+        matcher: 'exists',
       },
       'x-must-match': {
         pattern: '^(foo|bar)$',
-        style: 'regex',
+        matcher: 'regex',
       },
       'x-must-not-be-there': {
-        style: 'missing',
+        matcher: 'missing',
       },
     },
   })

--- a/packages/edge-bundler/node/declaration.ts
+++ b/packages/edge-bundler/node/declaration.ts
@@ -2,7 +2,7 @@ import { BundleError } from './bundle_error.js'
 import { FunctionConfig, FunctionConfigWithAllPossibleFields, HeadersConfig, HTTPMethod, Path } from './config.js'
 import { FeatureFlags } from './feature_flags.js'
 
-export type HeaderMatch = { pattern: string; style: 'regex' } | { style: 'exists' | 'missing' }
+export type HeaderMatch = { pattern: string; matcher: 'regex' } | { matcher: 'exists' | 'missing' }
 type HeaderMatchers = Record<string, HeaderMatch>
 
 interface BaseDeclaration {
@@ -192,9 +192,9 @@ export const getHeaderMatchers = (headers?: HeadersConfig): HeaderMatchers => {
 
   for (const header in headers) {
     if (typeof headers[header] === 'boolean') {
-      matchers[header] = { style: headers[header] ? 'exists' : 'missing' }
+      matchers[header] = { matcher: headers[header] ? 'exists' : 'missing' }
     } else if (typeof headers[header] === 'string') {
-      matchers[header] = { style: 'regex', pattern: normalizePattern(headers[header]) }
+      matchers[header] = { matcher: 'regex', pattern: normalizePattern(headers[header]) }
     } else {
       throw new BundleError(new Error(headerConfigError))
     }

--- a/packages/edge-bundler/node/manifest.test.ts
+++ b/packages/edge-bundler/node/manifest.test.ts
@@ -237,11 +237,11 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
 
   const matcher = getRouteMatcher(manifest)
 
-  expect(matcher('/showcases/boho-style')).toBeDefined()
+  expect(matcher('/showcases/boho-matcher')).toBeDefined()
   expect(matcher('/checkout/address')).toBeDefined()
   expect(matcher('/checkout/terms-and-conditions')).toBeUndefined()
   expect(matcher('/checkout/scrooge-mc-duck-animation.css')).toBeUndefined()
-  expect(matcher('/showcases/boho-style/expensive-chair.jpg')).toBeUndefined()
+  expect(matcher('/showcases/boho-matcher/expensive-chair.jpg')).toBeUndefined()
 })
 
 test('URLPattern named groups are supported', () => {
@@ -640,25 +640,25 @@ describe('Header matching', () => {
         path: '/f1/*',
         headers: {
           'x-absent': {
-            style: 'missing',
+            matcher: 'missing',
           },
           'x-also-present': {
-            style: 'exists',
+            matcher: 'exists',
           },
           'x-match-exact': {
             pattern: '^exact$',
-            style: 'regex',
+            matcher: 'regex',
           },
           'x-match-prefix': {
             pattern: '^prefix(.*)$',
-            style: 'regex',
+            matcher: 'regex',
           },
           'x-match-suffix': {
             pattern: '^(.*)suffix$',
-            style: 'regex',
+            matcher: 'regex',
           },
           'x-present': {
-            style: 'exists',
+            matcher: 'exists',
           },
         },
       },

--- a/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
+++ b/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
@@ -53,72 +53,6 @@ REQUIRED must have required property 'format'
   6 |   ],]
 `;
 
-exports[`headers > should throw on additional property in headers 1`] = `
-[ManifestValidationError: Validation of Edge Functions manifest failed
-ADDTIONAL PROPERTY must NOT have additional properties
-
-  33 |     "x-custom-header": {
-  34 |       "style": "exists",
-> 35 |       "foo": "bar"
-     |       ^^^^^ 😲  foo is not expected to be here!
-  36 |     }
-  37 |   }
-  38 | }]
-`;
-
-exports[`headers > should throw on invalid pattern format 1`] = `
-[ManifestValidationError: Validation of Edge Functions manifest failed
-FORMAT must match format "regexPattern"
-
-  33 |     "x-custom-header": {
-  34 |       "style": "regex",
-> 35 |       "pattern": "/^Bearer .+/"
-     |                  ^^^^^^^^^^^^^^ 👈🏽  format must match format "regexPattern"
-  36 |     }
-  37 |   }
-  38 | }]
-`;
-
-exports[`headers > should throw on invalid style value 1`] = `
-[ManifestValidationError: Validation of Edge Functions manifest failed
-ENUM must be equal to one of the allowed values
-(exists, missing, regex)
-
-  32 |   "headers": {
-  33 |     "x-custom-header": {
-> 34 |       "style": "invalid"
-     |                ^^^^^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
-  35 |     }
-  36 |   }
-  37 | }]
-`;
-
-exports[`headers > should throw on missing style property 1`] = `
-[ManifestValidationError: Validation of Edge Functions manifest failed
-REQUIRED must have required property 'style'
-
-  31 |   "bundler_version": "1.6.0",
-  32 |   "headers": {
-> 33 |     "x-custom-header": {
-     |                        ^ ☹️  style is missing here!
-  34 |       "pattern": "^Bearer .+"
-  35 |     }
-  36 |   }]
-`;
-
-exports[`headers > should throw when style is regex but pattern is missing 1`] = `
-[ManifestValidationError: Validation of Edge Functions manifest failed
-REQUIRED must have required property 'pattern'
-
-  31 |   "bundler_version": "1.6.0",
-  32 |   "headers": {
-> 33 |     "x-custom-header": {
-     |                        ^ ☹️  pattern is missing here!
-  34 |       "style": "regex"
-  35 |     }
-  36 |   }]
-`;
-
 exports[`import map URL > should throw on wrong type 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
 TYPE must be string
@@ -230,7 +164,7 @@ exports[`route headers > should throw on additional property in headers 1`] = `
 ADDTIONAL PROPERTY must NOT have additional properties
 
   15 |         "x-custom-header": {
-  16 |           "style": "exists",
+  16 |           "matcher": "exists",
 > 17 |           "foo": "bar"
      |           ^^^^^ 😲  foo is not expected to be here!
   18 |         }
@@ -238,12 +172,26 @@ ADDTIONAL PROPERTY must NOT have additional properties
   20 |     }]
 `;
 
+exports[`route headers > should throw on invalid matcher value 1`] = `
+[ManifestValidationError: Validation of Edge Functions manifest failed
+ENUM must be equal to one of the allowed values
+(exists, missing, regex)
+
+  14 |       "headers": {
+  15 |         "x-custom-header": {
+> 16 |           "matcher": "invalid"
+     |                      ^^^^^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
+  17 |         }
+  18 |       }
+  19 |     }]
+`;
+
 exports[`route headers > should throw on invalid pattern format 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
 FORMAT must match format "regexPattern"
 
   15 |         "x-custom-header": {
-  16 |           "style": "regex",
+  16 |           "matcher": "regex",
 > 17 |           "pattern": "/^Bearer .+/"
      |                      ^^^^^^^^^^^^^^ 👈🏽  format must match format "regexPattern"
   18 |         }
@@ -251,34 +199,20 @@ FORMAT must match format "regexPattern"
   20 |     }]
 `;
 
-exports[`route headers > should throw on invalid style value 1`] = `
+exports[`route headers > should throw on missing matcher property 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
-ENUM must be equal to one of the allowed values
-(exists, missing, regex)
-
-  14 |       "headers": {
-  15 |         "x-custom-header": {
-> 16 |           "style": "invalid"
-     |                    ^^^^^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
-  17 |         }
-  18 |       }
-  19 |     }]
-`;
-
-exports[`route headers > should throw on missing style property 1`] = `
-[ManifestValidationError: Validation of Edge Functions manifest failed
-REQUIRED must have required property 'style'
+REQUIRED must have required property 'matcher'
 
   13 |       "generator": "@netlify/fake-plugin@1.0.0",
   14 |       "headers": {
 > 15 |         "x-custom-header": {
-     |                            ^ ☹️  style is missing here!
+     |                            ^ ☹️  matcher is missing here!
   16 |           "pattern": "^Bearer .+$"
   17 |         }
   18 |       }]
 `;
 
-exports[`route headers > should throw when style is regex but pattern is missing 1`] = `
+exports[`route headers > should throw when matcher is regex but pattern is missing 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
 REQUIRED must have required property 'pattern'
 
@@ -286,7 +220,7 @@ REQUIRED must have required property 'pattern'
   14 |       "headers": {
 > 15 |         "x-custom-header": {
      |                            ^ ☹️  pattern is missing here!
-  16 |           "style": "regex"
+  16 |           "matcher": "regex"
   17 |         }
   18 |       }]
 `;

--- a/packages/edge-bundler/node/validation/manifest/index.test.ts
+++ b/packages/edge-bundler/node/validation/manifest/index.test.ts
@@ -182,33 +182,33 @@ describe('import map URL', () => {
 })
 
 describe('route headers', () => {
-  test('should accept valid headers with exists style', () => {
+  test('should accept valid headers with exists matcher', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'exists',
+        matcher: 'exists',
       },
     }
 
     expect(() => validateManifest(manifest)).not.toThrowError()
   })
 
-  test('should accept valid headers with missing style', () => {
+  test('should accept valid headers with missing matcher', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'missing',
+        matcher: 'missing',
       },
     }
 
     expect(() => validateManifest(manifest)).not.toThrowError()
   })
 
-  test('should accept valid headers with regex style and pattern', () => {
+  test('should accept valid headers with regex matcher and pattern', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'regex',
+        matcher: 'regex',
         pattern: '^Bearer .+$',
       },
     }
@@ -216,7 +216,7 @@ describe('route headers', () => {
     expect(() => validateManifest(manifest)).not.toThrowError()
   })
 
-  test('should throw on missing style property', () => {
+  test('should throw on missing matcher property', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
@@ -227,22 +227,22 @@ describe('route headers', () => {
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })
 
-  test('should throw on invalid style value', () => {
+  test('should throw on invalid matcher value', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'invalid',
+        matcher: 'invalid',
       },
     }
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })
 
-  test('should throw when style is regex but pattern is missing', () => {
+  test('should throw when matcher is regex but pattern is missing', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'regex',
+        matcher: 'regex',
       },
     }
 
@@ -253,7 +253,7 @@ describe('route headers', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'regex',
+        matcher: 'regex',
         pattern: '/^Bearer .+/',
       },
     }
@@ -265,7 +265,7 @@ describe('route headers', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-custom-header': {
-        style: 'exists',
+        matcher: 'exists',
         foo: 'bar',
       },
     }
@@ -273,17 +273,17 @@ describe('route headers', () => {
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })
 
-  test('should accept multiple headers with different styles', () => {
+  test('should accept multiple headers with different matchers', () => {
     const manifest = getBaseManifest()
     manifest.routes[0].headers = {
       'x-exists-header': {
-        style: 'exists',
+        matcher: 'exists',
       },
       'x-missing-header': {
-        style: 'missing',
+        matcher: 'missing',
       },
       authorization: {
-        style: 'regex',
+        matcher: 'regex',
         pattern: '^Bearer [a-zA-Z0-9]+$',
       },
     }

--- a/packages/edge-bundler/node/validation/manifest/schema.ts
+++ b/packages/edge-bundler/node/validation/manifest/schema.ts
@@ -23,13 +23,13 @@ const headersSchema = {
   patternProperties: {
     '.*': {
       type: 'object',
-      required: ['style'],
+      required: ['matcher'],
       properties: {
         pattern: {
           type: 'string',
           format: 'regexPattern',
         },
-        style: {
+        matcher: {
           type: 'string',
           enum: ['exists', 'missing', 'regex'],
         },
@@ -37,7 +37,7 @@ const headersSchema = {
       additionalProperties: false,
       if: {
         properties: {
-          style: { const: 'regex' },
+          matcher: { const: 'regex' },
         },
       },
       then: {


### PR DESCRIPTION
#### Summary

Follow-up to https://github.com/netlify/build/pull/6542. The right property name is `matcher`, not `style`.