### PR TITLE
fix: use gzip compression for the tarball generation

### DIFF
--- a/packages/edge-bundler/node/formats/tarball.ts
+++ b/packages/edge-bundler/node/formats/tarball.ts
@@ -13,7 +13,7 @@ import { listRecursively } from '../utils/fs.js'
 import { ImportMap } from '../import_map.js'
 import { getFileHash } from '../utils/sha256.js'
 
-const TARBALL_EXTENSION = '.tar'
+const TARBALL_EXTENSION = '.tar.gz'
 
 interface Manifest {
   functions: Record<string, string>
@@ -111,6 +111,7 @@ export const bundle = async ({
     {
       cwd: bundleDir.path,
       file: tarballPath,
+      gzip: true,
       noDirRecurse: true,
       onWriteEntry(entry) {
         const relativePath = path.relative(bundleDir.path, path.join('/', entry.path))


### PR DESCRIPTION
#### Summary

We will start to use .tar.gz instead of .tar - smaller files for the win ☺️ (we can't yet use br or zstd for this unfortunately, only gzip is possible)