### PR TITLE
fix: stop adding start/end chars to header patterns

### DIFF
--- a/packages/edge-bundler/node/declaration.ts
+++ b/packages/edge-bundler/node/declaration.ts
@@ -194,7 +194,10 @@ export const getHeaderMatchers = (headers?: HeadersConfig): HeaderMatchers => {
     if (typeof headers[header] === 'boolean') {
       matchers[header] = { matcher: headers[header] ? 'exists' : 'missing' }
     } else if (typeof headers[header] === 'string') {
-      matchers[header] = { matcher: 'regex', pattern: normalizePattern(headers[header]) }
+      // Strip leading and forward slashes.
+      const pattern = new RegExp(headers[header]).toString().slice(1, -1)
+
+      matchers[header] = { matcher: 'regex', pattern }
     } else {
       throw new BundleError(new Error(headerConfigError))
     }

--- a/packages/edge-bundler/node/manifest.test.ts
+++ b/packages/edge-bundler/node/manifest.test.ts
@@ -620,9 +620,9 @@ describe('Header matching', () => {
           'x-present': true,
           'x-also-present': true,
           'x-absent': false,
-          'x-match-prefix': '^prefix(.*)',
-          'x-match-exact': 'exact',
-          'x-match-suffix': '(.*)suffix$',
+          'x-match-prefix': '^prefix',
+          'x-match-exact': '^exact$',
+          'x-match-suffix': 'suffix$',
         },
       },
     ]
@@ -650,11 +650,11 @@ describe('Header matching', () => {
             matcher: 'regex',
           },
           'x-match-prefix': {
-            pattern: '^prefix(.*)$',
+            pattern: '^prefix',
             matcher: 'regex',
           },
           'x-match-suffix': {
-            pattern: '^(.*)suffix$',
+            pattern: 'suffix$',
             matcher: 'regex',
           },
           'x-present': {


### PR DESCRIPTION
#### Summary

Follow-up to https://github.com/netlify/build/pull/6501. Stops automatically adding the `^` and `$` delimiters, leaving it up to the user to decide how they want to match.