### PR TITLE
fix: replaced path-exists with existsSync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24854,8 +24854,7 @@
         "execa": "^8.0.0",
         "map-obj": "^5.0.0",
         "micromatch": "^4.0.2",
-        "moize": "^6.1.3",
-        "path-exists": "^5.0.0"
+        "moize": "^6.1.3"
       },
       "devDependencies": {
         "@types/node": "^18.19.111",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -53,8 +53,7 @@
     "execa": "^8.0.0",
     "map-obj": "^5.0.0",
     "micromatch": "^4.0.2",
-    "moize": "^6.1.3",
-    "path-exists": "^5.0.0"
+    "moize": "^6.1.3"
   },
   "devDependencies": {
     "@types/node": "^18.19.111",

--- a/packages/git-utils/src/exec.ts
+++ b/packages/git-utils/src/exec.ts
@@ -1,8 +1,7 @@
 import process from 'process'
-
+import { existsSync } from 'fs'
 import { execaSync } from 'execa'
 import moize from 'moize/mjs/index.mjs'
-import { pathExistsSync } from 'path-exists'
 
 // Fires the `git` binary. Memoized.
 const mGit = function (args, cwd) {
@@ -23,7 +22,7 @@ export const git = moize(mGit, { isDeepEqual: true, maxSize: 1e3 })
 const safeGetCwd = function (cwd) {
   const cwdA = getCwdValue(cwd)
 
-  if (!pathExistsSync(cwdA)) {
+  if (!existsSync(cwdA)) {
     throw new Error(`Current directory does not exist: ${cwdA}`)
   }
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Replace path-exists with native fs.existsSync in @netlify/git-utils

As stated in the package's README so we don't need this

> NOTE: fs.existsSync has been un-deprecated in Node.js since 6.8.0. If you only need to check synchronously, this module is not needed.

P.S. it was the lowest-hanging fruit, I'm prepin a bigger PR on the weekend :)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

Here's my friend's adorable cat

<details>
<summary>🐈</summary>

![photo_2025-06-05_01-17-20](https://github.com/user-attachments/assets/1fa91ae2-bc57-4519-9bac-1ff474ba7d39)

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/49d0094b-3e3b-422f-a70a-cf490909adcc" />
</details>