### PR TITLE
fix: pin DENO_VERSION_RANGE to not use 2.9.0 which introduced compatibility issue with our bootstrap

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,7 +52,7 @@ jobs:
         node-version: ['24']
         # Maximum supported deno version from the `DENO_VERSION_RANGE` constant in `node/bridge.ts`.
         # If there is no upper band - this should be set to whatever is the latest deno version at the time of updating this workflow.
-        deno-version: ['v2.8.0']
+        deno-version: ['v2.8.2']
         # We test on the oldest supported Node.js + Deno versions, but only on Linux
         include:
           - os: ubuntu-24.04

--- a/packages/edge-bundler/node/bridge.ts
+++ b/packages/edge-bundler/node/bridge.ts
@@ -19,7 +19,7 @@ export const LEGACY_DENO_VERSION_RANGE = '1.39.0 - 2.2.4'
 // When updating DENO_VERSION_RANGE, ensure that the deno version
 // on the netlify/buildbot build image satisfies this range!
 // https://github.com/netlify/buildbot/blob/f9c03c9dcb091d6570e9d0778381560d469e78ad/build-image/noble/Dockerfile#L410
-export const DENO_VERSION_RANGE = '^2.4.2'
+export const DENO_VERSION_RANGE = '2.4.2 - 2.8.2'
 
 export type OnBeforeDownloadHook = () => void | Promise<void>
 export type OnAfterDownloadHook = (error?: Error) => void | Promise<void>


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Recent Deno version released introduced compatbility issue with our edge functions bootstrap. Until that is resolved, we should not use the latest version.

Reproduction of the issue: https://github.com/teemingc/netlify-dev-edge-issue

Changes in Deno 2.9.0 made some nodejs builtin being loaded lazily, they do rely on some functionality that we are patching to explicitly disallow because it's not compatible with our EF runtime. Timing change seems to inverted the order causing now the deno internals themselve fall into not allowed FS methods

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
