### PR TITLE
chore(deps): bump @netlify/open-api from 2.50.0 to 2.51.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2407,9 +2407,9 @@
       "link": true
     },
     "node_modules/@netlify/open-api": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.50.0.tgz",
-      "integrity": "sha512-nvtP3GQqAg2fDCzZIz/PNIjgdQcbKRqJlRRQquRfBTP3DJi4254fMApWvBoj6+v07eowy2/t9xXHu+KRPw6iKw==",
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.51.0.tgz",
+      "integrity": "sha512-pnGsLklHMfx8BKbWsiK8ZZ7h+vfE8Xh5ox0Lq2n0UMJUZL+iLMqXDw4tc3Udp9JxmyC06xBE6yYkOTI82VV0aA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.8.0"
@@ -25258,7 +25258,7 @@
       "version": "14.0.17",
       "license": "MIT",
       "dependencies": {
-        "@netlify/open-api": "^2.50.0",
+        "@netlify/open-api": "^2.51.0",
         "node-fetch": "^3.0.0",
         "p-wait-for": "^5.0.0",
         "picoquery": "^2.5.0"

--- a/packages/js-client/package.json
+++ b/packages/js-client/package.json
@@ -41,7 +41,7 @@
     "node client"
   ],
   "dependencies": {
-    "@netlify/open-api": "^2.50.0",
+    "@netlify/open-api": "^2.51.0",
     "node-fetch": "^3.0.0",
     "picoquery": "^2.5.0",
     "p-wait-for": "^5.0.0"


### PR DESCRIPTION
## Summary
- Bumps `@netlify/open-api` from 2.50.0 to 2.51.0 in `packages/js-client`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)