### PR TITLE
fix: use correct type when validating EF header regex

### DIFF
--- a/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
+++ b/packages/edge-bundler/node/validation/manifest/__snapshots__/index.test.ts.snap
@@ -188,12 +188,12 @@ ENUM must be equal to one of the allowed values
 
 exports[`route headers > should throw on invalid pattern format 1`] = `
 [ManifestValidationError: Validation of Edge Functions manifest failed
-FORMAT must match format "regexPattern"
+TYPE must be string
 
   15 |         "x-custom-header": {
   16 |           "matcher": "regex",
-> 17 |           "pattern": "/^Bearer .+/"
-     |                      ^^^^^^^^^^^^^^ 👈🏽  format must match format "regexPattern"
+> 17 |           "pattern": {}
+     |                      ^^ 👈🏽  type must be string
   18 |         }
   19 |       }
   20 |     }]

--- a/packages/edge-bundler/node/validation/manifest/index.test.ts
+++ b/packages/edge-bundler/node/validation/manifest/index.test.ts
@@ -209,7 +209,7 @@ describe('route headers', () => {
     manifest.routes[0].headers = {
       'x-custom-header': {
         matcher: 'regex',
-        pattern: '^Bearer .+$',
+        pattern: 'Bearer .+',
       },
     }
 
@@ -254,7 +254,7 @@ describe('route headers', () => {
     manifest.routes[0].headers = {
       'x-custom-header': {
         matcher: 'regex',
-        pattern: '/^Bearer .+/',
+        pattern: /^Bearer .+/,
       },
     }
 

--- a/packages/edge-bundler/node/validation/manifest/schema.ts
+++ b/packages/edge-bundler/node/validation/manifest/schema.ts
@@ -27,7 +27,6 @@ const headersSchema = {
       properties: {
         pattern: {
           type: 'string',
-          format: 'regexPattern',
         },
         matcher: {
           type: 'string',


### PR DESCRIPTION
#### Summary

`regexPattern` is only when we want to receive a full URL path, which is not the case when matching edge function header values.