### PR TITLE
fix: update otel peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript-eslint": "^8.34.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -25160,10 +25160,10 @@
         "yarn": "^1.22.22"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@netlify/opentelemetry-sdk-setup": "^2.0.0",
+        "@netlify/opentelemetry-sdk-setup": "^2.0.0 || ^3.0.0",
         "@opentelemetry/api": "~1.8.0"
       },
       "peerDependenciesMeta": {
@@ -25202,7 +25202,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/build-info/node_modules/@types/node": {
@@ -25340,7 +25340,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/cache-utils/node_modules/@types/node": {
@@ -25404,7 +25404,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/config/node_modules/@types/node": {
@@ -25474,7 +25474,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/edge-bundler/node_modules/@types/node": {
@@ -25583,7 +25583,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/functions-utils/node_modules/@types/node": {
@@ -25619,7 +25619,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/git-utils/node_modules/@types/node": {
@@ -25657,7 +25657,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/headers-parser/node_modules/@types/node": {
@@ -25696,7 +25696,7 @@
         "vitest": "^3.2.3"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/js-client/node_modules/@types/node": {
@@ -25741,7 +25741,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/nock-udp/node_modules/@types/node": {
@@ -25786,7 +25786,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "~1.8.0"
@@ -25823,7 +25823,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "~1.8.0"
@@ -25862,7 +25862,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/redirect-parser/node_modules/@types/node": {
@@ -25896,7 +25896,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/run-utils/node_modules/@types/node": {
@@ -25940,7 +25940,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/testing/node_modules/@types/node": {
@@ -26025,7 +26025,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/zip-it-and-ship-it/node_modules/@types/node": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -141,7 +141,7 @@
     "yarn": "^1.22.22"
   },
   "peerDependencies": {
-    "@netlify/opentelemetry-sdk-setup": "^2.0.0",
+    "@netlify/opentelemetry-sdk-setup": "^2.0.0 || ^3.0.0",
     "@opentelemetry/api": "~1.8.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary
Related to FRB-2069

The 36.0.0 release (#7093) majored every package, including @netlify/opentelemetry-sdk-setup (2→3). @netlify/build's peerDependencies range stayed ^2.0.0, so npm install fails with ERESOLVE — blocking the release PR's benchmark, formatting, update-lockfile, and lint-title checks.

Widen the range to ^2.0.0 || ^3.0.0 (release-please's node-workspace doesn't auto-bump peerDeps; the union resolves on both main's current 2.x and the release's 3.0.0). Lockfile also picks up the engines.node sync #7054 left stale.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
