### PR TITLE
fix(edge-bundler): include tarball in bundles when dry-run succeeds

### DIFF
--- a/packages/edge-bundler/node/bundler.test.ts
+++ b/packages/edge-bundler/node/bundler.test.ts
@@ -856,7 +856,7 @@ describe.skipIf(lt(denoVersion, '2.4.3'))(
     })
 
     describe('Dry-run tarball generation flag enabled', () => {
-      test('Logs success message when tarball generation succeeded', async () => {
+      test('Includes tarball in bundles when generation succeeds', async () => {
         const systemLogger = vi.fn()
         const { basePath, cleanup, distPath } = await useFixture('imports_node_builtin', { copyDirectory: true })
         const declarations: Declaration[] = [
@@ -882,8 +882,14 @@ describe.skipIf(lt(denoVersion, '2.4.3'))(
         const manifest = JSON.parse(manifestFile)
 
         expect(manifest.bundling_timing).toEqual({ tarball_ms: expect.any(Number) })
-        expect(manifest.bundles.length).toBe(1)
-        expect(manifest.bundles[0].format).toBe('eszip2')
+        expect(manifest.bundles.length).toBe(2)
+        expect(manifest.bundles[0].format).toBe('tarball')
+        expect(manifest.bundles[1].format).toBe('eszip2')
+
+        // Verify the tarball is functional
+        const tarballPath = join(distPath, manifest.bundles[0].asset)
+        const tarballResult = await runTarball(tarballPath)
+        expect(tarballResult).toStrictEqual({ func1: 'ok' })
 
         await cleanup()
       })

--- a/packages/edge-bundler/node/bundler.ts
+++ b/packages/edge-bundler/node/bundler.ts
@@ -151,10 +151,13 @@ export const bundle = async (
       }
     })()
 
+    let tarballPromiseResolved = false
+
     if (featureFlags.edge_bundler_dry_run_generate_tarball) {
       try {
         await tarballPromise
         logger.system('Dry run: Tarball bundle generated successfully.')
+        tarballPromiseResolved = true
       } catch (error: unknown) {
         if (error instanceof Error) {
           logger.system(`Dry run: Tarball bundle generation failed: ${error.message}`)
@@ -164,7 +167,7 @@ export const bundle = async (
       }
     }
 
-    if (featureFlags.edge_bundler_generate_tarball) {
+    if (featureFlags.edge_bundler_generate_tarball || tarballPromiseResolved) {
       bundles.push(await tarballPromise)
     }
   }


### PR DESCRIPTION
#### Summary

Previously, dry-run mode would generate the tarball and log the result but always discard it. Now, if the tarball generates successfully during dry-run, it is included in the bundles.