### PR TITLE
ci: add e18e GitHub action

### DIFF
--- a/.github/workflows/analyze-e18e.yml
+++ b/.github/workflows/analyze-e18e.yml
@@ -1,0 +1,28 @@
+name: Analyze Dependencies (e18e)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+
+jobs:
+  diff_dependencies:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Analyze Dependencies
+        id: analyze
+        uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc
+        with:
+          mode: artifact
+          duplicate-threshold: -1
+      - name: Upload Artifact
+        if: steps.analyze.outputs.artifact-path
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: e18e-diff-result
+          path: ${{ steps.analyze.outputs.artifact-path }}

--- a/.github/workflows/report-e18e.yml
+++ b/.github/workflows/report-e18e.yml
@@ -1,0 +1,27 @@
+name: Report Dependency Analysis (e18e)
+
+on:
+  workflow_run:
+    workflows: ['Analyze Dependencies (e18e)']
+    types:
+      - completed
+
+jobs:
+  post_comment:
+    runs-on: ubuntu-24.04
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: e18e-diff-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post Comment
+        uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc
+        with:
+          mode: comment-from-artifact
+          artifact-path: e18e-diff-result.json


### PR DESCRIPTION
This adds the e18e action which scans PRs for changes in dependencies and flags the following:

- Significant increase in size
- Significant increase in dependency count
- Change in trust levels
- Dependencies introduced which have recommended replacements or are redundant


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
