### PR TITLE
fix(esbuild): sort srcFiles so zip checksum is deterministic

### DIFF
--- a/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/esbuild/index.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/esbuild/index.ts
@@ -129,7 +129,8 @@ const bundle: BundleFunction = async ({
     mainFile: normalizedMainFile,
     moduleFormat,
     nativeNodeModules,
-    srcFiles: [...supportingSrcFiles, ...bundlePaths.keys()],
+    // We sort so that the archive's checksum is deterministic.
+    srcFiles: [...supportingSrcFiles, ...bundlePaths.keys()].sort(),
   }
 }
 

--- a/packages/zip-it-and-ship-it/tests/esbuild.test.ts
+++ b/packages/zip-it-and-ship-it/tests/esbuild.test.ts
@@ -5,8 +5,14 @@ import { ARCHIVE_FORMAT } from '../src/archive.js'
 import { NODE_BUNDLER } from '../src/runtimes/node/bundlers/types.js'
 
 import { zipFixture } from './helpers/main.js'
+import { computeSha1 } from './helpers/sha.js'
 
 import 'source-map-support/register'
+
+// Shared state used by the `src_files` mock below to optionally reverse the
+// order in which source files are discovered, simulating the run-to-run
+// filesystem traversal variance that happens across build environments.
+const { srcFilesOrder } = vi.hoisted(() => ({ srcFilesOrder: { reverse: false } }))
 
 vi.mock('../src/utils/shell.js', () => ({ shellUtils: { runCommand: vi.fn() } }))
 
@@ -19,9 +25,27 @@ vi.mock('esbuild', async () => {
   }
 })
 
+// Wraps the real `getSrcFiles` so a test can flip the discovery order without
+// touching the filesystem. With `reverse` disabled (the default) the behaviour
+// is identical to the real module, so other tests are unaffected.
+vi.mock('../src/runtimes/node/bundlers/esbuild/src_files.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/runtimes/node/bundlers/esbuild/src_files.js')>(
+    '../src/runtimes/node/bundlers/esbuild/src_files.js',
+  )
+
+  const getSrcFiles: typeof actual.getSrcFiles = async (options) => {
+    const result = await actual.getSrcFiles(options)
+
+    return srcFilesOrder.reverse ? { ...result, srcFiles: [...result.srcFiles].reverse() } : result
+  }
+
+  return { ...actual, getSrcFiles }
+})
+
 describe('esbuild', () => {
   afterEach(() => {
     vi.mocked(build).mockReset()
+    srcFilesOrder.reverse = false
   })
 
   test('Generates a bundle for the Node runtime version specified in the `nodeVersion` config property', async () => {
@@ -37,5 +61,31 @@ describe('esbuild', () => {
     })
 
     expect(build).toHaveBeenCalledWith(expect.objectContaining({ target: ['node22'] }))
+  })
+
+  // Netlify content-addresses function uploads, so an unchanged function should
+  // produce a byte-identical zip and skip re-uploading. The order in which
+  // source files are discovered on disk is not stable across build environments,
+  // so the bundler must emit them in a deterministic order — otherwise the zip
+  // checksum changes on every build and dedup never hits. The `zisi` and `nft`
+  // bundlers already sort their `srcFiles` for this reason; this asserts esbuild
+  // does too. See `getSrcFiles` in `runtimes/node/bundlers/esbuild/index.ts`.
+  test('Produces a byte-identical zip regardless of the order in which source files are discovered', async () => {
+    const opts = {
+      archiveFormat: ARCHIVE_FORMAT.ZIP,
+      config: { '*': { nodeBundler: NODE_BUNDLER.ESBUILD, externalNodeModules: ['test'] } },
+    }
+
+    srcFilesOrder.reverse = false
+    const {
+      files: [first],
+    } = await zipFixture('node-module-and-local-imports', { opts })
+
+    srcFilesOrder.reverse = true
+    const {
+      files: [second],
+    } = await zipFixture('node-module-and-local-imports', { opts })
+
+    expect(await computeSha1(first.path)).toBe(await computeSha1(second.path))
   })
 })


### PR DESCRIPTION
Fixes #7086.

The esbuild bundler returned `srcFiles: [...supportingSrcFiles, ...bundlePaths.keys()]` without sorting, so identical function content was archived in a run-dependent order and the zip sha256 changed every build — defeating Netlify's content-addressed function-upload dedup (every function re-uploads on every deploy). The `zisi` and `nft` bundlers already `.sort()` for this exact reason; this aligns esbuild with them.

### Change
Add `.sort()` to the returned `srcFiles` in `packages/zip-it-and-ship-it/src/runtimes/node/bundlers/esbuild/index.ts`. Entry order has no runtime effect, so sorting is safe.

> Alternative: sort `deduplicatedSrcFiles` centrally in `packages/zip-it-and-ship-it/src/runtimes/node/utils/zip.ts` (which already keeps the add loop synchronous "so that the archive's checksum is deterministic") to cover all bundlers at once. I went with the localized esbuild fix to match the existing `zisi`/`nft` precedent and keep the change minimal, but happy to switch if maintainers prefer the central approach.

### Test
Added a Vitest regression test in `tests/esbuild.test.ts` that bundles the same function twice with the esbuild bundler while perturbing the source-file discovery order between runs, and asserts a byte-identical zip. It fails on `main` and passes with this change.

A plain "bundle twice and compare" test isn't sufficient here: within a single warm process the filesystem traversal order is incidentally stable, so identical checksums are produced even without the fix (the existing `'Produces deterministic checksums'` test in `main.test.ts` passes on buggy `main` for this reason). The non-determinism only manifests _across_ build environments, so the test reverses the discovered `srcFiles` order on the second bundle to simulate that variance — which is exactly what the sort neutralizes.

### Evidence
- Before: with the discovery order reversed between two builds of identical source, the zip sha differs (`ff807ba…` vs `2376cf0…`) despite identical contents.
- After: identical sha regardless of discovery order.
- Real-world: on a ~239-function Next.js site, an identical redeploy went from ~239 function uploads to 1 once entry order was deterministic.

---

This was originally found against the standalone `netlify/zip-it-and-ship-it` repo (now archived → redirects here); the affected code is unchanged after the move.
