### PR TITLE
test: cover config error reporting regressions

### DIFF
--- a/packages/build/tests/core/fixtures/invalid_edge_functions_path/netlify.toml
+++ b/packages/build/tests/core/fixtures/invalid_edge_functions_path/netlify.toml
@@ -1,0 +1,3 @@
+[[edge_functions]]
+path = ["/*"]
+function = "hello"

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -135,6 +135,14 @@ test('Exit code is 2 on user error', async (t) => {
   t.is(exitCode, 2)
 })
 
+test('Invalid initial configuration preserves the validation error', async (t) => {
+  const { output } = await new Fixture(test.meta.file, './fixtures/invalid_edge_functions_path').runBuildBinary()
+
+  t.true(output.includes('Configuration error'))
+  t.true(output.includes('Configuration property edge_functions[0].path must be a string.'))
+  t.false(output.includes("Cannot read properties of undefined (reading 'packageName')"))
+})
+
 test('Exit code is 3 on plugin error', async (t) => {
   const { exitCode } = await new Fixture(test.meta.file, './fixtures/plugin_error').runBuildBinary()
   t.is(exitCode, 3)

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -1,8 +1,6 @@
 import { Fixture, normalizeOutput } from '@netlify/testing'
 import test from 'ava'
 
-import { reportStatuses } from '../../lib/status/report.js'
-
 const STATUS_PATH = '/api/v1/deploys/test/plugin_runs'
 
 // Normalize API request body so it can be snapshot in a stable way
@@ -27,10 +25,6 @@ const WHITESPACE_REGEXP = /\s+/g
 const comparePackage = function ({ body: { package: packageA } }, { body: { package: packageB } }) {
   return packageA < packageB ? -1 : 1
 }
-
-test('reporting statuses tolerates missing plugin initialization data', async (t) => {
-  await t.notThrowsAsync(reportStatuses({ statuses: [] }))
-})
 
 test('utils.status.show() can override a success status', async (t) => {
   const { requests, output } = await new Fixture(test.meta.file, './fixtures/success_status_override')

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -1,6 +1,8 @@
 import { Fixture, normalizeOutput } from '@netlify/testing'
 import test from 'ava'
 
+import { reportStatuses } from '../../lib/status/report.js'
+
 const STATUS_PATH = '/api/v1/deploys/test/plugin_runs'
 
 // Normalize API request body so it can be snapshot in a stable way
@@ -25,6 +27,10 @@ const WHITESPACE_REGEXP = /\s+/g
 const comparePackage = function ({ body: { package: packageA } }, { body: { package: packageB } }) {
   return packageA < packageB ? -1 : 1
 }
+
+test('reporting statuses tolerates missing plugin initialization data', async (t) => {
+  await t.notThrowsAsync(reportStatuses({ statuses: [] }))
+})
 
 test('utils.status.show() can override a success status', async (t) => {
   const { requests, output } = await new Fixture(test.meta.file, './fixtures/success_status_override')


### PR DESCRIPTION
This PR adds a regression test for the reporting of invalid framework API config option values. Without a fix, the error is swallowed up, making it difficult to debug a build failure