### PR TITLE
fix: skip directory imports when generating edge function tarballs

### DIFF
--- a/packages/edge-bundler/node/bundler.test.ts
+++ b/packages/edge-bundler/node/bundler.test.ts
@@ -1358,6 +1358,60 @@ describe.skipIf(lt(denoVersion, '2.4.2'))(
       await cleanup()
     })
 
+    test('Importing a directory when caught is handled', async () => {
+      // Importing a directory is unsupported in Deno, but `deno info` still lists
+      // the directory as an errored module reachable via a runtime (code) edge,
+      // so it lands in the set of source files to bundle. Tarball generation used
+      // to throw EISDIR when copying the directory; it must skip it instead.
+      const systemLogger = vi.fn()
+      const { basePath, cleanup, distPath } = await useFixture('caught-directory-import', {
+        copyDirectory: true,
+      })
+      const declarations: Declaration[] = [
+        {
+          function: 'func1',
+          path: '/func1',
+        },
+      ]
+
+      await bundle([join(basePath, 'netlify/edge-functions')], distPath, declarations, {
+        basePath,
+        featureFlags: {
+          edge_bundler_generate_tarball: true,
+        },
+        systemLogger,
+      })
+
+      const expectedOutput = {
+        func1: 'ok',
+      }
+
+      const manifestFile = await readFile(resolve(distPath, 'manifest.json'), 'utf8')
+      const manifest = JSON.parse(manifestFile)
+
+      const tarballPath = join(distPath, manifest.bundles[0].asset)
+      const tarballResult = await runTarball(tarballPath)
+      expect(tarballResult).toStrictEqual(expectedOutput)
+
+      const entries: string[] = []
+      await tar.list({
+        file: tarballPath,
+        onReadEntry: (entry) => {
+          entries.push(entry.path)
+        },
+      })
+
+      // The directory itself must not be present as an entry in the tarball.
+      expect(entries).toContain('./func1.ts')
+      expect(entries.some((entry) => entry === './models' || entry === './models/')).toBe(false)
+
+      const eszipPath = join(distPath, manifest.bundles[1].asset)
+      const eszipResult = await runESZIP(eszipPath)
+      expect(eszipResult).toStrictEqual(expectedOutput)
+
+      await cleanup()
+    })
+
     test('Importing a remote module that imports a WebAssembly binary (deno_dom)', async () => {
       // Deno <2.6 vendors `.wasm` imports under a `.d.mts` extension even though
       // the content is the raw WASM binary. The rewriter must detect this by

--- a/packages/edge-bundler/node/formats/tarball.test.ts
+++ b/packages/edge-bundler/node/formats/tarball.test.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { rewriteImportAssertions } from './tarball.js'
+
+describe('rewriteImportAssertions', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await fs.mkdtemp(join(tmpdir(), 'edge-bundler-tarball-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(workDir, { recursive: true, force: true })
+  })
+
+  test('rewrites import assertions in a source file', async () => {
+    const sourceFile = join(workDir, 'source.ts')
+    const destFile = join(workDir, 'dest.ts')
+    await fs.writeFile(sourceFile, `import data from './data.json' assert { type: 'json' };\n`)
+
+    await rewriteImportAssertions(sourceFile, destFile)
+
+    expect(await fs.readFile(destFile, 'utf-8')).toBe(`import data from './data.json' with { type: 'json' };\n`)
+  })
+
+  test('copies a file without rewritable extension verbatim', async () => {
+    const sourceFile = join(workDir, 'data.json')
+    const destFile = join(workDir, 'dest.json')
+    await fs.writeFile(sourceFile, `{ "assert": true }`)
+
+    await rewriteImportAssertions(sourceFile, destFile)
+
+    expect(await fs.readFile(destFile, 'utf-8')).toBe(`{ "assert": true }`)
+  })
+
+  // `deno info` can report a directory as a module specifier when source code
+  // imports a directory (e.g. `import x from './models'`). Copying or reading a
+  // directory throws EISDIR, which used to abort tarball generation.
+  test('skips a directory instead of throwing EISDIR', async () => {
+    const sourceDir = join(workDir, 'models')
+    const destDir = join(workDir, 'dest-models')
+    await fs.mkdir(sourceDir)
+
+    await expect(rewriteImportAssertions(sourceDir, destDir)).resolves.toBeUndefined()
+
+    // Nothing should have been written for the directory.
+    await expect(fs.stat(destDir)).rejects.toThrow()
+  })
+})

--- a/packages/edge-bundler/node/formats/tarball.ts
+++ b/packages/edge-bundler/node/formats/tarball.ts
@@ -276,6 +276,8 @@ async function getRequiredSourceFiles(
         continue
       }
 
+      const filePath = fileURLToPath(module.specifier)
+
       if (module.error) {
         // A module reachable only through type-only edges (e.g. a directory specifier
         // behind `import type`) can fail to resolve as an ES module. That's safe to
@@ -290,13 +292,34 @@ async function getRequiredSourceFiles(
           // require in try/catch).
           continue
         }
+
+        // Importing a directory is unsupported in Deno (ERR_UNSUPPORTED_DIR_IMPORT), yet
+        // the directory still surfaces here as an errored module. It's not a bundleable
+        // file: including it would pollute the common path prefix and, once copied, throw
+        // EISDIR. Skip it.
+        if (await isDirectory(filePath)) {
+          continue
+        }
       }
 
-      localFiles.add(fileURLToPath(module.specifier))
+      localFiles.add(filePath)
     }
   }
 
   return localFiles
+}
+
+/**
+ * Returns whether the given path exists and is a directory. Used to filter out
+ * directory specifiers that Deno surfaces as errored modules (directory imports
+ * are unsupported) so they're never treated as bundleable source files.
+ */
+async function isDirectory(entryPath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(entryPath)).isDirectory()
+  } catch {
+    return false
+  }
 }
 
 // WebAssembly binary magic bytes: `\0asm` (0x00 0x61 0x73 0x6d).
@@ -342,6 +365,13 @@ async function shouldRewrite(sourceFile: string): Promise<boolean> {
  * Defaults to copying the file in its current form
  */
 export async function rewriteImportAssertions(sourceFile: string, destPath: string): Promise<void> {
+  // Defensive guard: a directory has nothing to bundle, and copying/reading one
+  // throws EISDIR. `getRequiredSourceFiles` already filters directory specifiers
+  // out of the source set, so this only matters if one slips through.
+  if (await isDirectory(sourceFile)) {
+    return
+  }
+
   if (!(await shouldRewrite(sourceFile))) {
     if (sourceFile !== destPath) {
       await fs.copyFile(sourceFile, destPath)

--- a/packages/edge-bundler/test/fixtures/caught-directory-import/models/index.ts
+++ b/packages/edge-bundler/test/fixtures/caught-directory-import/models/index.ts
@@ -1,0 +1,4 @@
+// A regular file inside the imported directory. Its presence ensures the
+// directory exists on disk so it surfaces in the module graph as a directory
+// specifier rather than a "module not found".
+export const model = 'model'

--- a/packages/edge-bundler/test/fixtures/caught-directory-import/netlify/edge-functions/func1.ts
+++ b/packages/edge-bundler/test/fixtures/caught-directory-import/netlify/edge-functions/func1.ts
@@ -1,0 +1,18 @@
+// Importing a directory is unsupported in Deno (ERR_UNSUPPORTED_DIR_IMPORT).
+// `deno info` still reports the directory as an errored module reachable via a
+// runtime (code) edge, so it can end up in the list of source files to bundle.
+// Because it's caught, eszip bundling succeeds, but tarball generation used to
+// throw EISDIR when copying the directory. Guard against that.
+try {
+  await import('../../models')
+} catch (error) {
+  console.error('Error importing directory but we continue anyway:', error)
+}
+
+export default function Handler() {
+  return new Response('ok')
+}
+
+export const config = {
+  path: '/*',
+}


### PR DESCRIPTION
#### Summary

Deno reports an imported directory `ERR_UNSUPPORTED_DIR_IMPORT` as an errored module reachable through a runtime code edge, so it slipped past the type-only and module-not-found filters and into the source file set

It then pollutes the common path prefix and throws `EISDIR` when copied, aborting tarball generation even though eszip bundling succeeds

Filter directory specifiers out of the required source files, and guard the copy path defensively so a stray directory can never crash bundling