### PR TITLE
fix(zip-it-and-ship-it): pin @vercel/nft to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7208,74 +7208,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@vercel/nft": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.11.0.tgz",
-      "integrity": "sha512-m1QFg+U+3yPOnP1xSYJ73UIRxLOXdts1JOhiOiyPYqEsALgrXFFINvgUaD6R6iNvaBFAjHllBCbkfx4FuOdpaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^2.0.0",
-        "@rollup/pluginutils": "^5.1.3",
-        "acorn": "^8.6.0",
-        "acorn-import-attributes": "^1.9.5",
-        "async-sema": "^3.1.1",
-        "bindings": "^1.4.0",
-        "estree-walker": "2.0.2",
-        "glob": "^13.0.0",
-        "graceful-fs": "^4.2.9",
-        "node-gyp-build": "^4.2.2",
-        "picomatch": "^4.0.4",
-        "resolve-from": "^5.0.0"
-      },
-      "bin": {
-        "nft": "out/cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@vercel/nft/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vercel/nft/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@vercel/nft/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.6",
       "dev": true,
@@ -24429,7 +24361,7 @@
         "@netlify/binary-info": "^1.0.0",
         "@netlify/serverless-functions-api": "2.18.0",
         "@opentelemetry/api": "~1.8.0",
-        "@vercel/nft": "^1.11.0",
+        "@vercel/nft": "1.3.1",
         "archiver": "^8.0.0",
         "common-path-prefix": "^3.0.0",
         "copy-file": "^11.0.0",
@@ -24485,6 +24417,74 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/@vercel/nft": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.3.1.tgz",
+      "integrity": "sha512-ihNT1rswiq3cy4WKQAV5kJi6UjWX1vLUzlLc+Vvq83G8CU9nMgfDWz5f1tOnSlS8LeC4Wp4qTB3+HGj/ccUrFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@rollup/pluginutils": "^5.1.3",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^13.0.0",
+        "graceful-fs": "^4.2.9",
+        "node-gyp-build": "^4.2.2",
+        "picomatch": "^4.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/zip-it-and-ship-it/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     }
   }

--- a/packages/zip-it-and-ship-it/package.json
+++ b/packages/zip-it-and-ship-it/package.json
@@ -46,7 +46,7 @@
     "@netlify/binary-info": "^1.0.0",
     "@netlify/serverless-functions-api": "2.18.0",
     "@opentelemetry/api": "~1.8.0",
-    "@vercel/nft": "^1.11.0",
+    "@vercel/nft": "1.3.1",
     "archiver": "^8.0.0",
     "common-path-prefix": "^3.0.0",
     "copy-file": "^11.0.0",

--- a/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/.env
+++ b/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/.env
@@ -1,0 +1,1 @@
+MY_SECRET=hello-from-env

--- a/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/function.js
+++ b/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/function.js
@@ -1,0 +1,5 @@
+import { config } from 'fake-dotenv'
+
+config()
+
+export default async () => new Response(process.env.MY_SECRET)

--- a/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/node_modules/fake-dotenv/index.js
+++ b/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/node_modules/fake-dotenv/index.js
@@ -1,0 +1,24 @@
+// Minimal stand-in for `dotenv`: reads `.env` from `process.cwd()`
+// inside `node_modules`, which nft should trace as an asset
+// (see FRB-2345 / vercel/nft#606).
+
+import fs from 'fs'
+import path from 'path'
+
+export function config() {
+  const envPath = path.resolve(process.cwd(), '.env')
+
+  if (!fs.existsSync(envPath)) {
+    return
+  }
+
+  const contents = fs.readFileSync(envPath, 'utf8')
+
+  for (const line of contents.split('\n')) {
+    const [key, ...rest] = line.split('=')
+
+    if (key) {
+      process.env[key.trim()] = rest.join('=').trim()
+    }
+  }
+}

--- a/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/node_modules/fake-dotenv/package.json
+++ b/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/node_modules/fake-dotenv/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake-dotenv",
+  "main": "index.js",
+  "type": "module"
+}

--- a/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/package.json
+++ b/packages/zip-it-and-ship-it/tests/fixtures-esm/v2-api-env-file/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/zip-it-and-ship-it/tests/v2_api_env_file.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2_api_env_file.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises'
+
 import { expect, test } from 'vitest'
 
 import { FIXTURES_ESM_DIR, unzipFiles, zipFixture } from './helpers/main.js'
@@ -11,4 +13,5 @@ test('includes a `.env` file resolved from `process.cwd()` by a dependency when 
   const [{ unzipPath }] = await unzipFiles(files)
 
   await expect(`${unzipPath}/.env`).toPathExist()
+  expect(await readFile(`${unzipPath}/.env`, 'utf8')).toBe('MY_SECRET=hello-from-env\n')
 })

--- a/packages/zip-it-and-ship-it/tests/v2_api_env_file.test.ts
+++ b/packages/zip-it-and-ship-it/tests/v2_api_env_file.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+
+import { FIXTURES_ESM_DIR, unzipFiles, zipFixture } from './helpers/main.js'
+
+test('includes a `.env` file resolved from `process.cwd()` by a dependency when bundling a v2 function', async () => {
+  const { files } = await zipFixture('v2-api-env-file', { fixtureDir: FIXTURES_ESM_DIR })
+
+  expect(files[0].bundler).toBe('nft')
+  expect(files[0].runtimeAPIVersion).toBe(2)
+
+  const [{ unzipPath }] = await unzipFiles(files)
+
+  await expect(`${unzipPath}/.env`).toPathExist()
+})


### PR DESCRIPTION
See: https://linear.app/netlify/issue/FRB-2345/

* Pins `@vercel/nft` to `1.3.1`, the last version before the regression. This restores `.env` tracing while keeping the other fixes we needed from the upgrade.
* Uses an exact version instead of a range so dependency updates can't silently move us back to a broken version.
* Adds a regression test that verifies `.env` is included when bundling a v2 function.

Refer to:

- vercel/nft#568
- vercel/nft#606
