### PR TITLE
feat: allow using .env files to get around 4 KB env size limits

### DIFF
--- a/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/utils/entry_file.ts
@@ -60,6 +60,7 @@ const getEntryFileContents = (
     return [
       `import * as bootstrap from './${BOOTSTRAP_FILE_NAME}'`,
       `import * as func from '${importPath}'`,
+      'try { const dotenv = await import("dotenv"); dotenv.config() } catch {}',
 
       // See https://esbuild.github.io/content-types/#default-interop.
       'const funcModule = typeof func.default === "function" ? func : func.default',


### PR DESCRIPTION
#### Summary

This could be one "quick" way we can solve the 4 KB ENV limit on AWS Lambda.

Some time ago, I wrote this plugin: https://github.com/hrishikesh-k/netlify-plugin-bundle-env that would allow users to include their build-time env into Functions. It kinda works, but has various shortcomings, while being very easy to break. Instead, I think a simpler and a more reliable solution would be to simply generate a `.env` file during a build and include it in the Function.

Next Runtime already does that, except the "reading" of the `.env` file is handled by Next.js itself, as far as I'm aware. I think other frameworks might also handle the reading themselves, but for other users, this would still come in handy. There have been several users who have run into this in the past as well as this was most recently experienced here: https://netlify.zendesk.com/agent/tickets/424746. Based on npm stats: https://www.npmjs.com/package/netlify-plugin-bundle-env, my package has 4k weekly downloads, so there's at least some demand to this.

What do you all think about this approach?

The reason `dotenv` is a dynamic import is because not everyone will have that package installed (or even need it). My plugin would handle adding the `dotenv` in the bundle, so whoever is using my plugin should be fine, but we don't want to break this for others.