### PR TITLE
feat: allow any numeric prefix on migration files

### DIFF
--- a/packages/build/src/plugins_core/db_setup/validation.test.ts
+++ b/packages/build/src/plugins_core/db_setup/validation.test.ts
@@ -10,6 +10,10 @@ describe('MIGRATION_DIR_PATTERN', () => {
     '9999999999_z',
     '1700000000_a',
     '1700000000_abc-def-123',
+    '001_create-users',
+    '1_init',
+    '0001_add-posts',
+    '42_z',
   ]
 
   test.each(validNames)('matches valid name: %s', (name) => {
@@ -17,14 +21,12 @@ describe('MIGRATION_DIR_PATTERN', () => {
   })
 
   const invalidNames = [
-    { name: '170000000_short-ts', reason: '9-digit timestamp' },
-    { name: '17000000000_long-ts', reason: '11-digit timestamp' },
     { name: '1700000000_CAPS', reason: 'uppercase letters' },
     { name: '1700000000_under_score', reason: 'underscores in slug' },
-    { name: 'no-timestamp', reason: 'no timestamp prefix' },
+    { name: 'no-timestamp', reason: 'no numeric prefix' },
     { name: '1700000000_', reason: 'empty slug' },
     { name: '1700000000', reason: 'missing underscore and slug' },
-    { name: '_create-users', reason: 'missing timestamp' },
+    { name: '_create-users', reason: 'missing number prefix' },
     { name: '1700000000_hello world', reason: 'spaces in slug' },
     { name: '1700000000_special!char', reason: 'special characters in slug' },
   ]
@@ -101,7 +103,7 @@ describe('formatValidationErrors', () => {
 
     expect(message).toContain('Database migration validation failed')
     expect(message).toContain('"bad-name"')
-    expect(message).toContain('<Unix-timestamp>_<slug>')
+    expect(message).toContain('<number>_<slug>')
   })
 
   test('formats missing_sql_file errors', () => {

--- a/packages/build/src/plugins_core/db_setup/validation.ts
+++ b/packages/build/src/plugins_core/db_setup/validation.ts
@@ -1,4 +1,4 @@
-export const MIGRATION_DIR_PATTERN = /^\d{10}_[a-z0-9-]+$/
+export const MIGRATION_DIR_PATTERN = /^\d+_[a-z0-9-]+$/
 
 interface ValidationError {
   type: 'invalid_dir_name' | 'missing_sql_file'
@@ -43,7 +43,7 @@ export const validateMigrationDirs = (
 export const formatValidationErrors = (errors: ValidationError[]): string => {
   const lines = errors.map((error) => {
     if (error.type === 'invalid_dir_name') {
-      return `  - "${error.dirName}" does not match the required pattern "<Unix-timestamp>_<slug>" (e.g. "1700000000_create-users"). Slugs must be lowercase alphanumeric with hyphens.`
+      return `  - "${error.dirName}" does not match the required pattern "<number>_<slug>" (e.g. "1700000000_create-users" or "001_create-users"). Slugs must be lowercase alphanumeric with hyphens.`
     }
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (error.type === 'missing_sql_file') {


### PR DESCRIPTION
#### Summary

We've changed the initial decision of using timestamps, and now can use any numerical prefix.