### PR TITLE
feat: introduce new FrameworkId type

### DIFF
--- a/packages/build-info/src/frameworks/framework.ts
+++ b/packages/build-info/src/frameworks/framework.ts
@@ -5,6 +5,61 @@ import { Environment } from '../file-system.js'
 import { getBuildCommands, getDevCommands } from '../get-commands.js'
 import { Project } from '../project.js'
 
+export type FrameworkId =
+  | 'analog'
+  | 'angular'
+  | 'assemble'
+  | 'astro'
+  | 'blitz'
+  | 'brunch'
+  | 'cecil'
+  | 'create-react-app'
+  | 'docpad'
+  | 'docusaurus'
+  | 'eleventy'
+  | 'ember'
+  | 'expo'
+  | 'gatsby'
+  | 'gridsome'
+  | 'grunt'
+  | 'gulp'
+  | 'harp'
+  | 'hexo'
+  | 'hono'
+  | 'hugo'
+  | 'hydrogen'
+  | 'jekyll'
+  | 'metalsmith'
+  | 'middleman'
+  | 'next'
+  | 'nuxt'
+  | 'observable'
+  | 'parcel'
+  | 'phenomic'
+  | 'quasar'
+  | 'qwik'
+  | 'react-router'
+  | 'react-static'
+  | 'redwoodjs'
+  | 'remix'
+  | 'roots'
+  | 'sapper'
+  | 'solid-js'
+  | 'solid-start'
+  | 'stencil'
+  | 'svelte'
+  | 'svelte-kit'
+  | 'tanstack-router'
+  | 'tanstack-start'
+  | 'vike'
+  | 'vite'
+  | 'vue'
+  | 'vuepress'
+  | 'waku'
+  | 'wintersmith'
+  | 'wmr'
+  | 'zola'
+
 export enum Category {
   BackendFramework = 'backend_framework',
   FrontendFramework = 'frontend_framework',
@@ -56,7 +111,7 @@ export type FrameworkInfo = ReturnType<Framework['toJSON']>
 export interface Framework {
   project: Project
 
-  id: string
+  id: FrameworkId
   name: string
   category: Category
   /**
@@ -178,7 +233,7 @@ export function mergeDetections(detections: (Detection | undefined)[]): Detectio
 }
 
 export abstract class BaseFramework implements Framework {
-  id: string
+  id: FrameworkId
   name: string
   category: Category
   detected?: Detection

--- a/packages/build-info/src/frameworks/index.ts
+++ b/packages/build-info/src/frameworks/index.ts
@@ -10,6 +10,7 @@ import { Docusaurus } from './docusaurus.js'
 import { Eleventy } from './eleventy.js'
 import { Ember } from './ember.js'
 import { Expo } from './expo.js'
+import { FrameworkId } from './framework.js'
 import { Gatsby } from './gatsby.js'
 import { Gridsome } from './gridsome.js'
 import { Grunt } from './grunt.js'
@@ -115,7 +116,6 @@ export const frameworks = [
   WMR,
 ]
 
-type Frameworks = typeof frameworks
-// To get a list of the names it's required that ALL Frameworks have the id property as `readonly`
-export type FrameworkName = InstanceType<Frameworks[number]>['id']
+// TODO: see if the FrameworkName type can be removed
+export type FrameworkName = FrameworkId
 export type { FrameworkInfo, PollingStrategy } from './framework.js'

--- a/packages/build-info/src/index.ts
+++ b/packages/build-info/src/index.ts
@@ -5,6 +5,7 @@ export type {
   DetectedFramework,
   FrameworkInfo,
   PollingStrategy,
+  FrameworkId,
   VersionAccuracy,
 } from './frameworks/framework.js'
 export * from './get-framework.js'

--- a/packages/build-info/src/settings/get-build-settings.ts
+++ b/packages/build-info/src/settings/get-build-settings.ts
@@ -1,4 +1,4 @@
-import { type Framework } from '../frameworks/framework.js'
+import { FrameworkId, type Framework } from '../frameworks/framework.js'
 import { type Project } from '../project.js'
 
 export type Settings = {
@@ -12,7 +12,7 @@ export type Settings = {
   frameworkPort?: number
   /** the detected framework */
   framework: {
-    id: string
+    id: FrameworkId
     name: string
   }
   buildSystem?: {


### PR DESCRIPTION
#### Summary

It's pretty minor, but as a consumer of the build-info library I think it would be pretty nice if the id of frameworks could be an actual union of the known ids instead of `string` (this would help writing more type-safe code and also be more convenient for intellisense and autocompletion), so I figured I could try to open a PR to propose just that and see what y'all think 🙂.

The downside here is that when someone adds (or removes) a new framework they also need to update the `FrameworkId` union type as well, this seems pretty ok as a tradeoff to me for better type safety but up to you 🙂  (again this change is not super essential, but definitely something I'd like to take advantage of when using the library 😄)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
