### PR TITLE
feat(edge-bundler): exclude unrouted functions from the bundle

### DIFF
--- a/packages/build/src/plugins_core/edge_functions/index.ts
+++ b/packages/build/src/plugins_core/edge_functions/index.ts
@@ -137,6 +137,15 @@ const coreStep = async function ({
       bootstrapURL: edgeFunctionsBootstrapURL,
       vendorDirectory,
     })
+
+    // Edge Bundler produces no manifest when there is nothing to deploy - no
+    // edge function has a route - in which case there is nothing more to do.
+    if (manifest === undefined) {
+      systemLog('No edge function has a route; skipping manifest generation.')
+
+      return {}
+    }
+
     const metrics = getMetrics(manifest)
 
     systemLog('Edge Functions manifest:', manifest)

--- a/packages/edge-bundler/node/bundler.test.ts
+++ b/packages/edge-bundler/node/bundler.test.ts
@@ -15,6 +15,7 @@ import { denoVersion, runESZIP, runTarball, useFixture } from '../test/util.js'
 import { BundleError } from './bundle_error.js'
 import { bundle, BundleOptions } from './bundler.js'
 import { Declaration } from './declaration.js'
+import type { Manifest } from './manifest.js'
 import { isFileNotFoundError } from './utils/error.js'
 import { validateManifest } from './validation/manifest/index.js'
 
@@ -55,6 +56,74 @@ test('Produces an ESZIP bundle', async () => {
   expect(func1).toBe('HELLO, JANE DOE!')
   expect(func2).toBe('Jane Doe')
   expect(func3).toBe('hello, netlify!')
+
+  await cleanup()
+})
+
+test('Excludes functions with no route from the bundle when `edge_bundler_exclude_unrouted_functions` is enabled', async () => {
+  const { basePath, cleanup, distPath } = await useFixture('with_import_maps')
+  // Only `func1` is routed. `func2` and `func3` have no declaration, so they
+  // should be left out of the bundle rather than eagerly loaded.
+  const declarations: Declaration[] = [
+    {
+      function: 'func1',
+      path: '/func1',
+    },
+  ]
+  const userDirectory = join(basePath, 'user-functions')
+  const internalDirectory = join(basePath, 'functions')
+  const result = await bundle([userDirectory, internalDirectory], distPath, declarations, {
+    basePath,
+    configPath: join(internalDirectory, 'config.json'),
+    importMapPaths: [join(userDirectory, 'import_map.json')],
+    featureFlags: { edge_bundler_exclude_unrouted_functions: true },
+  })
+
+  // The full set of discovered functions is still returned and reflected in the
+  // manifest's `function_config`; only the bundle contents are trimmed.
+  expect(result.functions.length).toBe(3)
+
+  const manifestFile = await readFile(resolve(distPath, 'manifest.json'), 'utf8')
+  const manifest = JSON.parse(manifestFile) as Manifest
+  expect(() => validateManifest(manifest)).not.toThrowError()
+  expect(manifest.routes.map((route) => route.function)).toEqual(['func1'])
+
+  const bundlePath = join(distPath, manifest.bundles[0].asset)
+  const bundledFunctions = await runESZIP(bundlePath)
+
+  expect(Object.keys(bundledFunctions)).toEqual(['func1'])
+  expect(bundledFunctions.func1).toBe('HELLO, JANE DOE!')
+  expect(bundledFunctions.func2).toBeUndefined()
+  expect(bundledFunctions.func3).toBeUndefined()
+
+  await cleanup()
+})
+
+test('Produces no bundle or manifest when no function has a route and `edge_bundler_exclude_unrouted_functions` is enabled', async () => {
+  const { basePath, cleanup, distPath } = await useFixture('with_import_maps')
+  const userDirectory = join(basePath, 'user-functions')
+  const internalDirectory = join(basePath, 'functions')
+
+  // No declarations at all, so every function is unrouted. There is nothing that
+  // can ever be invoked, so there is nothing to deploy: we produce no manifest,
+  // rather than one with no bundle. The deploy pipeline reads a bundle-less
+  // manifest as the deprecated JS format and can reject it, whereas a missing
+  // manifest is the same well-handled path as a site with no edge functions.
+  const result = await bundle([userDirectory, internalDirectory], distPath, [], {
+    basePath,
+    configPath: join(internalDirectory, 'config.json'),
+    importMapPaths: [join(userDirectory, 'import_map.json')],
+    featureFlags: {
+      edge_bundler_exclude_unrouted_functions: true,
+      edge_bundler_generate_tarball: true,
+    },
+  })
+
+  // The full set of discovered functions is still returned, but no manifest is.
+  expect(result.functions.length).toBe(3)
+  expect(result.manifest).toBeUndefined()
+
+  await expect(access(resolve(distPath, 'manifest.json'))).rejects.toThrowError()
 
   await cleanup()
 })
@@ -1112,7 +1181,7 @@ describe.skipIf(lt(denoVersion, '2.4.2'))(
         const { bundle: bundleUnderTest } = await import('./bundler.js')
 
         const { basePath, cleanup, distPath } = await useFixture('imports_node_builtin', { copyDirectory: true })
-        const sourceDirectory = join(basePath, 'functions')
+        const sourceDirectory = join(basePath, 'netlify/edge-functions')
         const declarations: Declaration[] = [
           {
             function: 'func1',
@@ -1123,7 +1192,7 @@ describe.skipIf(lt(denoVersion, '2.4.2'))(
         await expect(
           bundleUnderTest([sourceDirectory], distPath, declarations, {
             basePath,
-            configPath: join(sourceDirectory, 'config.json'),
+            configPath: join(basePath, '.netlify/edge-functions/config.json'),
             featureFlags: {
               edge_bundler_dry_run_generate_tarball: true,
               edge_bundler_generate_tarball: false,

--- a/packages/edge-bundler/node/bundler.ts
+++ b/packages/edge-bundler/node/bundler.ts
@@ -127,6 +127,99 @@ export const bundle = async (
     importMap.add(vendor.importMap)
   }
 
+  // Extracts the in-source configuration for each function and derives the
+  // manifest's function config and routes from it.
+  const computeManifestData = async (log: Logger) => {
+    const { internalFunctions: internalFunctionsWithConfig, userFunctions: userFunctionsWithConfig } =
+      await getFunctionConfigs({
+        deno,
+        importMap,
+        internalFunctions,
+        log,
+        userFunctions,
+      })
+
+    // Creating a final declarations array by combining the TOML file with the
+    // deploy configuration API and the in-source configuration.
+    const declarations = mergeDeclarations(
+      tomlDeclarations,
+      userFunctionsWithConfig,
+      internalFunctionsWithConfig,
+      deployConfig.declarations,
+      featureFlags,
+    )
+
+    const internalFunctionConfig = createFunctionConfig({
+      internalFunctionsWithConfig,
+      declarations,
+    })
+
+    const manifestFunctionConfig = generateManifestFunctionConfig({
+      functions,
+      internalFunctionConfig,
+      userFunctionConfig: userFunctionsWithConfig,
+    })
+
+    const manifestRoutes = generateManifestRoutes({
+      functions,
+      declarations,
+    })
+
+    return { manifestFunctionConfig, manifestRoutes }
+  }
+
+  const excludeUnroutedFunctions = Boolean(featureFlags.edge_bundler_exclude_unrouted_functions)
+
+  // Excluding unrouted functions is the only reason to extract the config
+  // before bundling - we need the routes to know what to leave out. When we're
+  // not, we keep extracting it after bundling, as we always have, so that the
+  // extra Deno subprocess never runs ahead of the bundle and can't change what
+  // a build failure looks like.
+  //
+  // Config extraction reports the underlying failure to the user before it
+  // throws. When it runs up front we may end up discarding that error in favour
+  // of a bundling error (see below), and printing the detail of an error we
+  // then discard is just noise - so on that path we hold those logs back and
+  // only flush them if we do surface the config error.
+  const heldUserLogs: unknown[][] = []
+  const configLogger: Logger = {
+    system: logger.system,
+    user: (...args: unknown[]) => {
+      heldUserLogs.push(args)
+    },
+  }
+  const manifestDataPromise = excludeUnroutedFunctions ? computeManifestData(configLogger) : undefined
+
+  // A function with no route is never invoked, so bundling it only serves to
+  // eagerly load code that can never run - which can surface import-time
+  // failures. The manifest is still generated from the full set of functions,
+  // but its routes exclude unrouted functions by definition. If config
+  // extraction failed, we have no routes to go on, so we bundle everything and
+  // let bundling report the failure.
+  const routes = manifestDataPromise ? (await manifestDataPromise.catch(() => undefined))?.manifestRoutes : undefined
+  const bundledFunctions =
+    excludeUnroutedFunctions && routes
+      ? functions.filter(({ name }) => !routes.unroutedFunctions.includes(name))
+      : functions
+
+  // With nothing to bundle there is no code that can ever be invoked, so we
+  // produce neither a bundle nor a manifest. The deploy pipeline treats a
+  // manifest that exists but carries no ESZIP bundle as the deprecated JS format
+  // and can reject the deploy, so a missing manifest - the same path as a site
+  // with no edge functions at all - is safer than an empty one.
+  if (bundledFunctions.length === 0) {
+    // Config extraction may have produced function output that we were holding
+    // back; surface it before returning.
+    heldUserLogs.forEach((args) => {
+      logger.user(...args)
+    })
+    logger.system('Skipping bundling because no edge function has a route.')
+
+    await vendor?.cleanup()
+
+    return { functions, manifest: undefined }
+  }
+
   const bundles: Bundle[] = []
   let tarballBundleDurationMs: number | undefined
   let tarballDryRunError: unknown
@@ -143,7 +236,7 @@ export const bundle = async (
           debug,
           deno,
           distDirectory,
-          functions,
+          functions: bundledFunctions,
           featureFlags,
           importMap: importMap.clone(),
           vendorDirectory: vendor?.directory,
@@ -177,47 +270,31 @@ export const bundle = async (
       deno,
       distDirectory,
       externals,
-      functions,
+      functions: bundledFunctions,
       featureFlags,
       importMap,
       vendorDirectory: vendor?.directory,
     }),
   )
 
-  const { internalFunctions: internalFunctionsWithConfig, userFunctions: userFunctionsWithConfig } =
-    await getFunctionConfigs({
-      deno,
-      importMap,
-      internalFunctions,
-      log: logger,
-      userFunctions,
+  // When we extracted the config up front, bundling didn't fail, so no more
+  // precise error is coming - re-awaiting surfaces the config extraction error
+  // if there was one. When we didn't, we extract it now, after bundling, as we
+  // always have. Either way, we reach this point only once bundling has had its
+  // chance to throw, so any logs we held back are no longer masking a bundling
+  // error and should reach the user: on success they are the function's own
+  // output, on failure the detail of the error we are about to surface.
+  let manifestData: Awaited<ReturnType<typeof computeManifestData>>
+
+  try {
+    manifestData = await (manifestDataPromise ?? computeManifestData(logger))
+  } finally {
+    heldUserLogs.forEach((args) => {
+      logger.user(...args)
     })
+  }
 
-  // Creating a final declarations array by combining the TOML file with the
-  // deploy configuration API and the in-source configuration.
-  const declarations = mergeDeclarations(
-    tomlDeclarations,
-    userFunctionsWithConfig,
-    internalFunctionsWithConfig,
-    deployConfig.declarations,
-    featureFlags,
-  )
-
-  const internalFunctionConfig = createFunctionConfig({
-    internalFunctionsWithConfig,
-    declarations,
-  })
-
-  const manifestFunctionConfig = generateManifestFunctionConfig({
-    functions,
-    internalFunctionConfig,
-    userFunctionConfig: userFunctionsWithConfig,
-  })
-
-  const manifestRoutes = generateManifestRoutes({
-    functions,
-    declarations,
-  })
+  const { manifestFunctionConfig, manifestRoutes } = manifestData
 
   if (!tarballDryRunError && finalizeTarballBundle) {
     try {

--- a/packages/edge-bundler/node/feature_flags.ts
+++ b/packages/edge-bundler/node/feature_flags.ts
@@ -1,6 +1,7 @@
 const defaultFlags = {
   edge_bundler_generate_tarball: false,
   edge_bundler_dry_run_generate_tarball: false,
+  edge_bundler_exclude_unrouted_functions: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags

--- a/packages/edge-bundler/test/fixtures/imports_npm_module_scheme/functions/func1.ts
+++ b/packages/edge-bundler/test/fixtures/imports_npm_module_scheme/functions/func1.ts
@@ -1,1 +1,3 @@
 import pRetry from "npm:p-retry"
+
+export default async () => new Response(typeof pRetry)


### PR DESCRIPTION
#### Summary

Functions with no route are never invoked, but they were still bundled and eagerly loaded, which could surface import-time failures Behind the `edge_bundler_exclude_unrouted_functions` flag, compute routes before bundling and leave unrouted functions out of the tarball and ESZIP

https://linear.app/netlify/issue/FRB-2238/exclude-unconfigured-edge-functions-from-nimble-bundles
