### PR TITLE
fix: support new functions getter in edge functions

### DIFF
--- a/packages/edge-bundler/node/formats/javascript.ts
+++ b/packages/edge-bundler/node/formats/javascript.ts
@@ -78,7 +78,7 @@ const getLocalEntryPoint = (
       }
       `
   })
-  const bootCall = `boot(functions, metadata);`
+  const bootCall = `boot(() => functions, metadata);`
 
   return [bootImport, declaration, ...imports, bootCall].join('\n\n')
 }

--- a/packages/edge-bundler/node/stage_2.test.ts
+++ b/packages/edge-bundler/node/stage_2.test.ts
@@ -14,8 +14,9 @@ test('`getLocalEntryPoint` returns a valid stage 2 file for local development', 
   // This is a fake bootstrap that we'll create just for the purpose of logging
   // the functions and the metadata that are sent to the `boot` function.
   const printer = `
-    export const boot = async (functions, metadata) => {
+    export const boot = async (getFunctions, metadata) => {
       const responses = {}
+      const functions = await getFunctions()
 
       for (const name in functions) {
         responses[name] = await functions[name]()


### PR DESCRIPTION
The `serve` function now accepts a functions getter rather than a plain object.

For example:

```ts
serve(async () => {
  return {
    someFunction: await doSomethingAsync()
  }
}, metadata);
```

Not sure how you want to handle landing this, since many clients will still be seeing the old `server.ts` which doesn't support this.

**DRAFT since i imagine you folks are already on this internally, so feel free to throw this PR away if you're solving it elsewhere**

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅