### PR TITLE
feat: trigger no-op releases with NPM Trusted Publishing

### DIFF
--- a/packages/build-info/README.md
+++ b/packages/build-info/README.md
@@ -48,5 +48,5 @@ $ build-info path/to/site --rootDir /project/root/dir
 
 ## Contributors
 
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks
-for contributing!
+Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks for
+contributing!

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -1,0 +1,12 @@
+# Netlify Build
+
+`@netlify/build` implements the core of Netlify's procedures for preparing a project for deployment or local preview. It
+is used under the hood by [Netlify CLI](https://developers.netlify.com/cli/) and
+[continuous deployment on the Netlify platform](https://docs.netlify.com/deploy/create-deploys/#deploy-with-git).
+
+You almost certainly do not need to depend on this package directly.
+
+## Contributors
+
+Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks for
+contributing!

--- a/packages/cache-utils/README.md
+++ b/packages/cache-utils/README.md
@@ -1,7 +1,7 @@
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
-Utility for caching files in Netlify Build.
+Utility for caching files in Netlify Build
 
 # Examples
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -364,6 +364,6 @@ Site's environment variables. Each environment variable value is an object with 
 netlify-config
 ```
 
-Like [`resolveConfig()`](resolveconfig), but in the CLI. The return value is printed on `stdout`.
+Like [`resolveConfig()`](resolveconfig), but in the CLI. The return value is printed as JSON on `stdout`.
 
 The CLI flags use the same options.

--- a/packages/edge-bundler/README.md
+++ b/packages/edge-bundler/README.md
@@ -3,7 +3,7 @@
 
 # Edge Bundler
 
-Intelligently prepare Netlify Edge Functions for deployment.
+Prepare Netlify Edge Functions for deployment
 
 ## Usage
 
@@ -46,5 +46,5 @@ This will go away soon as we move away from the ESZIP format.
 
 ## Contributors
 
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks
-for contributing!
+Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks for
+contributing!

--- a/packages/functions-utils/README.md
+++ b/packages/functions-utils/README.md
@@ -1,7 +1,7 @@
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
-Utility for handling Netlify Functions in Netlify Build plugins.
+Utility for handling Netlify Functions in Netlify Build plugins
 
 This allows plugins to:
 

--- a/packages/git-utils/README.md
+++ b/packages/git-utils/README.md
@@ -79,4 +79,4 @@ export const onPreBuild = function ({ utils }) {
 
 ## Prior art
 
-This was originally found in [danger.js](https://danger.systems/js/) and extracted into this utility
+This was originally found in [danger.js](https://danger.systems/js/) and extracted into this utility.

--- a/packages/headers-parser/README.md
+++ b/packages/headers-parser/README.md
@@ -1,3 +1,3 @@
 # Netlify Headers Parser
 
-Parses headers rules from both `_headers` and `netlify.toml` and normalizes them to an array of objects.
+Parses headers rules from both `_headers` and `netlify.toml` and normalizes them to an array of objects

--- a/packages/js-client/README.md
+++ b/packages/js-client/README.md
@@ -1,4 +1,6 @@
-A Netlify [OpenAPI](https://github.com/netlify/open-api) client that works in the browser and Node.js.
+# `@netlify/api`
+
+A Netlify [OpenAPI](https://github.com/netlify/open-api) client that works in the browser and Node.js
 
 ## Usage
 

--- a/packages/nock-udp/README.md
+++ b/packages/nock-udp/README.md
@@ -1,7 +1,8 @@
 # Nock UDP
 
-Mock outgoing UDP requests. Useful for testing purposes mostly. Based on
-[node-mock-udp](https://github.com/mattrobenolt/node-mock-udp).
+Mock outgoing UDP requests. Useful for testing purposes mostly.
+
+Based on [node-mock-udp](https://github.com/mattrobenolt/node-mock-udp).
 
 ## Install
 
@@ -71,5 +72,5 @@ console.log(isMocked())
 
 ## Contributors
 
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks
-for contributing!
+Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for instructions on how to set up and work on this repository. Thanks for
+contributing!

--- a/packages/opentelemetry-sdk-setup/README.md
+++ b/packages/opentelemetry-sdk-setup/README.md
@@ -1,8 +1,8 @@
 # Opentelemetry SDK Setup
 
-This package extracts the logic necessary to initialise the Opentelemetry JS SDK using our tracing exporter. This not
+This package extracts the logic necessary to initialise the OpenTelemetry JS SDK using our tracing exporter. This not
 only allows us to reuse the initialisation logic across different node process executions but also means **our modules
-don't need to depend on any @opentelemetry module other than the @opentelemetry/api**
+don't need to depend on any `@opentelemetry` module other than the `@opentelemetry/api`**.
 
 ## How to use it?
 

--- a/packages/opentelemetry-utils/README.md
+++ b/packages/opentelemetry-utils/README.md
@@ -1,4 +1,4 @@
-# Opentelemetry Utils
+# OpenTelemetry Utils
 
 This package extracts utility methods to interact with open telemetry across our JS packages. It's a thin wrapper around
 the OTEL API and is built strictly so that no other `@opentelemetry` dependency is **required besides

--- a/packages/redirect-parser/README.md
+++ b/packages/redirect-parser/README.md
@@ -1,6 +1,6 @@
 # Netlify Redirect Parser
 
-Parses redirect rules from both `_redirects` and `netlify.toml` and normalizes them to an array of objects.
+Parses redirect rules from both `_redirects` and `netlify.toml` and normalizes them to an array of objects
 
 For most users, you are not meant to use this directly, please refer to https://github.com/netlify/cli instead. However
 if you are debugging issues with redirect parsing, issues and PRs are welcome.

--- a/packages/run-utils/README.md
+++ b/packages/run-utils/README.md
@@ -1,8 +1,10 @@
 [![Coverage Status](https://codecov.io/gh/netlify/build/branch/main/graph/badge.svg)](https://codecov.io/gh/netlify/build)
 [![Build](https://github.com/netlify/build/workflows/Build/badge.svg)](https://github.com/netlify/build/actions)
 
-Utility for running commands inside Netlify Build. Currently, there is just one utility, `run`, which is a thin wrapper
-over `execa` defaulting to `{ preferLocal: true, stdio: 'inherit' }`.
+Utility for running commands inside Netlify Build
+
+Currently, there is just one utility, `run`, which is a thin wrapper over `execa` defaulting to
+`{ preferLocal: true, stdio: 'inherit' }`.
 
 # Examples
 

--- a/packages/zip-it-and-ship-it/README.md
+++ b/packages/zip-it-and-ship-it/README.md
@@ -5,7 +5,8 @@
 [![Build](https://github.com/netlify/zip-it-and-ship-it/workflows/Build/badge.svg)](https://github.com/netlify/zip-it-and-ship-it/actions)
 [![Downloads](https://img.shields.io/npm/dm/@netlify/zip-it-and-ship-it.svg)](https://www.npmjs.com/package/@netlify/zip-it-and-ship-it)
 
-Creates Zip archives from Node.js, Go, and Rust programs. Those archives are ready to be uploaded to AWS Lambda.
+Creates Zip archives from Netlify Functions written in Node.js, Go, or Rust. Those archives are ready to be uploaded to
+AWS Lambda.
 
 This library is used under the hood by several Netlify features, including
 [production CI builds](https://github.com/netlify/build), [Netlify CLI](https://github.com/netlify/cli) and the
@@ -493,8 +494,3 @@ In Netlify, this is done by ensuring that the following Node.js versions are the
 Note that this problem might not apply for Node.js native modules using the [N-API](https://nodejs.org/api/n-api.html).
 
 More information in [this issue](https://github.com/netlify/zip-it-and-ship-it/issues/69).
-
-## File Serving
-
-As of `v0.3.0` the `serveFunctions` capability has been extracted out to
-[Netlify Dev](https://github.com/netlify/netlify-dev-plugin/).


### PR DESCRIPTION
#### Summary

This makes one no-op change in each package, to force a first release with Trusted Publishing, configured in https://github.com/netlify/build/pull/7061.