### PR TITLE
fix: remove unused zisi_esbuild_parser feature flag

### DIFF
--- a/packages/build/src/core/feature_flags.ts
+++ b/packages/build/src/core/feature_flags.ts
@@ -16,7 +16,6 @@ const getFeatureFlag = function (name: string): FeatureFlags {
 // Default values for feature flags
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   buildbot_zisi_trace_nft: false,
-  buildbot_zisi_esbuild_parser: false,
   netlify_build_updated_plugin_compatibility: false,
   netlify_build_plugin_system_log: false,
   edge_bundler_generate_tarball: false,

--- a/packages/build/src/plugins_core/functions/feature_flags.ts
+++ b/packages/build/src/plugins_core/functions/feature_flags.ts
@@ -2,6 +2,5 @@ import type { FeatureFlags } from '../../core/feature_flags.js'
 
 export const getZisiFeatureFlags = (featureFlags: FeatureFlags): FeatureFlags => ({
   ...featureFlags,
-  parseWithEsbuild: featureFlags.buildbot_zisi_esbuild_parser,
   traceWithNft: featureFlags.buildbot_zisi_trace_nft,
 })

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -525,26 +525,21 @@ test.serial('Passes the right feature flags to zip-it-and-ship-it', async (t) =>
     .withFlags({ featureFlags: { buildbot_zisi_trace_nft: true } })
     .runWithBuild()
   await new Fixture(test.meta.file, './fixtures/schedule')
-    .withFlags({ featureFlags: { buildbot_zisi_esbuild_parser: true } })
-    .runWithBuild()
-  await new Fixture(test.meta.file, './fixtures/schedule')
     .withFlags({ featureFlags: { this_is_a_mock_flag: true, and_another_one: true } })
     .runWithBuild()
 
   stub.restore()
 
-  t.is(mockZipFunctions.callCount, 4)
+  t.is(mockZipFunctions.callCount, 3)
 
   t.false(mockZipFunctions.calls[0][2].featureFlags.traceWithNft)
-  t.false(mockZipFunctions.calls[0][2].featureFlags.parseWithEsbuild)
   t.is(mockZipFunctions.calls[0][2].config.test.schedule, '@daily')
   t.is(mockZipFunctions.calls[0][2].featureFlags.this_is_a_mock_flag, undefined)
   t.is(mockZipFunctions.calls[0][2].featureFlags.and_another_one, undefined)
 
   t.true(mockZipFunctions.calls[1][2].featureFlags.traceWithNft)
-  t.true(mockZipFunctions.calls[2][2].featureFlags.parseWithEsbuild)
-  t.true(mockZipFunctions.calls[3][2].featureFlags.this_is_a_mock_flag)
-  t.true(mockZipFunctions.calls[3][2].featureFlags.and_another_one)
+  t.true(mockZipFunctions.calls[2][2].featureFlags.this_is_a_mock_flag)
+  t.true(mockZipFunctions.calls[2][2].featureFlags.and_another_one)
 })
 
 test('Print warning on lingering processes', async (t) => {

--- a/packages/zip-it-and-ship-it/src/feature_flags.ts
+++ b/packages/zip-it-and-ship-it/src/feature_flags.ts
@@ -4,9 +4,6 @@ export const defaultFlags = {
   // Build Rust functions from source.
   buildRustSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE),
 
-  // Use esbuild to trace dependencies in the legacy bundler.
-  parseWithEsbuild: false,
-
   // Use NFT as the default bundler.
   traceWithNft: false,
 

--- a/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/zisi/list_imports.ts
+++ b/packages/zip-it-and-ship-it/src/runtimes/node/bundlers/zisi/list_imports.ts
@@ -1,77 +1,9 @@
-import * as esbuild from 'esbuild'
-import { isBuiltin } from 'node:module'
 import precinct from 'precinct'
-import { tmpName } from 'tmp-promise'
 
 import { FeatureFlags } from '../../../../feature_flags.js'
 import { FunctionBundlingUserError } from '../../../../utils/error.js'
-import { safeUnlink } from '../../../../utils/fs.js'
 import { RUNTIME } from '../../../runtime.js'
 import { NODE_BUNDLER } from '../types.js'
-
-// Maximum number of log messages that an esbuild instance will produce. This
-// limit is important to avoid out-of-memory errors due to too much data being
-// sent in the Go<>Node IPC channel.
-const ESBUILD_LOG_LIMIT = 10
-
-const getListImportsPlugin = ({ imports, path }: { imports: Set<string>; path: string }): esbuild.Plugin => ({
-  name: 'list-imports',
-  setup(build) {
-    build.onResolve({ filter: /.*/ }, (args) => {
-      const isEntryPoint = args.path === path
-      const isImport = !isEntryPoint && !isBuiltin(args.path)
-
-      if (isImport) {
-        imports.add(args.path)
-      }
-
-      return {
-        namespace: 'list-imports',
-        external: isImport,
-      }
-    })
-  },
-})
-
-const listImportsWithESBuild = async ({
-  functionName,
-  path,
-}: {
-  functionName: string
-  path: string
-}): Promise<string[]> => {
-  // We're not interested in the output that esbuild generates, we're just
-  // using it for its parsing capabilities in order to find import/require
-  // statements. However, if we don't give esbuild a path in `outfile`, it
-  // will pipe the output to stdout, which we also don't want. So we create
-  // a temporary file to serve as the esbuild output and then get rid of it
-  // when we're done.
-  const targetPath = await tmpName()
-  const imports = new Set<string>()
-
-  try {
-    await esbuild.build({
-      bundle: true,
-      entryPoints: [path],
-      logLevel: 'error',
-      logLimit: ESBUILD_LOG_LIMIT,
-      outfile: targetPath,
-      platform: 'node',
-      plugins: [getListImportsPlugin({ imports, path })],
-      target: 'esnext',
-    })
-  } catch (error) {
-    throw FunctionBundlingUserError.addCustomErrorInfo(error, {
-      functionName,
-      runtime: RUNTIME.JAVASCRIPT,
-      bundler: NODE_BUNDLER.ZISI,
-    })
-  } finally {
-    await safeUnlink(targetPath)
-  }
-
-  return [...imports]
-}
 
 const listImportsWithPrecinct = async ({ functionName, path }: { functionName: string; path: string }) => {
   try {
@@ -97,4 +29,4 @@ export const listImports = async ({
   featureFlags: FeatureFlags
   functionName: string
   path: string
-}) => (featureFlags.parseWithEsbuild ? await listImportsWithESBuild(args) : await listImportsWithPrecinct(args))
+}) => await listImportsWithPrecinct(args)

--- a/packages/zip-it-and-ship-it/tests/helpers/main.ts
+++ b/packages/zip-it-and-ship-it/tests/helpers/main.ts
@@ -171,7 +171,7 @@ export const getRequires = async function (
   currentDepth = 1,
 ): Promise<string[]> {
   const requires = await listImports({
-    featureFlags: { parseWithEsbuild: true },
+    featureFlags: {},
     functionName: 'test-function',
     path: filePath,
   })


### PR DESCRIPTION
This feature flag was never rolled out so is just dead code right now. Seems safe to remove it.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
