### PR TITLE
test: warm deno cache before test runs

### DIFF
--- a/packages/edge-bundler/test/global_setup.ts
+++ b/packages/edge-bundler/test/global_setup.ts
@@ -1,0 +1,10 @@
+import { getURL } from '@netlify/edge-functions-bootstrap/version'
+
+import { DenoBridge } from '../node/bridge.js'
+
+export default async function setup() {
+  const deno = new DenoBridge({})
+  const bootstrapURL = await getURL()
+
+  await deno.run(['install', '--allow-import', '--entrypoint', bootstrapURL])
+}

--- a/packages/edge-bundler/vitest.config.ts
+++ b/packages/edge-bundler/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   },
   test: {
     include: ['node/**/*.test.ts'],
+    globalSetup: ['test/global_setup.ts'],
     // Some tests download and install deno CLI, so allow some extra time for that
     testTimeout: 60_000,
     env: {


### PR DESCRIPTION
In edge-bundler, we import `bootstrapURL`, which can be expensive and cause the tests to take longer than their ~30s timeout.

Doing this in setup theoretically means tests already have a warm cache of the module graph by the time they run.



---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
