### PR TITLE
Recognize git worktree roots in @netlify/config

### DIFF
--- a/packages/config/src/options/repository_root.js
+++ b/packages/config/src/options/repository_root.js
@@ -4,14 +4,17 @@ import { findUp } from 'find-up'
 
 // Find out repository root among (in priority order):
 //  - `repositoryRoot` option
-//  - find a `.git` directory up from `cwd`
+//  - find a `.git` directory or file up from `cwd`
 //  - `cwd` (fallback)
+// Git worktrees use a `.git` file (not a directory). find-up defaults to
+// type "file", so check directories first then files.
 export const getRepositoryRoot = async function ({ repositoryRoot, cwd }) {
   if (repositoryRoot !== undefined) {
     return repositoryRoot
   }
 
-  const repositoryRootA = await findUp('.git', { cwd, type: 'directory' })
+  const repositoryRootA =
+    (await findUp('.git', { cwd, type: 'directory' })) ?? (await findUp('.git', { cwd, type: 'file' }))
 
   if (repositoryRootA === undefined) {
     return cwd

--- a/packages/config/src/options/repository_root.js
+++ b/packages/config/src/options/repository_root.js
@@ -1,4 +1,5 @@
-import { dirname } from 'path'
+import { lstat } from 'fs/promises'
+import { dirname, join } from 'path'
 
 import { findUp } from 'find-up'
 
@@ -6,15 +7,25 @@ import { findUp } from 'find-up'
 //  - `repositoryRoot` option
 //  - find a `.git` directory or file up from `cwd`
 //  - `cwd` (fallback)
-// Git worktrees use a `.git` file (not a directory). find-up defaults to
-// type "file", so check directories first then files.
+// Git worktrees use a `.git` file (not a directory). Walk once and accept
+// whichever marker is nearest so a parent `.git` directory cannot hide a
+// closer worktree `.git` file.
+const gitMarkerIn = async (directory) => {
+  const gitPath = join(directory, '.git')
+  try {
+    await lstat(gitPath)
+    return gitPath
+  } catch {
+    return undefined
+  }
+}
+
 export const getRepositoryRoot = async function ({ repositoryRoot, cwd }) {
   if (repositoryRoot !== undefined) {
     return repositoryRoot
   }
 
-  const repositoryRootA =
-    (await findUp('.git', { cwd, type: 'directory' })) ?? (await findUp('.git', { cwd, type: 'file' }))
+  const repositoryRootA = await findUp(gitMarkerIn, { cwd })
 
   if (repositoryRootA === undefined) {
     return cwd

--- a/packages/config/tests/cwd/cwd.test.js
+++ b/packages/config/tests/cwd/cwd.test.js
@@ -67,6 +67,22 @@ test('git worktree .git file is treated as repository root', async () => {
   }
 })
 
+test('nearest worktree .git file wins over a parent .git directory', async () => {
+  const parent = await mkdtemp(join(tmpdir(), 'netlify-config-nested-wt-'))
+  try {
+    await mkdir(join(parent, '.git'))
+    const worktree = join(parent, 'wt')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: /tmp/main/.git/worktrees/wt\n')
+    const nested = join(worktree, 'apps', 'site')
+    await mkdir(nested, { recursive: true })
+    const repositoryRoot = await getRepositoryRoot({ cwd: nested })
+    expect(resolve(repositoryRoot)).toBe(resolve(worktree))
+  } finally {
+    await rm(parent, { recursive: true, force: true })
+  }
+})
+
 test('--cwd non-existing', async () => {
   const output = await new Fixture()
     .withFlags({ cwd: '/invalid', repositoryRoot: `${FIXTURES_DIR}/empty` })

--- a/packages/config/tests/cwd/cwd.test.js
+++ b/packages/config/tests/cwd/cwd.test.js
@@ -1,9 +1,13 @@
-import { relative } from 'path'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join, relative, resolve } from 'path'
 import { cwd } from 'process'
 import { fileURLToPath } from 'url'
 
 import { Fixture, normalizeOutput } from '@netlify/testing'
 import { expect, test } from 'vitest'
+
+import { getRepositoryRoot } from '../../src/options/repository_root.js'
 
 const FIXTURES_DIR = fileURLToPath(new URL('fixtures', import.meta.url))
 
@@ -48,6 +52,19 @@ test('No .git', async () => {
     .withCopyRoot({ git: false, cwd: true })
     .then((fixture) => fixture.runWithConfig())
   expect(normalizeOutput(output)).toMatchSnapshot()
+})
+
+test('git worktree .git file is treated as repository root', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'netlify-config-worktree-'))
+  try {
+    await writeFile(join(root, '.git'), 'gitdir: /tmp/main/.git/worktrees/wt\n')
+    const nested = join(root, 'apps', 'site')
+    await mkdir(nested, { recursive: true })
+    const repositoryRoot = await getRepositoryRoot({ cwd: nested })
+    expect(resolve(repositoryRoot)).toBe(resolve(root))
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })
 
 test('--cwd non-existing', async () => {


### PR DESCRIPTION
## Summary

Git worktrees store a `.git` file rather than a directory. `getRepositoryRoot` only looked for a directory so worktree checkouts fell back to cwd and broke path resolution.

This also looks for a `.git` file so worktree roots resolve correctly.

Fixes https://github.com/netlify/cli/issues/7868

## Test plan

* Added unit test covering a `.git` file worktree layout
* Ran packages/config cwd tests