### PR TITLE
perf(build): use node:fs for cache checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23154,9 +23154,7 @@
       "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
-        "cpy": "^11.0.0",
         "get-stream": "^9.0.0",
-        "globby": "^14.0.0",
         "junk": "^4.0.0",
         "locate-path": "^7.0.0",
         "move-file": "^3.0.0",

--- a/packages/cache-utils/package.json
+++ b/packages/cache-utils/package.json
@@ -50,9 +50,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "cpy": "^11.0.0",
     "get-stream": "^9.0.0",
-    "globby": "^14.0.0",
     "junk": "^4.0.0",
     "locate-path": "^7.0.0",
     "move-file": "^3.0.0",

--- a/packages/cache-utils/src/fs.ts
+++ b/packages/cache-utils/src/fs.ts
@@ -1,8 +1,6 @@
-import { promises as fs, Stats } from 'fs'
-import { basename, dirname, join } from 'path'
+import { promises as fs, Stats } from 'node:fs'
+import { basename } from 'node:path'
 
-import cpy from 'cpy'
-import { type Options, globby } from 'globby'
 import { isNotJunk } from 'junk'
 import { moveFile } from 'move-file'
 
@@ -18,66 +16,29 @@ export const moveCacheFile = async function (src: string, dest: string, move = f
     return moveFile(src, dest, { overwrite: false })
   }
 
-  const { srcGlob, dest: matchedDest, ...options } = await getSrcAndDest(src, dirname(dest))
-  if (srcGlob && matchedDest) {
-    return cpy(srcGlob, matchedDest, { ...options, overwrite: false })
+  if ((await getStat(src)) === undefined) {
+    return
   }
+
+  await fs.cp(src, dest, { recursive: true, force: false, errorOnExist: false })
 }
 
 /**
  * Non-existing files and empty directories are always skipped
  */
 export const hasFiles = async function (src: string): Promise<boolean> {
-  const { srcGlob, isDir, dest, ...options } = await getSrcAndDest(src, '')
-  return srcGlob !== undefined && !(await isEmptyDir(srcGlob, isDir, options))
-}
-
-/** Replicates what `cpy` is doing under the hood. */
-const isEmptyDir = async function (globPattern: string, isDir: boolean, options: Options) {
-  if (!isDir) {
+  const stat = await getStat(src)
+  if (stat === undefined) {
     return false
   }
-
-  const files = await globby(globPattern, options)
-  const filteredFiles = files.filter((file) => isNotJunk(basename(file)))
-  return filteredFiles.length === 0
-}
-
-type GlobOptions = {
-  srcGlob?: string
-  dest?: string
-  isDir: boolean
-  cwd: string
-  dot?: boolean
-}
-
-/**
- * Get globbing pattern with files to move/copy
- */
-const getSrcAndDest = async function (src: string, dest: string): Promise<GlobOptions> {
-  const srcStat = await getStat(src)
-
-  if (srcStat === undefined) {
-    return { srcGlob: undefined, isDir: false, cwd: '' }
+  if (!stat.isDirectory()) {
+    return isNotJunk(basename(src))
   }
-
-  const isDir = srcStat.isDirectory()
-  const srcBasename = basename(src)
-  const cwd = dirname(src)
-
-  const baseOptions: GlobOptions = {
-    srcGlob: srcBasename,
-    dest,
-    isDir,
-    cwd,
-    dot: true, // collect .dot directories as well
-  }
-
-  if (isDir) {
-    return { ...baseOptions, srcGlob: `${srcBasename}/**`, dest: join(dest, srcBasename) }
-  }
-
-  return baseOptions
+  const files = await fs.readdir(src, {
+    recursive: true,
+    withFileTypes: true,
+  })
+  return files.some((entry) => !entry.isDirectory() && isNotJunk(entry.name))
 }
 
 const getStat = async (src: string): Promise<Stats | undefined> => {

--- a/packages/cache-utils/src/fs.ts
+++ b/packages/cache-utils/src/fs.ts
@@ -20,7 +20,12 @@ export const moveCacheFile = async function (src: string, dest: string, move = f
     return
   }
 
-  await fs.cp(src, dest, { recursive: true, force: false, errorOnExist: false })
+  await fs.cp(src, dest, {
+    recursive: true,
+    force: false,
+    errorOnExist: false,
+    filter: (source) => isNotJunk(basename(source)),
+  })
 }
 
 /**


### PR DESCRIPTION
This switches from globby/cpy/etc to using the built-in `node:fs` functions.

We can use `fs.cp` to recursively copy, and `fs.readdir` to recursively read, so we no longer need dependencies to do this.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
