### PR TITLE
ci: fix new analyze deps workflow config

### DIFF
--- a/.github/workflows/analyze-e18e.yml
+++ b/.github/workflows/analyze-e18e.yml
@@ -19,7 +19,7 @@ jobs:
         uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc
         with:
           mode: artifact
-          duplicate-threshold: -1
+          duplicate-threshold: 999 # disable, would be too noisy here 😬
       - name: Upload Artifact
         if: steps.analyze.outputs.artifact-path
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
#### Summary

Follow-up to https://github.com/netlify/build/pull/7108

This was configured backwards. It's failing because it's trying to report eeeverything and it won't even fit in a GitHub comment 😶: https://github.com/netlify/build/actions/runs/28198477018/job/83531481380.