### PR TITLE
fix(edge-bundler): rewrite bare specifier imports to resolved URLs in tarball bundles

### DIFF
--- a/packages/edge-bundler/test/fixtures/bare_specifier_import/functions/func1.ts
+++ b/packages/edge-bundler/test/fixtures/bare_specifier_import/functions/func1.ts
@@ -1,0 +1,8 @@
+import { encode as base64Encode } from "my-encoding"
+
+export default async () => {
+  const encoded = base64Encode("Netlify Edge Functions")
+  return new Response(encoded)
+}
+
+export const config = { path: '/func1' }

--- a/packages/edge-bundler/test/fixtures/bare_specifier_import/import_map.json
+++ b/packages/edge-bundler/test/fixtures/bare_specifier_import/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "my-encoding": "https://deno.land/std@0.194.0/encoding/base64.ts"
+  }
+}


### PR DESCRIPTION
At runtime, Deno discovers config from /platform/deno.json (the bootstrap entry point), not /function/deno.json, so customer import maps are unreachable. Bare specifiers like "lodash" are rewritten to their resolved URLs from the import map at build time, allowing --vendor to resolve them from the local vendor directory without needing the import map at runtime.
