### PR TITLE
ci: work around npm 11 bug for now

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,10 @@ jobs:
           cache: 'npm'
           check-latest: true
 
+      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
+      - name: Setup npm version
+        run: npm install -g npm@10
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,6 +16,9 @@ jobs:
           node-version: '22'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
+      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
+      - name: Setup npm version
+        run: npm install -g npm@10
       - name: Extract tag, version and package
         id: extract
         run: |-

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           node-version: 22
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
+      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
+      - name: Setup npm version
+        run: npm install -g npm@10
+        if: ${{ !steps.release-check.outputs.IS_RELEASE && matrix.node-version == '22' }}
       - name: Install dependencies
         run: npm ci
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
@@ -78,6 +82,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
+      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
+      - name: Setup npm version
+        run: npm install -g npm@10
+        if: ${{ !steps.release-check.outputs.IS_RELEASE && matrix.node-version == '22' }}
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
@@ -159,10 +167,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
+      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
+      - name: Setup npm version
+        run: npm install -g npm@10
+        if: ${{ !steps.release-check.outputs.IS_RELEASE && matrix.node-version == '22' }}
       - name: corepack update
         # corepack version distributed with Node.js has a problem with new package manager releases,
         # so forcing fixed version of corepack here
         run: npm i -g corepack --force
+        if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: setup pnpm/yarn
         run: corepack enable
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>netlify/renovate-config:esm"],
-  "automerge": true,
-  "dependencyDashboard": true,
-  "ignorePresets": [":prHourlyLimit2"],
-  "ignorePaths": ["**/fixtures/**", "**/fixtures-esm/**", "**/node_modules/**"],
-  "semanticCommits": "enabled"
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,12 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['github>netlify/renovate-config:esm'],
+  automerge: true,
+  dependencyDashboard: true,
+  ignorePresets: [':prHourlyLimit2'],
+  ignorePaths: ['**/fixtures/**', '**/fixtures-esm/**', '**/node_modules/**'],
+  semanticCommits: 'enabled',
+  constraints: {
+    npm: '^10.0.0',
+  },
+}


### PR DESCRIPTION
#### Summary

Renovate keeps removing dependencies from our lockfile. It seems to be an issue with npm 11 (default in node 22+): https://github.com/npm/cli/issues/8489.

This pins to npm v10 for now.