### PR TITLE
fix: ignore deno.json config when producing module graph for tarball bundle

### DIFF
--- a/packages/edge-bundler/node/formats/tarball.ts
+++ b/packages/edge-bundler/node/formats/tarball.ts
@@ -212,6 +212,7 @@ async function getRequiredSourceFiles(
       const { stdout } = await deno.run([
         'info',
         '--json',
+        '--no-config',
         '--import-map',
         importMapDataUrl,
         pathToFileURL(entryPoint).href,


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

We don't use potential `deno.json` configs when producing eszips - https://github.com/netlify/build/blob/ef0c60a227cf51312ce9ecc6bf243d02fcfa4e0e/packages/edge-bundler/node/formats/eszip.ts#L61

So let's not use it when producing tarballs as well.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
