### PR TITLE
fix: cleanup migration dist files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ packages/*/lib/
 !**/fixtures/**/functions_*/.netlify
 !**/fixtures/**/functions_*/.netlify/edge-functions/manifest.json
 !**/fixtures/**/monorepo/**/.netlify
+**/fixtures/**/monorepo/**/.netlify/internal/db/migrations
 **/plugins/deno-cli
 !**/fixtures-esm/v2-api-files-and-directories/.netlify
 

--- a/packages/build/src/plugins_core/pre_cleanup/index.ts
+++ b/packages/build/src/plugins_core/pre_cleanup/index.ts
@@ -5,8 +5,12 @@ import { getBlobsDirs } from '../../utils/blobs.js'
 import { FRAMEWORKS_API_PATH } from '../../utils/frameworks_api.js'
 import { CoreStep, CoreStepFunction } from '../types.js'
 
-const coreStep: CoreStepFunction = async ({ buildDir, packagePath }) => {
-  const paths = [...getBlobsDirs(buildDir, packagePath), resolve(buildDir, packagePath || '', FRAMEWORKS_API_PATH)]
+const coreStep: CoreStepFunction = async ({ buildDir, constants, packagePath }) => {
+  const paths = [
+    ...getBlobsDirs(buildDir, packagePath),
+    resolve(buildDir, packagePath || '', FRAMEWORKS_API_PATH),
+    constants.DB_MIGRATIONS_DIST ? resolve(buildDir, constants.DB_MIGRATIONS_DIST) : undefined,
+  ].filter((path): path is string => Boolean(path))
 
   try {
     await Promise.all(paths.map((dir) => rm(dir, { recursive: true, force: true })))

--- a/packages/build/tests/db_setup/fixtures/monorepo/apps/app-1/netlify/database/migrations/001_init/migration.sql
+++ b/packages/build/tests/db_setup/fixtures/monorepo/apps/app-1/netlify/database/migrations/001_init/migration.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id INT);

--- a/packages/build/tests/db_setup/fixtures/monorepo/apps/app-1/netlify/database/migrations/002_add-posts.sql
+++ b/packages/build/tests/db_setup/fixtures/monorepo/apps/app-1/netlify/database/migrations/002_add-posts.sql
@@ -1,0 +1,1 @@
+CREATE TABLE posts (id INT);

--- a/packages/build/tests/db_setup/fixtures/with_db_dependency/netlify/database/migrations/001_init/migration.sql
+++ b/packages/build/tests/db_setup/fixtures/with_db_dependency/netlify/database/migrations/001_init/migration.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id INT);

--- a/packages/build/tests/db_setup/fixtures/with_db_dependency/netlify/database/migrations/002_add-posts.sql
+++ b/packages/build/tests/db_setup/fixtures/with_db_dependency/netlify/database/migrations/002_add-posts.sql
@@ -1,0 +1,1 @@
+CREATE TABLE posts (id INT);

--- a/packages/build/tests/db_setup/tests.js
+++ b/packages/build/tests/db_setup/tests.js
@@ -1,5 +1,11 @@
+import { existsSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
 import { Fixture, startServer } from '@netlify/testing'
 import test from 'ava'
+
+const DIST_RELATIVE = '.netlify/internal/db/migrations'
 
 const SITE_INFO_PATH = '/api/v1/sites/test'
 const SITE_INFO_RESPONSE = { id: 'test', name: 'test-site' }
@@ -89,6 +95,29 @@ test('Does not run the db_setup core step when the feature flag is off', async (
   t.false(stdout.join('\n').includes('Netlify Database setup completed'))
 })
 
+test('Copies migrations from netlify/database/migrations into DB_MIGRATIONS_DIST', async (t) => {
+  const fixture = await new Fixture('./fixtures/with_db_dependency').withCopyRoot({ git: false })
+  await runWithMockServer(fixture)
+
+  const distDir = join(fixture.repositoryRoot, DIST_RELATIVE)
+  t.true(existsSync(join(distDir, '001_init/migration.sql')))
+  t.true(existsSync(join(distDir, '002_add-posts/migration.sql')))
+})
+
+test('Removes stale migrations from previous builds before copying new ones', async (t) => {
+  const fixture = await new Fixture('./fixtures/with_db_dependency').withCopyRoot({ git: false })
+  const distDir = join(fixture.repositoryRoot, DIST_RELATIVE)
+
+  await mkdir(join(distDir, '999_stale'), { recursive: true })
+  await writeFile(join(distDir, '999_stale/migration.sql'), 'DROP TABLE users;')
+
+  await runWithMockServer(fixture)
+
+  t.false(existsSync(join(distDir, '999_stale/migration.sql')))
+  t.true(existsSync(join(distDir, '001_init/migration.sql')))
+  t.true(existsSync(join(distDir, '002_add-posts/migration.sql')))
+})
+
 test('monorepo > Runs the db_setup core step when @netlify/database is in workspace devDependencies', async (t) => {
   const { output } = await runWithMockServer(
     new Fixture('./fixtures/monorepo').withFlags({ packagePath: 'apps/app-1' }),
@@ -96,4 +125,31 @@ test('monorepo > Runs the db_setup core step when @netlify/database is in worksp
 
   t.true(output.includes('Netlify Database setup completed'))
   t.true(output.includes(MAIN_CONNECTION_STRING))
+})
+
+test('monorepo > Copies migrations from apps/app-1/netlify/database/migrations into DB_MIGRATIONS_DIST', async (t) => {
+  const fixture = await new Fixture('./fixtures/monorepo')
+    .withFlags({ packagePath: 'apps/app-1' })
+    .withCopyRoot({ git: false })
+  await runWithMockServer(fixture)
+
+  const distDir = join(fixture.repositoryRoot, 'apps/app-1', DIST_RELATIVE)
+  t.true(existsSync(join(distDir, '001_init/migration.sql')))
+  t.true(existsSync(join(distDir, '002_add-posts/migration.sql')))
+})
+
+test('monorepo > Removes stale migrations from previous builds before copying new ones', async (t) => {
+  const fixture = await new Fixture('./fixtures/monorepo')
+    .withFlags({ packagePath: 'apps/app-1' })
+    .withCopyRoot({ git: false })
+  const distDir = join(fixture.repositoryRoot, 'apps/app-1', DIST_RELATIVE)
+
+  await mkdir(join(distDir, '999_stale'), { recursive: true })
+  await writeFile(join(distDir, '999_stale/migration.sql'), 'DROP TABLE users;')
+
+  await runWithMockServer(fixture)
+
+  t.false(existsSync(join(distDir, '999_stale/migration.sql')))
+  t.true(existsSync(join(distDir, '001_init/migration.sql')))
+  t.true(existsSync(join(distDir, '002_add-posts/migration.sql')))
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Clean up potentially stale deploy migration files at the start of the build similarly as we cleanup blobs for deployments. This should make sure that there are no stale, leftover migration files for cases when a previous deploy might have failed due to out of order migrations or other problems that fail deploy side validation and source migrations were adjusted for it and re-deploy was initiated.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
