### PR TITLE
fix: do not rewrite bare specifiers during tarball bundling

### DIFF
--- a/packages/edge-bundler/node/bundler.test.ts
+++ b/packages/edge-bundler/node/bundler.test.ts
@@ -864,9 +864,8 @@ describe.skipIf(lt(denoVersion, '2.4.3'))(
 
       const sourceContent = await readFile(join(tmpDir.path, funcPath), 'utf8')
 
-      // Bare specifier "parent-1" should be rewritten to a relative path to the vendored file
-      expect(sourceContent).not.toContain("from 'parent-1'")
-      expect(sourceContent).toMatch(/from ['"]\.\.?\/.*\.netlify-npm-vendor.*bundled-parent-1\.js['"]/)
+      // Bare specifier "parent-1" should not be rewritten to a relative path
+      expect(sourceContent).toContain("from 'parent-1'")
 
       await tmpDir.cleanup()
 
@@ -967,9 +966,8 @@ describe.skipIf(lt(denoVersion, '2.4.3'))(
 
       const sourceContent = await readFile(join(tmpDir.path, 'func1.ts'), 'utf8')
 
-      // The bare specifier "my-encoding" should be rewritten to the resolved URL
-      expect(sourceContent).toContain('from "https://deno.land/std@0.194.0/encoding/base64.ts"')
-      expect(sourceContent).not.toContain('from "my-encoding"')
+      // The bare specifier "my-encoding" should NOT be rewritten to the resolved URL
+      expect(sourceContent).toContain('from "my-encoding"')
 
       // The tarball should still execute correctly
       const tarballResult = await runTarball(tarballPath)


### PR DESCRIPTION
#### Summary

Now that we are using a different snapshotting strategy, we no longer need to rewrite bare specifiers
Removing the relevant code and updating the tests

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
