### PR TITLE
fix(db): fall back to the deploy ID when a deploy has no git branch

### DIFF
--- a/packages/build/src/plugins_core/db_setup/branch-id.test.ts
+++ b/packages/build/src/plugins_core/db_setup/branch-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+
+import { getDatabaseBranchId } from './utils.js'
+
+const DEPLOY_ID = '6a7b7aad242683d1afab3f2c'
+
+describe('getDatabaseBranchId', () => {
+  test('uses the git branch when the deploy has one', () => {
+    expect(getDatabaseBranchId({ branch: 'my-feature', deployId: DEPLOY_ID })).toBe('my-feature')
+  })
+
+  test.each([undefined, ''])('falls back to the deploy ID when branch is %o', (branch) => {
+    expect(getDatabaseBranchId({ branch, deployId: DEPLOY_ID })).toBe(DEPLOY_ID)
+  })
+
+  test('gives two branchless deploys different IDs', () => {
+    // Sharing one ID would put unrelated previews on the same database, and
+    // branch cleanup resolves a branchless deploy by its deploy ID, so a
+    // shared ID would also never be collected.
+    const first = getDatabaseBranchId({ deployId: '6a67d980f5a4c125104f5375' })
+    const second = getDatabaseBranchId({ deployId: '6a67dcc8a623bb39450d934b' })
+    expect(first).not.toBe(second)
+  })
+
+  test('reuses one ID across redeploys of the same git branch', () => {
+    expect(getDatabaseBranchId({ branch: 'shared', deployId: 'deploy-a' })).toBe(
+      getDatabaseBranchId({ branch: 'shared', deployId: 'deploy-b' }),
+    )
+  })
+})

--- a/packages/build/src/plugins_core/db_setup/index.ts
+++ b/packages/build/src/plugins_core/db_setup/index.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { logDbProvisioning, logDbMigrations } from '../../log/messages/core_steps.js'
 import { getPackageJson, type PackageJson } from '../../utils/package.js'
 import { CoreStep, CoreStepCondition, CoreStepFunction } from '../types.js'
-import { readMigrationEntries, getMigrationNames, getMigrationsSrc } from './utils.js'
+import { getDatabaseBranchId, readMigrationEntries, getMigrationNames, getMigrationsSrc } from './utils.js'
 
 const NPM_PACKAGE_NAME = '@netlify/database'
 
@@ -37,7 +37,7 @@ interface TemporaryDatabaseResponse {
   connection_string: string
 }
 
-const coreStep: CoreStepFunction = async ({ api, branch, buildDir, constants, context, logs }) => {
+const coreStep: CoreStepFunction = async ({ api, branch, buildDir, constants, context, deployId, logs }) => {
   const siteId = constants.SITE_ID
 
   logDbProvisioning({ logs, branch, context })
@@ -56,7 +56,7 @@ const coreStep: CoreStepFunction = async ({ api, branch, buildDir, constants, co
   if (context !== 'production') {
     const databaseBranch = (await api.createSiteDatabaseBranch({
       site_id: siteId,
-      body: { branch_id: branch },
+      body: { branch_id: getDatabaseBranchId({ branch, deployId }) },
     })) as TemporaryDatabaseResponse
 
     connectionString = databaseBranch.connection_string

--- a/packages/build/src/plugins_core/db_setup/utils.ts
+++ b/packages/build/src/plugins_core/db_setup/utils.ts
@@ -66,3 +66,19 @@ export const getMigrationNames = ({ dirNames, fileNames }: MigrationEntries): st
   ...dirNames,
   ...fileNames.map((f) => f.replace(/\.sql$/, '')),
 ]
+
+/**
+ * Resolves the ID for the deploy's database branch.
+ *
+ * `branch` is absent for deploys made without git — CLI and API deploys — and
+ * an absent ID reached the API as an empty one, which it stored verbatim as a
+ * branch no route could address.
+ *
+ */
+export const getDatabaseBranchId = ({ branch, deployId }: { branch?: string; deployId?: string }): string => {
+  if (branch) {
+    return branch
+  }
+
+  return deployId ?? ''
+}

--- a/packages/build/tests/db_setup/tests.js
+++ b/packages/build/tests/db_setup/tests.js
@@ -71,6 +71,15 @@ test('Runs the db_setup core step and creates a database branch for non-producti
   t.deepEqual(branchRequests[0].body, { branch_id: 'feat/my-feature' })
 })
 
+test('Always sends a non-empty branch_id, even outside a git repository', async (t) => {
+  const fixture = await new Fixture(test.meta.file, './fixtures/with_db_dependency').withCopyRoot({ git: false })
+  const { requests } = await runWithMockServer(fixture, { context: 'deploy-preview' })
+
+  const branchRequests = requests.filter((r) => r.url === CREATE_DATABASE_BRANCH_PATH)
+  t.is(branchRequests.length, 1)
+  t.truthy(branchRequests[0].body.branch_id)
+})
+
 test('Does not run the db_setup core step when @netlify/database is not in dependencies', async (t) => {
   const fixture = await new Fixture(test.meta.file, './fixtures/without_db_dependency').withCopyRoot({ git: false })
 


### PR DESCRIPTION
#### Summary

Deploys made without git — CLI and API deploys — have no branch. `db_setup` passed that straight through as `branch_id`, so the database branch was created with an empty ID. The API stores it verbatim, and the result is a branch nothing can address: it can't be fetched, reset, or deleted, it still counts against the tier branch limit, and building a link for it took the whole project's database dashboard down to an error boundary.

This falls back to the deploy ID.

**Why the deploy ID and not the deploy context.** Branch cleanup in Bitballoon resolves a branch by the deploy's `subdomain_alias` or its git `branch`, and for a branchless deploy the alias *is* the deploy ID — verified across four affected sites, every row matching. So keying on the deploy ID keeps the branch collectable by the path that already exists. Keying on the context (`deploy-preview`) would instead put every branchless deploy on a site onto one shared database, and leave behind a branch cleanup could never resolve — a permanent orphan against the branch cap.
🦦