### PR TITLE
chore: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,10 +13,10 @@ jobs:
   benchmark:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
         working-directory: packages/zip-it-and-ship-it
 
       - name: Run Delta
-        uses: netlify/delta-action@v4
+        uses: netlify/delta-action@1195810c67610e177b2f60da3f4cf6f620bd5d54 # v4.1.0
         with:
           title: '⏱ Benchmark results'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -7,7 +7,7 @@ jobs:
   lint-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Dependencies
         run: npm install @commitlint/config-conventional
-      - uses: JulienKode/pull-request-name-linter-action@v20.1.0
+      - uses: JulienKode/pull-request-name-linter-action@4fb4c2773193ad7ae5fe105c98ab30778abb1536 # v20.1.0

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download fossa cli
         run: |-
           mkdir -p $HOME/.local/bin

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,10 +8,10 @@ jobs:
   prerelease:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           check-latest: true

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/stale@v10.2.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           exempt-issue-labels: 'WIP,security,action_item,never_stale'
           days-before-issue-stale: 365

--- a/.github/workflows/typescript-nudge.yml
+++ b/.github/workflows/typescript-nudge.yml
@@ -12,13 +12,13 @@ jobs:
   Nudge-to-convert-to-TypeScript-if-JavaScript-found:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: 🔎 Get changed JavaScript files
         id: changed-javascript-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
@@ -41,7 +41,7 @@ jobs:
         if:
           steps.changed-javascript-files.outputs.modified_files != '' ||
           steps.changed-javascript-files.outputs.added_files != ''
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             This pull request adds or modifies JavaScript (`.js`, `.cjs`, `.mjs`) files.
@@ -53,7 +53,7 @@ jobs:
         if:
           steps.changed-javascript-files.outputs.modified_files != '' ||
           steps.changed-javascript-files.outputs.added_files != ''
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@c96b68fec76a0987cd93957189e9abd0b9a72ff1 # v1.1.3
         with:
           labels: 'Adds or modifies js files'
 
@@ -62,7 +62,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'Adds or modifies js files') &&
           steps.changed-javascript-files.outputs.modified_files == '' &&
           steps.changed-javascript-files.outputs.added_files == ''
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             ~This pull request adds or modifies JavaScript (`.js`, `.cjs`, `.mjs`) files. Consider converting them to TypeScript.~
@@ -75,6 +75,6 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'Adds or modifies js files') &&
           steps.changed-javascript-files.outputs.modified_files == '' &&
           steps.changed-javascript-files.outputs.added_files == ''
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@f5dccab59b9ed79c1a5ddd2ab6d8771449b0250f # v1.3.0
         with:
           labels: 'Adds or modifies js files'

--- a/.github/workflows/typescript-nudge.yml
+++ b/.github/workflows/typescript-nudge.yml
@@ -53,7 +53,7 @@ jobs:
         if:
           steps.changed-javascript-files.outputs.modified_files != '' ||
           steps.changed-javascript-files.outputs.added_files != ''
-        uses: actions-ecosystem/action-add-labels@c96b68fec76a0987cd93957189e9abd0b9a72ff1 # v1.1.3
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: 'Adds or modifies js files'
 
@@ -75,6 +75,6 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'Adds or modifies js files') &&
           steps.changed-javascript-files.outputs.modified_files == '' &&
           steps.changed-javascript-files.outputs.added_files == ''
-        uses: actions-ecosystem/action-remove-labels@f5dccab59b9ed79c1a5ddd2ab6d8771449b0250f # v1.3.0
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: 'Adds or modifies js files'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -207,7 +207,7 @@ jobs:
           echo "node=node_${node/.*.*/}" >> $GITHUB_OUTPUT
           echo "node=node_${node/.*.*/}" >> $env:GITHUB_OUTPUT
         shell: bash
-      - uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
         with:
           files:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,11 +19,11 @@ jobs:
           echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
           echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
         if: ${{ startsWith(github.head_ref, 'release-') }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
@@ -40,7 +40,7 @@ jobs:
       - name: test
         run: npx nx run-many --target=e2e
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: playwright-report
@@ -70,12 +70,12 @@ jobs:
           echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
           echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
         if: ${{ startsWith(github.head_ref, 'release-') }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -85,7 +85,7 @@ jobs:
         run: npm install -g npm@10
         if: ${{ !steps.release-check.outputs.IS_RELEASE && matrix.node-version == '22' }}
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1.5.2
         with:
           deno-version: ${{ matrix.deno-version }}
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
@@ -93,7 +93,7 @@ jobs:
         run: deno cache https://deno.land/x/eszip@v0.55.2/eszip.ts
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.18'
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
@@ -150,17 +150,17 @@ jobs:
           echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
         if: ${{ startsWith(github.head_ref, 'release-') }}
       - name: Git checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1.5.2
         with:
           deno-version: 2.5.6
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -178,7 +178,7 @@ jobs:
         run: corepack enable
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.18'
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
@@ -207,7 +207,7 @@ jobs:
           echo "node=node_${node/.*.*/}" >> $GITHUB_OUTPUT
           echo "node=node_${node/.*.*/}" >> $env:GITHUB_OUTPUT
         shell: bash
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
         with:
           files:


### PR DESCRIPTION
#### Summary

Pin all GHA action references to their full 40-character commit SHAs for supply chain security, with inline comments noting the version tag.