### PR TITLE
fix: support post-nitro TanStack Start versions

### DIFF
--- a/packages/build-info/src/frameworks/tanstack-start.test.ts
+++ b/packages/build-info/src/frameworks/tanstack-start.test.ts
@@ -8,7 +8,7 @@ beforeEach((ctx) => {
   ctx.fs = new NodeFS()
 })
 
-test('detects a TanStack Start React site (v1.121.0+)', async ({ fs }) => {
+test('detects a TanStack Start React site (v1.132.0+)', async ({ fs }) => {
   const cwd = mockFileSystem({
     'package.json': JSON.stringify({
       scripts: {
@@ -19,9 +19,46 @@ test('detects a TanStack Start React site (v1.121.0+)', async ({ fs }) => {
         test: 'vitest run',
       },
       dependencies: {
-        '@tanstack/react-router': '^1.121.2',
-        '@tanstack/react-router-devtools': '^1.121.2',
-        '@tanstack/start': '^1.121.2',
+        '@tanstack/react-router': '^1.132.0',
+        '@tanstack/react-router-devtools': '^1.132.0',
+        '@tanstack/react-start': '^1.132.0',
+        react: '^19.0.0',
+        'react-dom': '^19.0.0',
+      },
+      devDependencies: {
+        '@vitejs/plugin-react': '^4.3.4',
+        vite: '^7.0.0',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('vinxi')
+  expect(detectedFrameworks).not.toContain('vite')
+  expect(detectedFrameworks).not.toContain('tanstack-router')
+
+  expect(detected?.[0]?.id).toBe('tanstack-start')
+  expect(detected?.[0]?.build?.command).toBe('vite build')
+  expect(detected?.[0]?.build?.directory).toBe('dist/client')
+  expect(detected?.[0]?.dev?.command).toBe('vite dev')
+  expect(detected?.[0]?.dev?.port).toBe(3000)
+})
+
+test('sets build dir to `dist` for a pre-v1.132.0 TanStack Start React site', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': JSON.stringify({
+      scripts: {
+        dev: 'vite --port 3000',
+        start: 'vite --port 3000',
+        build: 'vite build',
+        serve: 'vite preview',
+        test: 'vitest run',
+      },
+      dependencies: {
+        '@tanstack/react-router': '^1.131.0',
+        '@tanstack/react-router-devtools': '^1.131.0',
+        '@tanstack/react-start': '^1.131.0',
         react: '^19.0.0',
         'react-dom': '^19.0.0',
       },
@@ -45,7 +82,7 @@ test('detects a TanStack Start React site (v1.121.0+)', async ({ fs }) => {
   expect(detected?.[0]?.dev?.port).toBe(3000)
 })
 
-test('detects a pre-v1.121.0 TanStack Start React site', async ({ fs }) => {
+test('sets `vinxi` build/dev commands for a pre-v1.121.0 TanStack Start React site', async ({ fs }) => {
   const cwd = mockFileSystem({
     'package.json': JSON.stringify({
       scripts: {
@@ -79,7 +116,81 @@ test('detects a pre-v1.121.0 TanStack Start React site', async ({ fs }) => {
   expect(detected?.[0]?.dev?.port).toBe(3000)
 })
 
-test('detects a TanStack Start Solid site', async ({ fs }) => {
+test('detects a TanStack Start Solid site (v1.132.0+)', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': JSON.stringify({
+      scripts: {
+        dev: 'vite --port 3000',
+        start: 'vite --port 3000',
+        build: 'vite build',
+        serve: 'vite preview',
+        test: 'vitest run',
+      },
+      dependencies: {
+        '@tanstack/solid-router': '^1.132.0',
+        '@tanstack/solid-router-devtools': '^1.132.0',
+        '@tanstack/solid-start': '^1.132.0',
+        'solid-js': '^1.9.5',
+      },
+      devDependencies: {
+        '@vitejs/plugin-solid': '^4.3.4',
+        vite: '^7.0.0',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('vinxi')
+  expect(detectedFrameworks).not.toContain('vite')
+  expect(detectedFrameworks).not.toContain('tanstack-router')
+  expect(detectedFrameworks).not.toContain('solid-js')
+
+  expect(detected?.[0]?.id).toBe('tanstack-start')
+  expect(detected?.[0]?.build?.command).toBe('vite build')
+  expect(detected?.[0]?.build?.directory).toBe('dist/client')
+  expect(detected?.[0]?.dev?.command).toBe('vite dev')
+  expect(detected?.[0]?.dev?.port).toBe(3000)
+})
+
+test('sets build dir to `dist` for a pre-v1.132.0 TanStack Start Solid site', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': JSON.stringify({
+      scripts: {
+        dev: 'vite --port 3000',
+        start: 'vite --port 3000',
+        build: 'vite build',
+        serve: 'vite preview',
+        test: 'vitest run',
+      },
+      dependencies: {
+        '@tanstack/solid-router': '^1.131.0',
+        '@tanstack/solid-router-devtools': '^1.131.0',
+        '@tanstack/solid-start': '^1.131.0',
+        'solid-js': '^1.9.5',
+      },
+      devDependencies: {
+        '@vitejs/plugin-solid': '^4.3.4',
+        vite: '^6.1.0',
+      },
+    }),
+  })
+  const detected = await new Project(fs, cwd).detectFrameworks()
+
+  const detectedFrameworks = (detected ?? []).map((framework) => framework.id)
+  expect(detectedFrameworks).not.toContain('vinxi')
+  expect(detectedFrameworks).not.toContain('vite')
+  expect(detectedFrameworks).not.toContain('tanstack-router')
+  expect(detectedFrameworks).not.toContain('solid-js')
+
+  expect(detected?.[0]?.id).toBe('tanstack-start')
+  expect(detected?.[0]?.build?.command).toBe('vite build')
+  expect(detected?.[0]?.build?.directory).toBe('dist')
+  expect(detected?.[0]?.dev?.command).toBe('vite dev')
+  expect(detected?.[0]?.dev?.port).toBe(3000)
+})
+
+test('sets `vinxi` build/dev commands for a pre-v1.121.0 TanStack Start Solid site', async ({ fs }) => {
   const cwd = mockFileSystem({
     'package.json': JSON.stringify({
       scripts: {
@@ -113,7 +224,7 @@ test('detects a TanStack Start Solid site', async ({ fs }) => {
   expect(detected?.[0]?.dev?.port).toBe(3000)
 })
 
-test('detects a pre-v1.111.10 TanStack Start site', async ({ fs }) => {
+test('detects a pre-v1.111.10 (pre-package-rename) TanStack Start site', async ({ fs }) => {
   const cwd = mockFileSystem({
     'package.json': JSON.stringify({
       scripts: {

--- a/packages/build-info/src/frameworks/tanstack-start.ts
+++ b/packages/build-info/src/frameworks/tanstack-start.ts
@@ -21,7 +21,7 @@ export class TanStackStart extends BaseFramework implements Framework {
 
   build = {
     command: 'vite build',
-    directory: 'dist',
+    directory: 'dist/client',
   }
 
   logo = {
@@ -39,6 +39,13 @@ export class TanStackStart extends BaseFramework implements Framework {
         this.dev.command = 'vinxi dev'
         this.build.command = 'vinxi build'
       }
+
+      // TanStack Start changed build directory from 'dist' to 'dist/client' in v1.132.0
+      // XXX(serhalp) This is a made-up placeholder version! Replace when released.
+      if (this.version && lt(this.version, '1.132.0')) {
+        this.build.directory = 'dist'
+      }
+
       return this as DetectedFramework
     }
   }

--- a/packages/build-info/src/frameworks/tanstack-start.ts
+++ b/packages/build-info/src/frameworks/tanstack-start.ts
@@ -41,7 +41,6 @@ export class TanStackStart extends BaseFramework implements Framework {
       }
 
       // TanStack Start changed build directory from 'dist' to 'dist/client' in v1.132.0
-      // XXX(serhalp) This is a made-up placeholder version! Replace when released.
       if (this.version && lt(this.version, '1.132.0')) {
         this.build.directory = 'dist'
       }


### PR DESCRIPTION
#### Summary

The `alpha` branch of the TanStack Start React/Solid packages builds the client into `dist/client` (previously `dist`), so this updates the default Netlify publish dir to `dist/client` when detecting TanStack Start projects.

We don't yet know what version this will land in — I've used the next minor (1.132) as a placeholder for now.

This also adds a missing test for the Solid package and improves the test descriptions.