### PR TITLE
Security: Unsafe JSON.parse of `angular.json` without Error Handling

### DIFF
--- a/packages/build-info/src/frameworks/angular.ts
+++ b/packages/build-info/src/frameworks/angular.ts
@@ -35,12 +35,16 @@ export class Angular extends BaseFramework implements Framework {
         this.plugins.push('@netlify/angular-runtime')
         const angularJson = await this.project.fs.gracefullyReadFile('angular.json')
         if (angularJson) {
-          const { projects, defaultProject } = JSON.parse(angularJson)
-          const project = projects[defaultProject ?? Object.keys(projects)[0]]
-          const outputPath = project?.architect?.build?.options?.outputPath
-          if (outputPath) {
-            const usesApplicationBuilder = project?.architect?.build?.builder?.endsWith(':application')
-            this.build.directory = usesApplicationBuilder ? this.project.fs.join(outputPath, 'browser') : outputPath
+          try {
+            const { projects, defaultProject } = JSON.parse(angularJson)
+            const project = projects[defaultProject ?? Object.keys(projects)[0]]
+            const outputPath = project?.architect?.build?.options?.outputPath
+            if (outputPath) {
+              const usesApplicationBuilder = project?.architect?.build?.builder?.endsWith(':application')
+              this.build.directory = usesApplicationBuilder ? this.project.fs.join(outputPath, 'browser') : outputPath
+            }
+          } catch {
+            // Ignore malformed angular.json files
           }
         }
       }


### PR DESCRIPTION
## Summary

Security: Unsafe JSON.parse of `angular.json` without Error Handling

## Problem

**Severity**: `Low` | **File**: `packages/build-info/src/frameworks/angular.ts:L38`

In `packages/build-info/src/frameworks/angular.ts`, `JSON.parse(angularJson)` is called without a `try...catch` block. If the `angular.json` file is malformed or contains invalid JSON, this will throw an unhandled `SyntaxError`, crashing the framework detection process for the entire project.

## Solution

Wrap the `JSON.parse` call in a `try...catch` block to gracefully handle malformed `angular.json` files, similar to how other parts of the codebase handle invalid JSON.

## Changes

- `packages/build-info/src/frameworks/angular.ts` (modified)