### PR TITLE
fix(build): more reliably ignore node_modules in secret scanner

### DIFF
--- a/packages/build/src/plugins_core/secrets_scanning/utils.ts
+++ b/packages/build/src/plugins_core/secrets_scanning/utils.ts
@@ -1,6 +1,7 @@
-import { createReadStream, promises as fs, existsSync } from 'node:fs'
+import { createReadStream } from 'node:fs'
 import path from 'node:path'
 
+import { execa, execaSync } from 'execa'
 import { fdir } from 'fdir'
 import { minimatch } from 'minimatch'
 
@@ -238,26 +239,32 @@ export function findLikelySecrets({
 export async function getFilePathsToScan({ env, base }): Promise<string[]> {
   const omitPathsAlways = ['.git/', '.cache/']
 
-  // node modules is dense and is only useful to scan if the repo itself commits these
-  // files. As a simple check to understand if the repo would commit these files, we expect
-  // that they would not ignore them from their git settings. So if gitignore includes
-  // node_modules anywhere we will omit looking in those folders - this will allow repos
-  // that do commit node_modules to still scan them.
-  let ignoreNodeModules = false
-
-  const gitignorePath = path.resolve(base, '.gitignore')
-  const gitignoreContents = existsSync(gitignorePath) ? await fs.readFile(gitignorePath, 'utf-8') : ''
-
-  if (gitignoreContents?.includes('node_modules')) {
-    ignoreNodeModules = true
-  }
-
+  const isInGitWorktree = (await execa('git', ['rev-parse', '--show-toplevel'], { reject: false })).exitCode === 0
   let files = await new fdir()
     .withRelativePaths()
-    .filter((path) => {
-      if (ignoreNodeModules && path.includes('node_modules')) {
-        return false
+    .filter((filepath) => {
+      if (path.basename(filepath) === 'node_modules') {
+        if (!isInGitWorktree) {
+          // When we're not in a git worktree (e.g. triggered by Drop, SWAR), users don't
+          // intentionally commit `node_modules` directories. There's little to no value to scanning
+          // third-party modules and we might pick up secrets that the user doesn't have a way to
+          // resolve.
+          //
+          // XXX(ndhoule): This isn't technically true, though, is it? Couldn't someone include a
+          // (smaller, to get around filesize limits) node_modules directory in their upload?
+          return false
+        }
+
+        // The user may intentionally commit their `node_modules`, in which case we assume they may
+        // be vendoring their own internal modules and scanning them may be valuable.
+        //
+        // git check-ignore returns 0 when the file is referenced by any .gitignore up to the root
+        // of the worktree, and 1 otherwise.
+        if (execaSync('git', ['check-ignore', filepath], { reject: false }).exitCode === 0) {
+          return false
+        }
       }
+
       return true
     })
     .crawl(base)


### PR DESCRIPTION
If there's no `.gitignore` present or if `base` resolves to a path that isn't the root of the project, we'll scan `node_modules` for secrets. Looking at the notes on the current implementation, I think the intention here is really to only scan `node_modules` directories that are vendored into the repository by the user.

This change updates the scanner to only scan `node_modules` only if we're positive that that the user has vendored their `node_modules` directory (or director_ies_, I guess).

Other little problems I noticed with the current implementation that this fixes:

- We currently ignore any path that has `node_modules` in its name, even if it's just a substring or if it's not a directory
- We ignore `node_modules` if the substring `node_modules` is found in the user's `.gitignore`, even if it's a substring or targets a different `node_modules`
- We ignore nested `.gitignore` files, so we may be matching against an incomplete `.gitignore` list
- If `base` does not resolve to the repository root, we won't locate a `.gitignore`. (I don't know if this is actually happening currently--I'd need to confirm with a repro.)