### PR TITLE
fix: catch errors during plugin shutdown

### DIFF
--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -200,22 +200,27 @@ const stopPlugin = async function ({
   logs: BufferedLogs
 }) {
   if (childProcess.connected) {
-    // reliable stop tracing inside child processes
-    await callChild({
-      childProcess,
-      eventName: 'shutdown',
-      payload: {
-        packageName,
-        pluginPath,
-        inputs,
-        packageJson,
+    try {
+      // reliable stop tracing inside child processes
+      await callChild({
+        childProcess,
+        eventName: 'shutdown',
+        payload: {
+          packageName,
+          pluginPath,
+          inputs,
+          packageJson,
+          verbose,
+          netlifyConfig,
+        },
+        logs,
         verbose,
-        netlifyConfig,
-      },
-      logs,
-      verbose,
-    })
-    childProcess.disconnect()
+      })
+      childProcess.disconnect()
+    } catch {
+      // The child process may exit before responding, e.g. when it already
+      // failed. It is being terminated anyway, so ignore the error
+    }
   }
 
   // On Windows with Node 21+, there's a bug where attempting to kill a child process

--- a/packages/build/src/plugins/spawn.ts
+++ b/packages/build/src/plugins/spawn.ts
@@ -216,10 +216,13 @@ const stopPlugin = async function ({
         logs,
         verbose,
       })
-      childProcess.disconnect()
     } catch {
       // The child process may exit before responding, e.g. when it already
       // failed. It is being terminated anyway, so ignore the error
+    } finally {
+      if (childProcess.connected) {
+        childProcess.disconnect()
+      }
     }
   }
 


### PR DESCRIPTION
This seems to be causing some test flakiness. We load a plugin with a syntax error to assert that it gets caught and raised properly.

However, it is possible for the process throwing that error to have exited before the shutdown call succeeds. In those cases, an ipc error is thrown rather than the "nice" error.

This try/catches the shutdown call and eats the error since we kill the process immediately after anyway.

You can see one of these failures here:
https://github.com/netlify/build/actions/runs/32718968671/job/97406124334?pr=7175#step:12:337


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](https://github.com/netlify/build/blob/main/CONTRIBUTING.md) 📖. This ensures
      your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
