### PR TITLE
test: resolve flaky telemetry and build info tests

### DIFF
--- a/packages/build-info/src/node/get-build-info.test.ts
+++ b/packages/build-info/src/node/get-build-info.test.ts
@@ -79,6 +79,7 @@ test.skipIf(platform() === 'win32')(
     const info = await getBuildInfo({ rootDir: fixture.cwd, projectDir: fixture.cwd })
 
     info.jsWorkspaces!.rootDir = '/cleaned-for-snapshot'
+    info.settings = info.settings.sort((a, b) => (a.dist < b.dist ? -1 : 1))
     expect(info).toMatchSnapshot()
   },
 )
@@ -90,6 +91,7 @@ test.skipIf(platform() === 'win32')(
     const info = await getBuildInfo({ rootDir: fixture.cwd, projectDir: join(fixture.cwd, 'packages/blog') })
 
     info.jsWorkspaces!.rootDir = '/cleaned-for-snapshot'
+    info.settings = info.settings.sort((a, b) => (a.dist < b.dist ? -1 : 1))
     expect(info).toMatchSnapshot()
   },
 )

--- a/packages/build/tests/telemetry/tests.js
+++ b/packages/build/tests/telemetry/tests.js
@@ -234,6 +234,7 @@ test('Telemetry calls timeout by default', async (t) => {
   const { telemetryRequests } = await runWithApiMock(t, 'success', {
     // Force a client side timeout
     telemetryTimeout: 0,
+    waitTelemetryServer: 1000,
     // The error monitor snapshot should contain the timeout error
     snapshot: true,
   })


### PR DESCRIPTION
#### Summary

1. `telemetry › tests › Telemetry calls timeout by default` (b48b211)
Example: https://github.com/netlify/build/actions/runs/16308326200/job/46058890684
2. `get-build-info > should retrieve the build info for providing a rootDir and the same projectDir` (44a2f151e)
Example: https://github.com/netlify/build/actions/runs/16307931875/job/46057797041

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
