### PR TITLE
fix(deps): upgrade to `@vercel/nft` v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1488,6 +1488,27 @@
         "@types/node": ">=18"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5808,9 +5829,9 @@
       }
     },
     "node_modules/@vercel/nft": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.30.4.tgz",
-      "integrity": "sha512-wE6eAGSXScra60N2l6jWvNtVK0m+sh873CpfZW4KI2v8EHuUQp+mSEi4T+IcdPCSEDgCdAS/7bizbhQlkjzrSA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.1.1.tgz",
+      "integrity": "sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==",
       "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^2.0.0",
@@ -5820,7 +5841,7 @@
         "async-sema": "^3.1.1",
         "bindings": "^1.4.0",
         "estree-walker": "2.0.2",
-        "glob": "^10.5.0",
+        "glob": "^13.0.0",
         "graceful-fs": "^4.2.9",
         "node-gyp-build": "^4.2.2",
         "picomatch": "^4.0.2",
@@ -5830,24 +5851,45 @@
         "nft": "out/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@vercel/nft/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "license": "ISC",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "path-scurry": "^2.0.0"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5860,6 +5902,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -25481,7 +25539,7 @@
         "@babel/types": "7.28.5",
         "@netlify/binary-info": "^1.0.0",
         "@netlify/serverless-functions-api": "^2.8.0",
-        "@vercel/nft": "0.30.4",
+        "@vercel/nft": "^1.1.1",
         "archiver": "^7.0.0",
         "common-path-prefix": "^3.0.0",
         "copy-file": "^11.0.0",

--- a/packages/zip-it-and-ship-it/package.json
+++ b/packages/zip-it-and-ship-it/package.json
@@ -45,7 +45,7 @@
     "@babel/types": "7.28.5",
     "@netlify/binary-info": "^1.0.0",
     "@netlify/serverless-functions-api": "^2.8.0",
-    "@vercel/nft": "0.30.4",
+    "@vercel/nft": "^1.1.1",
     "archiver": "^7.0.0",
     "common-path-prefix": "^3.0.0",
     "copy-file": "^11.0.0",


### PR DESCRIPTION
## Description

We had [previously pinned to 0.29.4](https://github.com/netlify/build/pull/6610) because [0.30 introduced a bug](https://answers.netlify.com/t/react-router-app-crashing-because-it-cant-find-package/155391).

This bug was fixed in https://github.com/vercel/nft/pull/550, released in 1.1.0.

I've confirmed this:

1. Clone https://github.com/netlify/react-router-template/
2. `npm i`
4. ✅ `rm -rf .netlify/ && npx -y netlify@latest deploy --skip-functions-cache`
5. ✅ `rm -rf .netlify/ && npx -y netlify@23.0.0 deploy --skip-functions-cache`
6. ✅ `rm -rf .netlify/ && npx -y netlify@23.1.3 deploy --skip-functions-cache`
7. ❌ `rm -rf .netlify/ && npx -y netlify@23.1.2 deploy --skip-functions-cache`
8. Clone this branch, `npm i && npm run build`. Clone netlify-cli, `npm link ../build/packages/zip-it-and-ship-it`.
9. ✅ `rm -rf .netlify/ && ../cli/bin/run.js deploy --skip-functions-cache`

---

This upgrade is worthwhile because it:
- removes 28 transitive dependencies and ~1 MB from the install size
- resolves 6 security vulnerability warnings (3 moderate, 3 high)