### PR TITLE
test(build): run edge_functions test suite serially to avoid fixture races

### DIFF
--- a/packages/build/tests/edge_functions/tests.js
+++ b/packages/build/tests/edge_functions/tests.js
@@ -72,27 +72,27 @@ const FLAG_VARIANTS = isDenoVersionSupported(denoVersion)
   : [{ id: 'default', flags: { debug: false } }]
 
 for (const variant of FLAG_VARIANTS) {
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_SRC default value', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_SRC default value', async (t) => {
     const output = await new Fixture('./fixtures/src_default').withFlags(variant.flags).runWithBuild()
     t.snapshot(normalizeOutput(output))
   })
 
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_SRC automatic value', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_SRC automatic value', async (t) => {
     const output = await new Fixture('./fixtures/src_auto').withFlags(variant.flags).runWithBuild()
     t.snapshot(normalizeOutput(output))
   })
 
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_SRC relative path', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_SRC relative path', async (t) => {
     const output = await new Fixture('./fixtures/src_relative').withFlags(variant.flags).runWithBuild()
     t.snapshot(normalizeOutput(output))
   })
 
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_SRC missing path', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_SRC missing path', async (t) => {
     const output = await new Fixture('./fixtures/src_missing').withFlags(variant.flags).runWithBuild()
     t.snapshot(normalizeOutput(output))
   })
 
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_SRC created dynamically', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_SRC created dynamically', async (t) => {
     const output = await new Fixture('./fixtures/src_dynamic')
       .withFlags(variant.flags)
       .withCopyRoot({ git: false })
@@ -100,7 +100,7 @@ for (const variant of FLAG_VARIANTS) {
     t.snapshot(normalizeOutput(output))
   })
 
-  test(
+  test.serial(
     variant.id + ' - constants.EDGE_FUNCTIONS_SRC dynamic is ignored if EDGE_FUNCTIONS_SRC is specified',
     async (t) => {
       const output = await new Fixture('./fixtures/src_dynamic_ignore')
@@ -111,12 +111,12 @@ for (const variant of FLAG_VARIANTS) {
     },
   )
 
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_DIST default value', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_DIST default value', async (t) => {
     const output = await new Fixture('./fixtures/print_dist').withFlags(variant.flags).runWithBuild()
     t.snapshot(normalizeOutput(output))
   })
 
-  test(variant.id + ' - constants.EDGE_FUNCTIONS_DIST custom value', async (t) => {
+  test.serial(variant.id + ' - constants.EDGE_FUNCTIONS_DIST custom value', async (t) => {
     const output = await new Fixture('./fixtures/print_dist')
       .withFlags({ ...variant.flags, mode: 'buildbot', edgeFunctionsDistDir: '/another/path' })
       .runWithBuild()
@@ -183,7 +183,7 @@ for (const variant of FLAG_VARIANTS) {
     assertBundlesExist(t, manifest, variant)
   })
 
-  test(variant.id + ' - handles failure when bundling Edge Functions via runCoreSteps function', async (t) => {
+  test.serial(variant.id + ' - handles failure when bundling Edge Functions via runCoreSteps function', async (t) => {
     const output = await new Fixture('./fixtures/functions_invalid')
       .withFlags({ ...variant.flags, buildSteps: ['edge_functions_bundling'], useRunCoreSteps: true })
       .runWithBuild()
@@ -228,7 +228,7 @@ for (const variant of FLAG_VARIANTS) {
     }
   })
 
-  test(variant.id + ' - build plugins can manipulate netlifyToml.edge_functions array', async (t) => {
+  test.serial(variant.id + ' - build plugins can manipulate netlifyToml.edge_functions array', async (t) => {
     const output = await new Fixture('./fixtures/functions_plugin_mutations').withFlags(variant.flags).runWithBuild()
     t.snapshot(normalizeOutput(output))
     const manifest = await assertManifest(t, 'functions_plugin_mutations')
@@ -348,7 +348,7 @@ for (const variant of FLAG_VARIANTS) {
     },
   )
 
-  test(variant.id + ' - skip bundling when edge function directories exist, contain no functions', async (t) => {
+  test.serial(variant.id + ' - skip bundling when edge function directories exist, contain no functions', async (t) => {
     await new Fixture('./fixtures/functions_empty_directory').withFlags(variant.flags).runWithBuild()
 
     const manifestPath = join(
@@ -362,7 +362,7 @@ for (const variant of FLAG_VARIANTS) {
     t.false(await pathExists(manifestPath))
   })
 
-  test(
+  test.serial(
     variant.id + ' - skip bundling when edge function directories exist, contain no functions, contain empty manifest',
     async (t) => {
       await new Fixture('./fixtures/functions_empty_manifest').withFlags(variant.flags).runWithBuild()


### PR DESCRIPTION
Within each FLAG_VARIANTS iteration, parallel `test(...)` calls were sharing on-disk fixture directories across variants. The "build plugins can manipulate netlifyToml.edge_functions array" test in particular raced its own `default` and `tarball` variants on
`functions_plugin_mutations/.netlify/edge-functions-dist/`, causing an internal error during Edge Functions bundling when one run's `fs.rm` landed in the middle of the other run's bundling.

Make all tests in the file `test.serial` to eliminate this class of flakiness; future tests added to this file should follow the same convention.

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
