### PR TITLE
fix: centralize build plugin auto-enable escape hatches

### DIFF
--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -31,7 +31,7 @@ export class Angular extends BaseFramework implements Framework {
     await super.detect()
 
     if (this.detected) {
-      if (this.version && gte(this.version, '17.0.0-rc')) {
+      if (this.version && gte(this.version, '17.0.0-rc') && !process.env.NETLIFY_ANGULAR_PLUGIN_SKIP) {
         this.plugins.push('@netlify/angular-runtime')
         const angularJson = await this.project.fs.gracefullyReadFile('angular.json')
         if (angularJson) {

--- a/packages/build-info/src/frameworks/gatsby.ts
+++ b/packages/build-info/src/frameworks/gatsby.ts
@@ -44,7 +44,7 @@ export class Gatsby extends BaseFramework implements Framework {
       }
 
       const nodeVersion = await this.project.getCurrentNodeVersion()
-      if (nodeVersion && gte(nodeVersion, '12.13.0')) {
+      if (nodeVersion && gte(nodeVersion, '12.13.0') && !process.env.NETLIFY_SKIP_GATSBY_BUILD_PLUGIN) {
         this.plugins.push('@netlify/plugin-gatsby')
       }
       return this as DetectedFramework

--- a/packages/build-info/src/frameworks/next.test.ts
+++ b/packages/build-info/src/frameworks/next.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 
-import { beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { createFixture } from '../../tests/helpers.js'
 import { mockFileSystem } from '../../tests/mock-file-system.js'
@@ -34,6 +34,10 @@ describe('Next.js Plugin', () => {
     })
   })
 
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test('Should detect Next.js plugin for Next.js if when Node version >= 10.13.0', async ({ fs, cwd }) => {
     const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
     const frameworks = await project.detectFrameworks()
@@ -43,6 +47,14 @@ describe('Next.js Plugin', () => {
 
   test('Should not detect Next.js plugin for Next.js if when Node version < 10.13.0', async ({ fs, cwd }) => {
     const project = new Project(fs, cwd).setNodeVersion('v8.3.1')
+    const frameworks = await project.detectFrameworks()
+    expect(frameworks?.[0].id).toBe('next')
+    expect(frameworks?.[0].plugins).toHaveLength(0)
+  })
+
+  test('Should not install plugin when NETLIFY_NEXT_PLUGIN_SKIP is set', async ({ fs, cwd }) => {
+    const project = new Project(fs, cwd).setNodeVersion('v10.13.0')
+    vi.stubEnv('NETLIFY_NEXT_PLUGIN_SKIP', 'true')
     const frameworks = await project.detectFrameworks()
     expect(frameworks?.[0].id).toBe('next')
     expect(frameworks?.[0].plugins).toHaveLength(0)

--- a/packages/build-info/src/frameworks/next.ts
+++ b/packages/build-info/src/frameworks/next.ts
@@ -32,7 +32,7 @@ export class Next extends BaseFramework implements Framework {
 
     if (this.detected) {
       const nodeVersion = await this.project.getCurrentNodeVersion()
-      if (nodeVersion && gte(nodeVersion, '10.13.0')) {
+      if (nodeVersion && gte(nodeVersion, '10.13.0') && !process.env.NETLIFY_NEXT_PLUGIN_SKIP) {
         this.plugins.push('@netlify/plugin-nextjs')
       }
       return this as DetectedFramework


### PR DESCRIPTION
#### Summary

Fixes FRB-2046
Centralize plugin escape hatches for next, angular, and gatsby
Allow users to disable auto-detection at the build level for these three frameworks

- `NETLIFY_ANGULAR_PLUGIN_SKIP` is a new addition
- `NETLIFY_SKIP_GATSBY_BUILD_PLUGIN` is from https://github.com/netlify/netlify-plugin-gatsby
- `NETLIFY_NEXT_PLUGIN_SKIP` is from https://github.com/opennextjs/opennextjs-netlify

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
