### PR TITLE
build: upgrade to npm 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
 executors:
   node:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:24.17.0
   windows:
     machine:
       image: windows-server-2019-vs2019:stable

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,10 +22,6 @@ jobs:
           cache: 'npm'
           check-latest: true
 
-      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
-      - name: Setup npm version
-        run: npm install -g npm@10
-
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           check-latest: true
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,9 +16,6 @@ jobs:
           node-version: '24'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
-      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
-      - name: Setup npm version
-        run: npm install -g npm@10
       - name: Extract tag, version and package
         id: extract
         run: |-

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
       # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,10 +27,6 @@ jobs:
         with:
           node-version: 24
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
-      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
-      - name: Setup npm version
-        run: npm install -g npm@10
-        if: ${{ !steps.release-check.outputs.IS_RELEASE && matrix.node-version == '22' }}
       - name: Install dependencies
         run: npm ci
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
@@ -84,10 +80,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
-      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
-      - name: Setup npm version
-        run: npm install -g npm@10
-        if: ${{ !steps.release-check.outputs.IS_RELEASE && startsWith(matrix.node-version, '22') }}
       - name: Setup Deno
         uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1.5.2
         with:
@@ -170,10 +162,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
-      # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
-      - name: Setup npm version
-        run: npm install -g npm@10
-        if: ${{ !steps.release-check.outputs.IS_RELEASE && startsWith(matrix.node-version, '22') }}
       - name: corepack update
         # The Node-bundled corepack can fail on newer package-manager releases; install the
         # latest. Corepack only manages yarn here (see below).

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
         if: ${{ !steps.release-check.outputs.IS_RELEASE }}
       # Use npm@10 on Node 22+ due to https://github.com/npm/cli/issues/8489
       - name: Setup npm version
@@ -52,10 +52,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14, windows-2025]
-        node-version: ['22']
+        # latest version we support
+        node-version: ['24']
         # Maximum supported deno version from the `DENO_VERSION_RANGE` constant in `node/bridge.ts`.
         # If there is no upper band - this should be set to whatever is the latest deno version at the time of updating this workflow.
         deno-version: ['v2.8.0']
+        # We test on the oldest supported Node.js + Deno versions, but only on Linux
         include:
           - os: ubuntu-24.04
             # Earliest supported version
@@ -115,7 +117,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14, windows-2025]
-        node-version: ['22']
+        # latest version we support
+        node-version: ['24']
         install-command: ['npm ci']
         machine: ['0', '1', '2', '3', '4']
         include:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5296,13 +5296,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -5311,13 +5309,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -5326,13 +5322,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -5341,13 +5335,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -5356,13 +5348,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -5371,13 +5361,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -5386,13 +5374,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -5401,13 +5387,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -5416,13 +5400,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -5431,13 +5413,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -5446,13 +5426,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -5461,13 +5439,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -5476,13 +5452,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -5491,13 +5465,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -5506,13 +5478,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -5521,13 +5491,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -5536,13 +5504,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -5551,13 +5517,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -5566,13 +5530,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -5581,13 +5543,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -5596,13 +5556,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -5611,13 +5569,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -5626,13 +5582,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -5641,13 +5595,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -5656,13 +5608,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -11445,7 +11395,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11463,7 +11412,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11481,7 +11429,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11499,7 +11446,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11517,7 +11463,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11535,7 +11480,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11553,7 +11497,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11571,7 +11514,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11589,7 +11531,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11607,7 +11548,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11625,7 +11565,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11643,7 +11582,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11661,7 +11599,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11679,7 +11616,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11697,7 +11633,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11715,7 +11650,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11733,7 +11667,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11751,7 +11684,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11769,7 +11701,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11787,7 +11718,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11805,7 +11735,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11823,7 +11752,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11841,7 +11769,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11859,7 +11786,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11877,7 +11803,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11895,7 +11820,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13490,7 +13414,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -25298,37 +25221,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/framework-info": {
-      "name": "@netlify/framework-info",
-      "version": "10.0.5",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.12.0",
-        "filter-obj": "^6.0.0",
-        "find-up": "^7.0.0",
-        "is-plain-obj": "^4.0.0",
-        "locate-path": "^7.0.0",
-        "p-filter": "^4.0.0",
-        "p-locate": "^6.0.0",
-        "read-package-up": "^11.0.0",
-        "semver": "^7.3.8"
-      },
-      "devDependencies": {
-        "cpy": "^11.0.0",
-        "cpy-cli": "^5.0.0",
-        "fast-glob": "^3.2.12",
-        "npm-run-all2": "^6.0.0",
-        "rollup-plugin-node-polyfills": "^0.2.1",
-        "tmp-promise": "^3.0.2",
-        "typescript": "^5.0.0",
-        "vite": "^6.0.0",
-        "vitest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.14.0"
-      }
     },
     "packages/functions-utils": {
       "name": "@netlify/functions-utils",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "description": "Netlify build module",
   "type": "module",
-  "packageManager": "npm@11.17.0+sha512.3eeaf18997b11070d313849268b23766b9db0068997dec9471073170fe43fa17f2b4d0337bf0f52330ee2274e7f5754b21b01052742e48f5c9c74d8b1e32ef43",
   "author": "Netlify Inc.",
   "scripts": {
     "lint": "eslint --cache --fix",
@@ -64,6 +63,17 @@
   },
   "engines": {
     "node": ">=22.12.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22.12.0"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11",
+      "onFail": "warn"
+    }
   },
   "allowScripts": {
     "esbuild@0.25.12": true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "description": "Netlify build module",
   "type": "module",
+  "packageManager": "npm@11.17.0+sha512.3eeaf18997b11070d313849268b23766b9db0068997dec9471073170fe43fa17f2b4d0337bf0f52330ee2274e7f5754b21b01052742e48f5c9c74d8b1e32ef43",
   "author": "Netlify Inc.",
   "scripts": {
     "lint": "eslint --cache --fix",
@@ -63,5 +64,15 @@
   },
   "engines": {
     "node": ">=22.12.0"
+  },
+  "allowScripts": {
+    "esbuild@0.25.12": true,
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.2": true,
+    "fsevents@2.3.3": true,
+    "nx@20.8.2": true,
+    "protobufjs@7.4.0": true,
+    "unix-dgram@2.0.6": true,
+    "yarn@1.22.22": true
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,4 @@
   ignorePresets: [':prHourlyLimit2'],
   ignorePaths: ['**/fixtures/**', '**/fixtures-esm/**', '**/node_modules/**'],
   semanticCommits: 'enabled',
-  constraints: {
-    npm: '^10.0.0',
-  },
 }


### PR DESCRIPTION
#### Summary

We need to get on npm 11.5.1 to use Trusted Publishing.

This PR upgrades from pinned npm 10 to npm 11.7.0.

It also, as a follow-up to #7054, updates some leftover CI workflows to use Node.js 24 instead of 22.

#### To do

- [ ] update required checks before merging