### PR TITLE
feat: bump `precinct` to v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,30 +60,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -93,13 +93,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -529,16 +529,16 @@
       }
     },
     "node_modules/@dependents/detective-less": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.1.tgz",
-      "integrity": "sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-6.0.1.tgz",
+      "integrity": "sha512-WRFmqQuZBajKzksO3kWCxskitTqxTdZ/xkyWn7gX+jvnmEeZauH8ngLs5RiluZZrXBNzngJd7kTrN0QwVhgAHg==",
       "license": "MIT",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^7.0.1"
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -5152,13 +5152,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -5167,13 +5165,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -5182,13 +5178,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -5197,13 +5191,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -5212,13 +5204,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -5227,13 +5217,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -5242,13 +5230,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -5257,13 +5243,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -5272,13 +5256,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -5287,13 +5269,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -5302,13 +5282,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -5317,13 +5295,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -5332,13 +5308,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -5347,13 +5321,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -5362,13 +5334,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -5377,13 +5347,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -5392,13 +5360,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -5407,13 +5373,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -5422,13 +5386,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -5437,13 +5399,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -5452,13 +5412,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -5467,13 +5425,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -5482,13 +5438,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -5497,13 +5451,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -5512,13 +5464,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -6056,6 +6006,7 @@
       "version": "8.35.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
       "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.35.1",
@@ -6095,6 +6046,7 @@
       "version": "8.35.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
       "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6135,6 +6087,7 @@
       "version": "8.35.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
       "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6148,6 +6101,7 @@
       "version": "8.35.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
       "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.35.1",
@@ -6200,6 +6154,7 @@
       "version": "8.35.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
       "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.35.1",
@@ -6217,6 +6172,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6565,59 +6521,59 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.14.tgz",
-      "integrity": "sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
+      "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.2",
-        "@vue/shared": "3.5.14",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.35",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.14.tgz",
-      "integrity": "sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
+      "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-core": "3.5.35",
+        "@vue/shared": "3.5.35"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.14.tgz",
-      "integrity": "sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz",
+      "integrity": "sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.2",
-        "@vue/compiler-core": "3.5.14",
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/compiler-ssr": "3.5.14",
-        "@vue/shared": "3.5.14",
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.35",
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.3",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.14.tgz",
-      "integrity": "sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz",
+      "integrity": "sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/shared": "3.5.35"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.14.tgz",
-      "integrity": "sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
+      "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
       "license": "MIT"
     },
     "node_modules/@whatwg-node/disposablestack": {
@@ -7311,12 +7267,12 @@
       }
     },
     "node_modules/ast-module-types": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.1.tgz",
-      "integrity": "sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-7.0.0.tgz",
+      "integrity": "sha512-WZf/zDJlZYMkn+/MSl1uwJzUnDzTpVitUCcvX2oUZzN5ccYTyiiI05249AYCOqMjvbKuwiielm7GfoQKYpH/7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
@@ -10167,9 +10123,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10644,135 +10600,277 @@
       }
     },
     "node_modules/detective-amd": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.0.1.tgz",
-      "integrity": "sha512-TtyZ3OhwUoEEIhTFoc1C9IyJIud3y+xYkSRjmvCt65+ycQuc3VcBrPRTMWoO/AnuCyOB8T5gky+xf7Igxtjd3g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-7.0.0.tgz",
+      "integrity": "sha512-ZSbF4yyY2P4VfXmyKfVt6YuHYXu5CE21iSpMzZq2ItcmVeVR90emURHO6bPSlCq/TfWo/NCTWJtA5wlnTBQ/UA==",
       "license": "MIT",
       "dependencies": {
-        "ast-module-types": "^6.0.1",
+        "ast-module-types": "^7.0.0",
         "escodegen": "^2.1.0",
-        "get-amd-module-type": "^6.0.1",
-        "node-source-walk": "^7.0.1"
+        "get-amd-module-type": "^7.0.0",
+        "node-source-walk": "^8.0.0"
       },
       "bin": {
         "detective-amd": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/detective-cjs": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.0.1.tgz",
-      "integrity": "sha512-tLTQsWvd2WMcmn/60T2inEJNhJoi7a//PQ7DwRKEj1yEeiQs4mrONgsUtEJKnZmrGWBBmE0kJ1vqOG/NAxwaJw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-7.0.0.tgz",
+      "integrity": "sha512-rp+2gWa939K35U6UVZc7af6RkJlUTsoDLsJS/1wPTCKUSt/E2rEnLHbE01DPJGsXzDso0hLfzdePwK0935EwPg==",
       "license": "MIT",
       "dependencies": {
-        "ast-module-types": "^6.0.1",
-        "node-source-walk": "^7.0.1"
+        "ast-module-types": "^7.0.0",
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/detective-es6": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.1.tgz",
-      "integrity": "sha512-XusTPuewnSUdoxRSx8OOI6xIA/uld/wMQwYsouvFN2LAg7HgP06NF1lHRV3x6BZxyL2Kkoih4ewcq8hcbGtwew==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-6.0.0.tgz",
+      "integrity": "sha512-gbrrUDI8a3VvQilbdlZLC1IOUdydtjIgoNF1dEUsy0Rba+ianG2tC5d5mXAp0T4GrJuzjyzP4yZVAtcUx6YYNg==",
       "license": "MIT",
       "dependencies": {
-        "node-source-walk": "^7.0.1"
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/detective-postcss": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-7.0.1.tgz",
-      "integrity": "sha512-bEOVpHU9picRZux5XnwGsmCN4+8oZo7vSW0O0/Enq/TO5R2pIAP2279NsszpJR7ocnQt4WXU0+nnh/0JuK4KHQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-9.0.0.tgz",
+      "integrity": "sha512-0K/pgq8MjCr7/Xh+M29K7blUzTEryQMDHPgEvFfgPdVISrCXU98b+hL3GXVDMy50zJZKO1768Xa0t9USRVntwA==",
       "license": "MIT",
       "dependencies": {
-        "is-url": "^1.2.4",
+        "is-url-superb": "^4.0.0",
         "postcss-values-parser": "^6.0.2"
       },
       "engines": {
-        "node": "^14.0.0 || >=16.0.0"
+        "node": ">=20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "postcss": "^8.4.47"
       }
     },
     "node_modules/detective-sass": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.1.tgz",
-      "integrity": "sha512-jSGPO8QDy7K7pztUmGC6aiHkexBQT4GIH+mBAL9ZyBmnUIOFbkfZnO8wPRRJFP/QP83irObgsZHCoDHZ173tRw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-7.0.1.tgz",
+      "integrity": "sha512-iv9U1j8C5AfVV4pHCCpU+a0H40pv6Xz+n0Hxi64ZHRjbJ3SU+WuS+ZW0V6uASL/L5xDi7Nz+UB8T9ZAK0epMxw==",
       "license": "MIT",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^7.0.1"
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/detective-scss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.1.tgz",
-      "integrity": "sha512-MAyPYRgS6DCiS6n6AoSBJXLGVOydsr9huwXORUlJ37K3YLyiN0vYHpzs3AdJOgHobBfispokoqrEon9rbmKacg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-6.0.1.tgz",
+      "integrity": "sha512-ZPGAJjRrSo7V84MvlzlkriX9VRsA0ln8kIRg5sRH9fi5V/0gWyMBcu9nPJVZag5h6IfIiJdJFaWBYz+zffw4/A==",
       "license": "MIT",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^7.0.1"
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/detective-stylus": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.1.tgz",
-      "integrity": "sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-6.0.0.tgz",
+      "integrity": "sha512-H12WWqOaajhdVUnePu3s3CyqQdYFcAJhgztDWDqu2giechAGPewXo0KctAd/aHM9bP+mpYvMHty6iAjzjcQNLg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/detective-typescript": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-14.0.0.tgz",
-      "integrity": "sha512-pgN43/80MmWVSEi5LUuiVvO/0a9ss5V7fwVfrJ4QzAQRd3cwqU1SfWGXJFcNKUqoD5cS+uIovhw5t/0rSeC5Mw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-15.0.0.tgz",
+      "integrity": "sha512-4V618NRA+WHrnynSKHaPjNszpkWRNm+SLUtzm3SIeSi+9O5veg+oSBkK1AA+dWhRJnS+5V2nt5iFQuEkB3nvBg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "^8.23.0",
-        "ast-module-types": "^6.0.1",
-        "node-source-walk": "^7.0.1"
+        "@typescript-eslint/typescript-estree": "^8.59.3",
+        "ast-module-types": "^7.0.0",
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "typescript": "^5.4.4"
+        "typescript": "^5.4.4 || ^6.0.2"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/project-service": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.60.0",
+        "@typescript-eslint/types": "^8.60.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/types": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.60.0",
+        "@typescript-eslint/tsconfig-utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/detective-vue2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.2.0.tgz",
-      "integrity": "sha512-sVg/t6O2z1zna8a/UIV6xL5KUa2cMTQbdTIIvqNM0NIPswp52fe43Nwmbahzj3ww4D844u/vC2PYfiGLvD3zFA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-3.0.0.tgz",
+      "integrity": "sha512-G9R8V5PE4YeCn94Lbo1N6gaUh+6ke1Z3Lkqdeqkpfoxv6K2GNEdQWuv02KApnjyZzpF6hbCpMupPbfWddZDxAw==",
       "license": "MIT",
       "dependencies": {
-        "@dependents/detective-less": "^5.0.1",
-        "@vue/compiler-sfc": "^3.5.13",
-        "detective-es6": "^5.0.1",
-        "detective-sass": "^6.0.1",
-        "detective-scss": "^5.0.1",
-        "detective-stylus": "^5.0.1",
-        "detective-typescript": "^14.0.0"
+        "@dependents/detective-less": "^6.0.0",
+        "@vue/compiler-sfc": "^3.5.34",
+        "detective-es6": "^6.0.0",
+        "detective-sass": "^7.0.0",
+        "detective-scss": "^6.0.0",
+        "detective-stylus": "^6.0.0",
+        "detective-typescript": "^15.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "typescript": "^5.4.4"
+        "typescript": "^5.4.4 || ^6.0.2"
       }
     },
     "node_modules/dettle": {
@@ -11009,9 +11107,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11289,7 +11387,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11307,7 +11404,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11325,7 +11421,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11343,7 +11438,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11361,7 +11455,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11379,7 +11472,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11397,7 +11489,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11415,7 +11506,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11433,7 +11523,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11451,7 +11540,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11469,7 +11557,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11487,7 +11574,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11505,7 +11591,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11523,7 +11608,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11541,7 +11625,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11559,7 +11642,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11577,7 +11659,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11595,7 +11676,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11613,7 +11693,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11631,7 +11710,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11649,7 +11727,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11667,7 +11744,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11685,7 +11761,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11703,7 +11778,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11721,7 +11795,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11739,7 +11812,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13398,7 +13470,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13450,16 +13521,16 @@
       }
     },
     "node_modules/get-amd-module-type": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.1.tgz",
-      "integrity": "sha512-MtjsmYiCXcYDDrGqtNbeIYdAl85n+5mSv2r3FbzER/YV3ZILw4HNNIw34HuV5pyl0jzs6GFYU1VHVEefhgcNHQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-7.0.0.tgz",
+      "integrity": "sha512-Pxu8tqdNbCBWoahaWS1EElwWxP9iNVTWr3VlqsobQPTs5qs77E66BI79ln00d2QoJdcvKIcoDlKDOiVGBehoDA==",
       "license": "MIT",
       "dependencies": {
-        "ast-module-types": "^6.0.1",
-        "node-source-walk": "^7.0.1"
+        "ast-module-types": "^7.0.0",
+        "node-source-walk": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/get-bin-path": {
@@ -15450,12 +15521,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "license": "MIT"
-    },
     "node_modules/is-url-superb": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
@@ -17122,12 +17187,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/magicast": {
@@ -17888,19 +17953,19 @@
       }
     },
     "node_modules/module-definition": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.1.tgz",
-      "integrity": "sha512-FeVc50FTfVVQnolk/WQT8MX+2WVcDnTGiq6Wo+/+lJ2ET1bRVi3HG3YlJUfqagNMc/kUlFSoR96AJkxGpKz13g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-7.0.0.tgz",
+      "integrity": "sha512-ctl9cJHEHUqP8IehBhEq9NuykuFVJAhxeLR4BeObsrcwrZMTu2ax3F22Ii5bad1T41LwKOug/9FAzO9wmfAZ1Q==",
       "license": "MIT",
       "dependencies": {
-        "ast-module-types": "^6.0.1",
-        "node-source-walk": "^7.0.1"
+        "ast-module-types": "^7.0.0",
+        "node-source-walk": "^8.0.0"
       },
       "bin": {
         "module-definition": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/module-details-from-path": {
@@ -18016,9 +18081,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -18288,15 +18353,15 @@
       "license": "MIT"
     },
     "node_modules/node-source-walk": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.1.tgz",
-      "integrity": "sha512-3VW/8JpPqPvnJvseXowjZcirPisssnBuDikk6JIZ8jQzF7KJQX52iPFX4RYYxLycYH7IbMRSPUOga/esVjy5Yg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-8.0.0.tgz",
+      "integrity": "sha512-/CsHIdZsVgpGm4A7cD+Vdajv2GyqkVPUNtpChugutV/O9e3j1YWkdOWwhWKo0NfRM4r4XoiKtkb4JoLzsCN5vw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.7"
+        "@babel/parser": "^7.29.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/node-stream-zip": {
@@ -20302,9 +20367,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -20321,7 +20386,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -20361,41 +20426,54 @@
       }
     },
     "node_modules/precinct": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.2.0.tgz",
-      "integrity": "sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-13.0.0.tgz",
+      "integrity": "sha512-ahvmU8sHKbNiXCNlnqavHjOPOShVuCR0RSQCFcXxY31gsskTRyDKVy4lCsewuGYCHWL3PTwXB/5ENTw82Wby8g==",
       "license": "MIT",
       "dependencies": {
-        "@dependents/detective-less": "^5.0.1",
-        "commander": "^12.1.0",
-        "detective-amd": "^6.0.1",
-        "detective-cjs": "^6.0.1",
-        "detective-es6": "^5.0.1",
-        "detective-postcss": "^7.0.1",
-        "detective-sass": "^6.0.1",
-        "detective-scss": "^5.0.1",
-        "detective-stylus": "^5.0.1",
-        "detective-typescript": "^14.0.0",
-        "detective-vue2": "^2.2.0",
-        "module-definition": "^6.0.1",
-        "node-source-walk": "^7.0.1",
-        "postcss": "^8.5.1",
-        "typescript": "^5.7.3"
+        "@dependents/detective-less": "^6.0.0",
+        "commander": "^14.0.3",
+        "detective-amd": "^7.0.0",
+        "detective-cjs": "^7.0.0",
+        "detective-es6": "^6.0.0",
+        "detective-postcss": "^9.0.0",
+        "detective-sass": "^7.0.0",
+        "detective-scss": "^6.0.0",
+        "detective-stylus": "^6.0.0",
+        "detective-typescript": "^15.0.0",
+        "detective-vue2": "^3.0.0",
+        "module-definition": "^7.0.0",
+        "node-source-walk": "^8.0.0",
+        "postcss": "^8.5.15",
+        "typescript": "^6.0.3"
       },
       "bin": {
         "precinct": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0 || >=22.12.0"
       }
     },
     "node_modules/precinct/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/precinct/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/preferred-node-version": {
@@ -21673,9 +21751,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -22991,7 +23069,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -23147,9 +23224,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -25987,7 +26064,7 @@
         "normalize-path": "^3.0.0",
         "p-map": "^7.0.0",
         "path-exists": "^5.0.0",
-        "precinct": "^12.0.0",
+        "precinct": "^13.0.0",
         "require-package-name": "^2.0.1",
         "resolve": "^2.0.0-next.1",
         "semver": "^7.3.8",
@@ -26025,7 +26102,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=20.8.0"
       }
     },
     "packages/zip-it-and-ship-it/node_modules/@types/node": {

--- a/packages/zip-it-and-ship-it/package.json
+++ b/packages/zip-it-and-ship-it/package.json
@@ -63,7 +63,7 @@
     "normalize-path": "^3.0.0",
     "p-map": "^7.0.0",
     "path-exists": "^5.0.0",
-    "precinct": "^12.0.0",
+    "precinct": "^13.0.0",
     "require-package-name": "^2.0.1",
     "resolve": "^2.0.0-next.1",
     "semver": "^7.3.8",
@@ -98,6 +98,6 @@
     "vitest": "^3.0.0"
   },
   "engines": {
-    "node": ">=18.14.0"
+    "node": ">=20.19.0"
   }
 }


### PR DESCRIPTION
Also ups the minimum node version to 20.19 as that's what `precinct@13` requires

#### Summary

We're updating TypeScript 6 as the minimum in SvelteKit 3. However, `precinct@12` is still pulling in `typescript@5.9.3`. So, we end up installing two versions of TypeScript.

This PR is meant to test the idea of starting a new major for `@netlify/zip-it-and-ship-it` in which we could make it more modern and performant, starting with bumping the min node version to 20+

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
