### PR TITLE
fix(redirect-parser): trim whitespace from from/to redirect fields

### DIFF
--- a/packages/redirect-parser/src/normalize.js
+++ b/packages/redirect-parser/src/normalize.js
@@ -65,6 +65,12 @@ const parseRedirectObject = function (
     throw new Error('"headers" field must be an object')
   }
 
+  // Redirects defined in `netlify.toml` can accidentally carry leading/trailing
+  // whitespace (e.g. a stray space before `https://...`), which silently breaks
+  // scheme detection in `isUrl()` and downstream URL parsing.
+  from = typeof from === 'string' ? from.trim() : from
+  to = typeof to === 'string' ? to.trim() : to
+
   const statusA = normalizeStatus(status)
   const finalTo = addForwardRule(from, statusA, to)
   const { scheme, host, path } = parseFrom(from)

--- a/packages/redirect-parser/tests/fixtures/netlify_config/to_leading_space.toml
+++ b/packages/redirect-parser/tests/fixtures/netlify_config/to_leading_space.toml
@@ -1,0 +1,3 @@
+[[redirects]]
+  from = "/old-path"
+  to = " http://www.example.com/new-path"

--- a/packages/redirect-parser/tests/netlify-config-parser.test.ts
+++ b/packages/redirect-parser/tests/netlify-config-parser.test.ts
@@ -61,6 +61,11 @@ test.each([
   ],
   ['from_no_slash', { netlifyConfigPath: 'from_no_slash' }, [{ from: 'old-path', path: 'old-path', to: 'new-path' }]],
   [
+    'to_leading_space',
+    { netlifyConfigPath: 'to_leading_space' },
+    [{ from: '/old-path', path: '/old-path', to: 'http://www.example.com/new-path' }],
+  ],
+  [
     'query',
     { netlifyConfigPath: 'query' },
     [{ from: '/old-path', path: '/old-path', to: '/new-path', query: { path: ':path' } }],


### PR DESCRIPTION
## Summary

Fixes netlify/cli#4707.

A stray leading/trailing space in a `netlify.toml` redirect's `to` (or `from`) value silently breaks it. `isUrl()` does a plain `pathOrUrl.startsWith('http://'|'https://')` check, so `to = " https://example.com"` (leading space) is not recognized as an absolute URL — the redirect gets misclassified instead of failing loudly, which is confusing to debug (this is exactly what was reported in the linked issue).

## Fix

Trim `from` and `to` in `parseRedirectObject` (`packages/redirect-parser/src/normalize.js`) right after they're validated/defaulted, before any scheme/URL detection happens.

## Test plan

- Added a fixture (`tests/fixtures/netlify_config/to_leading_space.toml`) and a case in `tests/netlify-config-parser.test.ts` asserting a leading-space `to` value is trimmed and correctly parsed as an absolute URL.
- Ran the full `redirect-parser` suite: `86 passed (86)`.