### PR TITLE
chore: drop `filter-obj`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25354,7 +25354,6 @@
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "fast-safe-stringify": "^2.1.1",
-        "filter-obj": "^6.0.0",
         "is-plain-obj": "^4.0.0",
         "path-exists": "^5.0.0"
       },

--- a/packages/redirect-parser/package.json
+++ b/packages/redirect-parser/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "fast-safe-stringify": "^2.1.1",
-    "filter-obj": "^6.0.0",
     "is-plain-obj": "^4.0.0",
     "path-exists": "^5.0.0"
   },

--- a/packages/redirect-parser/src/normalize.js
+++ b/packages/redirect-parser/src/normalize.js
@@ -1,4 +1,3 @@
-import { includeKeys } from 'filter-obj'
 import isPlainObj from 'is-plain-obj'
 
 import { normalizeConditions } from './conditions.js'
@@ -141,9 +140,9 @@ const isProxy = function (status, to) {
 }
 
 const removeUndefinedValues = function (object) {
-  return includeKeys(object, isDefined)
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => isDefined(value)))
 }
 
-const isDefined = function (key, value) {
+const isDefined = function (value) {
   return value !== undefined
 }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Replace `filter-obj` usage in redirect-parser with Object.entries/fromEntries

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/536bc146-9c84-42b1-8dc2-198d8fcef8aa" />
