### PR TITLE
fix(build): handle a case when `@netlify/edge-bundler` returns `manifest: undefined`

### DIFF
--- a/packages/build/src/plugins_core/edge_functions/index.ts
+++ b/packages/build/src/plugins_core/edge_functions/index.ts
@@ -137,6 +137,15 @@ const coreStep = async function ({
       bootstrapURL: edgeFunctionsBootstrapURL,
       vendorDirectory,
     })
+
+    // Edge Bundler produces no manifest when there is nothing to deploy - no
+    // edge function has a route - in which case there is nothing more to do.
+    if (manifest === undefined) {
+      systemLog('No edge function has a route; skipping manifest generation.')
+
+      return {}
+    }
+
     const metrics = getMetrics(manifest)
 
     systemLog('Edge Functions manifest:', manifest)


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Split out of https://github.com/netlify/build/pull/7132 so it can be squash merged as a `fix` for `@netlify/build` while the actual bulk of the change remain in original PR and is a breaking change for `@netlify/edge-bundler` so release-please version the packages in correct way (patch for `@netlify/build`, major for `@netlify/edge-bundler`). 

See https://github.com/netlify/build/pull/7132#discussion_r3630067774 for description. While suggestion that rebase merge would work, but release-please would not reference pull requests in changelogs, just individual commits and doing PR split will preserve links to PRs so it's easier to navigate changeskeeping the PR paper trail

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
