### PR TITLE
fix(js-client): statically import open-api spec so bundlers can trace it

### DIFF
--- a/packages/js-client/src/open_api.js
+++ b/packages/js-client/src/open_api.js
@@ -1,7 +1,3 @@
-import { createRequire } from 'module'
+import openApiSpec from '@netlify/open-api/dist/swagger.json' with { type: 'json' }
 
-// TODO: remove once Node.js supports JSON imports with pure ES modules without
-// any experimental flags
-const require = createRequire(import.meta.url)
-
-export const openApiSpec = require('@netlify/open-api')
+export { openApiSpec }

--- a/packages/js-client/tsconfig.json
+++ b/packages/js-client/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib" /* Specify an output folder for all emitted files. */
+    "outDir": "lib" /* Specify an output folder for all emitted files. */,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.js", "src/**/*.ts"],
   "exclude": ["src/**/*.test.js", "src/**/*.test.ts"],


### PR DESCRIPTION
Fixes FRB-2321.

Functions using `@netlify/api` currently crash in Lambda with `Cannot find module '@netlify/open-api'`.

This happens because `@vercel/nft` (pinned in `zip-it-and-ship-it`) only recognizes the literal `module.createRequire(...)` pattern and silently skips the named-import `createRequire` variant used here, so the dependency never makes it into the bundle.

This PR replaces the `createRequire`/`require` workaround with a static JSON import using an import attribute. It also imports the concrete `dist/swagger.json` subpath instead of the package root, which lets TypeScript infer the type directly from the JSON instead of using `@netlify/open-api`'s `types` field (which points to the generated OpenAPI types, not the Swagger document).

Verified that the dependency is correctly traced by both `nft 0.29.4` and `esbuild 0.28.1`.