### PR TITLE
fix: pass skew protection token down to config

### DIFF
--- a/packages/build/src/core/build.ts
+++ b/packages/build/src/core/build.ts
@@ -86,6 +86,7 @@ const tExecBuild = async function ({
   enhancedSecretScan,
   edgeFunctionsBootstrapURL,
   eventHandlers,
+  skewProtectionToken,
 }) {
   const configOpts = getConfigOpts({
     config,
@@ -107,6 +108,7 @@ const tExecBuild = async function ({
     buildId,
     testOpts,
     featureFlags,
+    skewProtectionToken,
   })
 
   const {

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -37,6 +37,7 @@ export const getConfigOpts = function ({
   buildId,
   testOpts,
   featureFlags,
+  skewProtectionToken,
 }) {
   return {
     config,
@@ -58,6 +59,7 @@ export const getConfigOpts = function ({
     env: envOpt,
     testOpts,
     featureFlags,
+    skewProtectionToken,
   }
 }
 

--- a/packages/build/src/log/messages/config.js
+++ b/packages/build/src/log/messages/config.js
@@ -60,6 +60,7 @@ const INTERNAL_FLAGS = [
   'edgeFunctionsBootstrapURL',
   'eventHandlers',
   'logger',
+  'skewProtectionToken',
 ]
 const HIDDEN_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, ...INTERNAL_FLAGS]
 const HIDDEN_DEBUG_FLAGS = [...SECURE_FLAGS, ...TEST_FLAGS, 'eventHandlers', 'logger']

--- a/packages/build/tests/core/fixtures/plugin_echo_env/manifest.yml
+++ b/packages/build/tests/core/fixtures/plugin_echo_env/manifest.yml
@@ -1,0 +1,2 @@
+name: test
+inputs: []

--- a/packages/build/tests/core/fixtures/plugin_echo_env/netlify.toml
+++ b/packages/build/tests/core/fixtures/plugin_echo_env/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "./plugin.js"

--- a/packages/build/tests/core/fixtures/plugin_echo_env/plugin.js
+++ b/packages/build/tests/core/fixtures/plugin_echo_env/plugin.js
@@ -1,0 +1,3 @@
+export const onPreBuild = function () {
+  console.log(JSON.stringify(process.env))
+}

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -356,6 +356,14 @@ test('--node-path is not used by core plugins', async (t) => {
   t.snapshot(normalizeOutput(output))
 })
 
+test('--skew-protection-token', async (t) => {
+  const output = await new Fixture('./fixtures/plugin_echo_env')
+    .withFlags({ skewProtectionToken: 'foobar' })
+    .runWithBuild()
+
+  t.true(output.includes(`"NETLIFY_SKEW_PROTECTION_TOKEN":"foobar"`))
+})
+
 test('featureFlags can be used programmatically', async (t) => {
   const output = await new Fixture('./fixtures/empty')
     .withFlags({ featureFlags: { test: true, testTwo: false } })


### PR DESCRIPTION
Follow-up to #6792. The token was not being property wired down to the config.