### PR TITLE
fix: make edge-bundler tars deterministic

### DIFF
--- a/packages/edge-bundler/node/bundler.test.ts
+++ b/packages/edge-bundler/node/bundler.test.ts
@@ -816,6 +816,51 @@ describe.skipIf(lt(denoVersion, '2.4.2'))(
       await cleanup()
     })
 
+    test('Produces byte-identical tarballs when bundling the same code twice', async () => {
+      const { basePath, cleanup, distPath } = await useFixture('imports_node_builtin', { copyDirectory: true })
+      const declarations: Declaration[] = [
+        {
+          function: 'func1',
+          path: '/func1',
+        },
+      ]
+
+      // Bundle the same code into two separate dist directories, one after the other.
+      const secondDist = await tmp.dir({ unsafeCleanup: true })
+      const secondDistPath = join(secondDist.path, '.netlify', 'edge-functions-dist')
+
+      const bundleTarball = async (dist: string) => {
+        await bundle([join(basePath, 'netlify/edge-functions')], dist, declarations, {
+          basePath,
+          configPath: join(basePath, '.netlify/edge-functions/config.json'),
+          featureFlags: {
+            edge_bundler_generate_tarball: true,
+          },
+        })
+
+        const manifest = JSON.parse(await readFile(resolve(dist, 'manifest.json'), 'utf8'))
+
+        return join(dist, manifest.bundles[0].asset)
+      }
+
+      const firstTarballPath = await bundleTarball(distPath)
+
+      // Wait long enough to cross a whole-second boundary. tar stores mtime at
+      // second resolution, so without the mtime-normalisation fix the second
+      // bundle's freshly written files would carry a different mtime and the two
+      // tarballs would diverge. With the fix, mtime is omitted and they match.
+      await new Promise((done) => setTimeout(done, 1_500))
+
+      const secondTarballPath = await bundleTarball(secondDistPath)
+
+      const [firstTarball, secondTarball] = await Promise.all([readFile(firstTarballPath), readFile(secondTarballPath)])
+
+      // The two tarballs must be byte-for-byte identical for reproducible builds.
+      expect(firstTarball.equals(secondTarball)).toBe(true)
+
+      await Promise.all([cleanup(), secondDist.cleanup()])
+    })
+
     test('Using npm and remote modules', async () => {
       const systemLogger = vi.fn()
       const { basePath, cleanup, distPath } = await useFixture('imports_npm_module', { copyDirectory: true })

--- a/packages/edge-bundler/node/formats/tarball.ts
+++ b/packages/edge-bundler/node/formats/tarball.ts
@@ -203,6 +203,9 @@ export const bundle = async ({
         file: tarballPath,
         gzip: true,
         noDirRecurse: true,
+        // Omit metadata that can vary across platforms and runs, to ensure reproducible tarballs.
+        portable: true, // omit uid/gid/uname/gname/ctime/atime
+        noMtime: true, // omit mtime
         // Ensure forward slashes inside the tarball for cross-platform consistency.
         onWriteEntry(entry) {
           entry.path = getUnixPath(entry.path)


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Tarballs we generate for edge bundles are currently not fully deterministic due to `ctime`/`mtime`/`atime` being included in the tarball.

We are generating and writing some files (manifest, possibly rewriting import assertions) as part of tarball bundling which means each bundling generate some fresh files which breaks determinism of produced bundles.

This removes those attributes from being involved and allow for reuse of bundles if the actual code or metadata did not change

Added test to check this (produce bundle twice with short sleep in-between to ensure bundling doesn't happen in the same "second" which would _happen_ to produce same bundles today without the changes) which fails with code as-is ([example](https://github.com/netlify/build/actions/runs/28595591233/job/84790035768?pr=7118#step:10:854)) and passes with adjustments in second commit

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
