### PR TITLE
chore: replace conventional commit checker

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -1,0 +1,13 @@
+name: PR Title - Conventional Commit
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: npm install @commitlint/config-conventional
+      - uses: JulienKode/pull-request-name-linter-action@v19.0.0

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] }


### PR DESCRIPTION
##Summary

The bot we were using to do this PR title linting [is deprecated now](https://github.com/apps/conventional-commit-lint-gcf) so this is a replacement.