### PR TITLE
fix: don't pipe plugin output more than once at the time

### DIFF
--- a/packages/build/src/log/stream.ts
+++ b/packages/build/src/log/stream.ts
@@ -50,7 +50,11 @@ const pushBuildCommandOutput = function (output: string, logsArray: string[]) {
 const pipedPluginProcesses = new WeakMap<ChildProcess, ReturnType<typeof pipePluginOutput>>()
 
 // Start plugin step output
-export const pipePluginOutput = function (childProcess: ChildProcess, logs: Logs, standardStreams: StandardStreams) {
+export const pipePluginOutput = function (
+  childProcess: ChildProcess,
+  logs: Logs,
+  standardStreams: StandardStreams,
+): LogsListeners | undefined {
   if (pipedPluginProcesses.has(childProcess)) {
     return pipedPluginProcesses.get(childProcess)
   }
@@ -84,7 +88,7 @@ export const unpipePluginOutput = async function (
 }
 
 // Usually, we stream stdout/stderr because it is more efficient
-const streamOutput = function (childProcess: ChildProcess, standardStreams: StandardStreams) {
+const streamOutput = function (childProcess: ChildProcess, standardStreams: StandardStreams): undefined {
   childProcess.stdout?.pipe(standardStreams.stdout)
   childProcess.stderr?.pipe(standardStreams.stderr)
 }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

https://github.com/netlify/build/pull/5899 made output unpiping conditional, however we still are piping for every hook leading to duplicated logs like so:
```
onBuild called
onBuild called
onPostBuild called
onPostBuild called
onPostBuild called
onSuccess called
onSuccess called
onSuccess called
onSuccess called
onEnd called
onEnd called
onEnd called
onEnd called
onEnd called
```
with number of repetitions increasing by one with each hook.

This attempts to ensure we don't have multiple active pipes, by return early if process was piped before without being unpiped

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
