### PR TITLE
feat: add `background` config property

### DIFF
--- a/packages/zip-it-and-ship-it/src/config.ts
+++ b/packages/zip-it-and-ship-it/src/config.ts
@@ -62,6 +62,7 @@ const FUNCTION_VCPU_MAX = 2
 const functionVcpu = z.number().min(FUNCTION_VCPU_MIN).max(FUNCTION_VCPU_MAX)
 
 export const functionConfigShape = z.object({
+  background: z.boolean().optional().catch(undefined),
   externalNodeModules: z.array(z.string()).optional().catch([]),
   generator: z.string().optional().catch(undefined),
   includedFiles: z.array(z.string()).optional().catch([]),

--- a/packages/zip-it-and-ship-it/src/runtimes/node/in_source_config/index.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/in_source_config/index.ts
@@ -55,6 +55,7 @@ export type HttpMethods = z.infer<typeof httpMethods>
 
 export const inSourceConfig = functionConfigShape
   .pick({
+    background: true,
     externalNodeModules: true,
     generator: true,
     includedFiles: true,
@@ -222,6 +223,10 @@ export const parseSource = (source: string, { functionName }: FindISCDeclaration
         methods: data.method ?? [],
         prefer_static: data.preferStatic || undefined,
       }))
+
+      if (data.background) {
+        result.invocationMode = INVOCATION_MODE.Background
+      }
     } else {
       // TODO: Handle multiple errors.
       const [issue] = error.issues

--- a/packages/zip-it-and-ship-it/src/runtimes/node/index.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/index.ts
@@ -153,14 +153,16 @@ const zipFunction: ZipFunction = async function ({
   // `stream` helper.
   let { invocationMode } = staticAnalysisResult
 
-  // If we're using the V2 API, force the invocation to "stream".
-  if (runtimeAPIVersion === 2) {
-    invocationMode = INVOCATION_MODE.Stream
-  }
-
-  // If this is a background function, set the right `invocationMode` value.
+  // If this is a background function (filename suffix), set the right
+  // `invocationMode` value.
   if (name.endsWith('-background')) {
     invocationMode = INVOCATION_MODE.Background
+  }
+
+  // V2 functions default to streamed invocation unless they were already
+  // marked as background (via filename suffix or `config.background: true`).
+  if (runtimeAPIVersion === 2 && invocationMode !== INVOCATION_MODE.Background) {
+    invocationMode = INVOCATION_MODE.Stream
   }
 
   const outputModuleFormat =

--- a/packages/zip-it-and-ship-it/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/packages/zip-it-and-ship-it/tests/unit/runtimes/node/in_source_config.test.ts
@@ -1064,4 +1064,33 @@ describe('V2 API', () => {
 
     expect(() => parseSource(source, options)).toThrow(/memory.*vcpu|vcpu.*memory/)
   })
+
+  test('Sets background invocation mode when `config.background` is true', () => {
+    const source = `
+    export default async () => new Response("Hello!")
+    export const config = { path: "/hello", background: true }`
+
+    const isc = parseSource(source, options)
+    expect(isc.config.background).toBe(true)
+    expect(isc.invocationMode).toBe('background')
+    expect(isc.runtimeAPIVersion).toBe(2)
+  })
+
+  test('Does not set background invocation mode when `config.background` is false', () => {
+    const source = `
+    export default async () => new Response("Hello!")
+    export const config = { path: "/hello", background: false }`
+
+    const isc = parseSource(source, options)
+    expect(isc.invocationMode).toBeUndefined()
+  })
+
+  test('Does not set background invocation mode when `config.background` is absent', () => {
+    const source = `
+    export default async () => new Response("Hello!")
+    export const config = { path: "/hello" }`
+
+    const isc = parseSource(source, options)
+    expect(isc.invocationMode).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Adds a new `background` boolean property to the in-source configuration object. When set to `true`, it marks the function as background without having to use the `-background` suffix in the filename.

_Example: netlify/functions/hello.ts_
```ts
import { Config, Context } from "@netlify/functions"

export default async (req: Request, context: Context) => {
	console.log("Hello from a background function")
}

export const config: Config = {
	background: true,
	path: "/hello-background"
}
```