### PR TITLE
feat!: stop throwing error when directories do not exist

### DIFF
--- a/packages/zip-it-and-ship-it/src/utils/fs.ts
+++ b/packages/zip-it-and-ship-it/src/utils/fs.ts
@@ -54,12 +54,11 @@ export const safeUnlink = async (path: string) => {
 
 // Takes a list of absolute paths and returns an array containing all the
 // filenames within those directories, if at least one of the directories
-// exists. If not, an error is thrown.
+// exists.
 export const listFunctionsDirectories = async function (srcFolders: string[]) {
   const filenamesByDirectory = await Promise.allSettled(
     srcFolders.map((srcFolder) => listFunctionsDirectory(srcFolder)),
   )
-  const errorMessages: string[] = []
   const validDirectories = filenamesByDirectory
     .map((result) => {
       if (result.status === 'rejected') {
@@ -76,11 +75,6 @@ export const listFunctionsDirectories = async function (srcFolders: string[]) {
       return result.value
     })
     .filter(nonNullable)
-
-  if (validDirectories.length === 0) {
-    throw new Error(`Functions folders do not exist: ${srcFolders.join(', ')}
-${errorMessages.join('\n')}`)
-  }
 
   return validDirectories.flat()
 }
@@ -105,6 +99,5 @@ export const mkdirAndWriteFile: typeof fs.writeFile = async (path: PathLike | fs
     await fs.mkdir(directory, { recursive: true })
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return fs.writeFile(path, ...params)
 }

--- a/packages/zip-it-and-ship-it/src/utils/fs.ts
+++ b/packages/zip-it-and-ship-it/src/utils/fs.ts
@@ -99,5 +99,6 @@ export const mkdirAndWriteFile: typeof fs.writeFile = async (path: PathLike | fs
     await fs.mkdir(directory, { recursive: true })
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return fs.writeFile(path, ...params)
 }

--- a/packages/zip-it-and-ship-it/tests/list_functions_files.test.ts
+++ b/packages/zip-it-and-ship-it/tests/list_functions_files.test.ts
@@ -40,21 +40,13 @@ describe('listFunctionsFiles', () => {
     },
   )
 
-  test('listFunctionsFiles throws if all function directories do not exist', async () => {
-    await expect(
-      async () =>
-        await listFunctionsFiles([
-          join(FIXTURES_DIR, 'missing-functions-folder', 'functions'),
-          join(FIXTURES_DIR, 'missing-functions-folder', 'functions2'),
-        ]),
-    ).rejects.toThrow(/Functions folders do not exist: /)
-  })
+  test('listFunctionsFiles returns an empty array if none of the function directories exist', async () => {
+    const files = await listFunctionsFiles([
+      join(FIXTURES_DIR, 'missing-functions-folder', 'functions'),
+      join(FIXTURES_DIR, 'missing-functions-folder', 'functions2'),
+    ])
 
-  test('listFunctionsFiles does not hide errors that have nothing todo with folder existents', async () => {
-    // @ts-expect-error test
-    await expect(() => listFunctionsFiles([true])).rejects.toThrow(
-      expect.not.stringContaining('Functions folders do not exist:'),
-    )
+    expect(files).toBe([])
   })
 
   test('listFunctionsFiles includes in-source config declarations', async () => {

--- a/packages/zip-it-and-ship-it/tests/main.test.ts
+++ b/packages/zip-it-and-ship-it/tests/main.test.ts
@@ -708,10 +708,6 @@ describe('zip-it-and-ship-it', () => {
     })
   })
 
-  testMany('Throws when the source folder does not exist', [...allBundleConfigs, 'bundler_none'], async (options) => {
-    await expect(zipNode('does-not-exist', { opts: options })).rejects.toThrowError(/Functions folders do not exist/)
-  })
-
   testMany(
     'Works even if destination folder does not exist',
     [...allBundleConfigs, 'bundler_none'],
@@ -3056,6 +3052,62 @@ test('Supports functions inside the plugins modules path', async () => {
   )
   expect(functions['user-func1'].generator).toBeUndefined()
   expect(functions['user-func1'].priority).toBe(10)
+
+  await tmpDir.cleanup()
+})
+
+test('Supports individual functions even when none of the given function directories exist', async () => {
+  const tmpDir = await getTmpDir({
+    // Cleanup the folder even if there are still files in them
+    unsafeCleanup: true,
+  })
+  const basePath = join(FIXTURES_ESM_DIR, 'v2-api-files-and-directories')
+  const files = await zipFunctions(
+    {
+      generated: {
+        directories: [join(basePath, 'does-not-exist/functions')],
+        functions: [
+          join(basePath, 'cat.jpg'),
+          join(basePath, 'func2.mjs'),
+          join(basePath, 'func3'),
+          join(basePath, 'func4'),
+        ],
+      },
+      user: {
+        directories: [join(basePath, 'does-not-exist-either/functions')],
+      },
+    },
+    tmpDir.path,
+    {
+      basePath,
+    },
+  )
+
+  expect(files.length).toBe(3)
+
+  const unzippedFunctions = await unzipFiles(files)
+  const functions = getFunctionResultsByName(unzippedFunctions)
+
+  const func2 = await importFunctionFile(`${tmpDir.path}/${functions.func2.name}/${functions.func2.entryFilename}`)
+  const func2Result = await invokeLambda(func2)
+  expect(func2Result.statusCode).toBe(200)
+  expect(await readAsBuffer(func2Result.body)).toStrictEqual(
+    JSON.stringify({ func: 2, mod3: 'module-3', mod4: 'module-4' }),
+  )
+
+  const func3 = await importFunctionFile(`${tmpDir.path}/${functions.func3.name}/${functions.func3.entryFilename}`)
+  const func3Result = await invokeLambda(func3)
+  expect(func3Result.statusCode).toBe(200)
+  expect(await readAsBuffer(func3Result.body)).toStrictEqual(
+    JSON.stringify({ func: 3, mod3: 'module-3', mod4: 'module-4' }),
+  )
+
+  const func4 = await importFunctionFile(`${tmpDir.path}/${functions.func4.name}/${functions.func4.entryFilename}`)
+  const func4Result = await invokeLambda(func4)
+  expect(func4Result.statusCode).toBe(200)
+  expect(await readAsBuffer(func4Result.body)).toStrictEqual(
+    JSON.stringify({ func: 4, mod3: 'module-3', mod4: 'module-4' }),
+  )
 
   await tmpDir.cleanup()
 })


### PR DESCRIPTION
#### Summary

zip-it-and-ship-it is currently throwing an error when none of the function directories exist. I suspect this is a legacy artefact and I can't think of a good reason why this should be in place.

First of all, we're [already checking the existence of these directories](https://github.com/netlify/build/blob/d4eb57852c9c01e1b0041dcf0d5edd8fbe6d03c3/packages/build/src/plugins_core/functions/index.ts#L225-L258) upstream of zip-it-and-ship-it. Also, these directories are a mixed bag of directories created by users and generated by frameworks, so it doesn't make sense to me that a user with a missing `netlify/functions` directory gets an error whereas another one doesn't because one has a `.netlify/v1/functions` generated by a framework and the other one doesn't.

I'm bumping a major version here because this is technically a breaking change.