### PR TITLE
fix: revert "fix: don't pipe plugin output more than once at the time (#6765)"

### DIFF
--- a/packages/build/src/log/stream.ts
+++ b/packages/build/src/log/stream.ts
@@ -47,25 +47,13 @@ const pushBuildCommandOutput = function (output: string, logsArray: string[]) {
   logsArray.push(output)
 }
 
-const pipedPluginProcesses = new WeakMap<ChildProcess, ReturnType<typeof pipePluginOutput>>()
-
 // Start plugin step output
-export const pipePluginOutput = function (
-  childProcess: ChildProcess,
-  logs: Logs,
-  standardStreams: StandardStreams,
-): LogsListeners | undefined {
-  if (pipedPluginProcesses.has(childProcess)) {
-    return pipedPluginProcesses.get(childProcess)
+export const pipePluginOutput = function (childProcess: ChildProcess, logs: Logs, standardStreams: StandardStreams) {
+  if (!logsAreBuffered(logs)) {
+    return streamOutput(childProcess, standardStreams)
   }
 
-  const listeners = !logsAreBuffered(logs)
-    ? streamOutput(childProcess, standardStreams)
-    : pushOutputToLogs(childProcess, logs, standardStreams.outputFlusher)
-
-  pipedPluginProcesses.set(childProcess, listeners)
-
-  return listeners
+  return pushOutputToLogs(childProcess, logs, standardStreams.outputFlusher)
 }
 
 // Stop streaming/buffering plugin step output
@@ -83,12 +71,10 @@ export const unpipePluginOutput = async function (
   }
 
   unpushOutputToLogs(childProcess, listeners.stdoutListener, listeners.stderrListener)
-
-  pipedPluginProcesses.delete(childProcess)
 }
 
 // Usually, we stream stdout/stderr because it is more efficient
-const streamOutput = function (childProcess: ChildProcess, standardStreams: StandardStreams): undefined {
+const streamOutput = function (childProcess: ChildProcess, standardStreams: StandardStreams) {
   childProcess.stdout?.pipe(standardStreams.stdout)
   childProcess.stderr?.pipe(standardStreams.stderr)
 }


### PR DESCRIPTION
This reverts commit 08dad8dad97d4748b4f83f2027181fa5b6456f80.

It's likely this cause regression - see https://netlify.slack.com/archives/C01TKAEBP3Q/p1762448974497299

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
