### PR TITLE
feat: add nub package manager detection

### DIFF
--- a/packages/build-info/src/package-managers/detect-package-manager.test.ts
+++ b/packages/build-info/src/package-managers/detect-package-manager.test.ts
@@ -80,7 +80,7 @@ test('should fallback to npm if just a package.json is present there', async ({ 
   expect(pkgManager?.name).toBe('npm')
 })
 
-describe.each([{ pm: 'npm' }, { pm: 'yarn' }, { pm: 'pnpm' }, { pm: 'bun' }])(
+describe.each([{ pm: 'npm' }, { pm: 'yarn' }, { pm: 'pnpm' }, { pm: 'bun' }, { pm: 'nub' }])(
   'should fallback to user agent if present',
   ({ pm }) => {
     test(`fallback ${pm}`, async ({ fs }) => {
@@ -133,6 +133,16 @@ test('should use bun if there is a bun.lock in the root', async ({ fs }) => {
   const project = new Project(fs, cwd)
   const pkgManager = await detectPackageManager(project)
   expect(pkgManager?.name).toBe('bun')
+})
+
+test('should use nub if there is a nub.lock in the root', async ({ fs }) => {
+  const cwd = mockFileSystem({
+    'package.json': '{}',
+    'nub.lock': '',
+  })
+  const project = new Project(fs, cwd)
+  const pkgManager = await detectPackageManager(project)
+  expect(pkgManager?.name).toBe('nub')
 })
 
 test('should use the `packageManager` property to detect yarn', async ({ fs }) => {

--- a/packages/build-info/src/package-managers/detect-package-manager.ts
+++ b/packages/build-info/src/package-managers/detect-package-manager.ts
@@ -12,6 +12,7 @@ export const enum PkgManager {
   YARN = 'yarn',
   PNPM = 'pnpm',
   BUN = 'bun',
+  NUB = 'nub',
   NPM = 'npm',
 }
 
@@ -73,6 +74,14 @@ export const AVAILABLE_PACKAGE_MANAGERS: Record<PkgManager, PkgManagerFields> = 
     remotePackageCommand: ['bunx'],
     lockFiles: ['bun.lockb', 'bun.lock'],
   },
+  [PkgManager.NUB]: {
+    name: PkgManager.NUB,
+    installCommand: 'nub install',
+    runCommand: 'nub run',
+    localPackageCommand: 'nubx',
+    remotePackageCommand: ['nubx'],
+    lockFiles: ['nub.lock'],
+  },
 }
 
 /**
@@ -102,6 +111,10 @@ export function sniffUserAgent(project: Project): PkgManager | undefined {
 
   if (userAgent.includes('bun')) {
     return PkgManager.BUN
+  }
+
+  if (userAgent.includes('nub')) {
+    return PkgManager.NUB
   }
 
   // npm should come last as it is included in the user agent strings of other package managers


### PR DESCRIPTION
Adds detection for [nub](https://github.com/nubjs/nub), a package manager whose native lockfile is `nub.lock` (pnpm-v9-compatible lockfile format).

## What changed

- Registers a `nub` entry in `AVAILABLE_PACKAGE_MANAGERS` (`@netlify/build-info`), mirroring the existing bun entry: `installCommand: 'nub install'`, `runCommand: 'nub run'`, `localPackageCommand`/`remotePackageCommand: 'nubx'`, `lockFiles: ['nub.lock']`.
- Adds `NUB` to the `PkgManager` enum and a `nub` branch to `sniffUserAgent`.
- Tests: a `nub.lock` root-detection case plus the `nub` user-agent variant in the existing parametrized suite.

Purely additive — no existing package manager's entry or behavior changes.

Verified with `npm run build` and `vitest run` in `packages/build-info` (all green); `oxfmt --check` and `eslint` clean on the touched files.
