### PR TITLE
fix(build): remove `builds` scope from deploy env vars

### DIFF
--- a/packages/build/src/plugins/child/utils.ts
+++ b/packages/build/src/plugins/child/utils.ts
@@ -63,7 +63,7 @@ const getDeployUtils = ({ deployEnvVars }: { deployEnvVars: DeployEnvVarsData })
         normalizedScopes = new Set(
           // If the user did not specify scopes, we assume they mean all valid scopes. Secrets are
           // not permitted in the post-processing scope.
-          isSecret ? ['builds', 'functions', 'runtime'] : ['builds', 'functions', 'post_processing', 'runtime'],
+          isSecret ? ['functions', 'runtime'] : ['functions', 'post_processing', 'runtime'],
         )
       }
       if (isSecret && normalizedScopes.has('post_processing')) {

--- a/packages/build/src/types/options/netlify_plugin_deploy_util.ts
+++ b/packages/build/src/types/options/netlify_plugin_deploy_util.ts
@@ -2,7 +2,7 @@ export interface NetlifyPluginDeployUtilEnv {
   add(
     key: string,
     value: string,
-    options?: { isSecret?: boolean; scopes?: ('builds' | 'functions' | 'post_processing' | 'runtime')[] },
+    options?: { isSecret?: boolean; scopes?: ('functions' | 'post_processing' | 'runtime')[] },
   ): this
 }
 

--- a/packages/build/tests/deploy/tests.js
+++ b/packages/build/tests/deploy/tests.js
@@ -147,19 +147,19 @@ test('Deploy plugin specifies deploy-specific variables in deploy event', async 
       is_secret: false,
       key: 'DATABASE_URI',
       value: '',
-      scopes: ['builds', 'functions', 'post_processing', 'runtime'],
+      scopes: ['functions', 'post_processing', 'runtime'],
     },
     {
       is_secret: true,
       key: 'DATABASE_PASSWORD',
       value: 'collision',
-      scopes: ['builds', 'functions', 'runtime'],
+      scopes: ['functions', 'runtime'],
     },
     {
       is_secret: false,
       key: 'DATABASE_MOOD',
       value: 'feisty',
-      scopes: ['builds', 'functions', 'post_processing', 'runtime'],
+      scopes: ['functions', 'post_processing', 'runtime'],
     },
   ])
 })


### PR DESCRIPTION
I realized this scope doesn't make any sense to accept as part of deploy
environment variables: These variables are _generated_ by the build.
