### PR TITLE
fix: preserve initial configuration errors

### DIFF
--- a/packages/build/src/core/build.ts
+++ b/packages/build/src/core/build.ts
@@ -1,5 +1,6 @@
 import { addAttributesToActiveSpan } from '@netlify/opentelemetry-utils'
 
+import { handleBuildError } from '../error/handle.js'
 import { getErrorInfo } from '../error/info.js'
 import { startErrorMonitor } from '../error/monitor/start.js'
 import { getBufferLogs, getSystemLogger } from '../log/logger.js'
@@ -383,20 +384,24 @@ export const runAndReportBuild = async function ({
     }
   } catch (error) {
     const [{ statuses }] = getErrorInfo(error)
-    await reportStatuses({
-      statuses,
-      childEnv,
-      api,
-      mode,
-      pluginsOptions,
-      netlifyConfig,
-      errorMonitor,
-      deployId,
-      logs,
-      debug,
-      sendStatus,
-      testOpts,
-    })
+    try {
+      await reportStatuses({
+        statuses,
+        childEnv,
+        api,
+        mode,
+        pluginsOptions,
+        netlifyConfig,
+        errorMonitor,
+        deployId,
+        logs,
+        debug,
+        sendStatus,
+        testOpts,
+      })
+    } catch (statusError) {
+      await handleBuildError(statusError, errorParams)
+    }
     throw error
   }
 }

--- a/packages/build/src/core/config.js
+++ b/packages/build/src/core/config.js
@@ -2,7 +2,7 @@ import { resolveConfig, restoreConfig, updateConfig } from '@netlify/config'
 
 import { getChildEnv } from '../env/main.js'
 import { addApiErrorHandlers } from '../error/api.js'
-import { changeErrorType } from '../error/info.js'
+import { addErrorInfo, changeErrorType } from '../error/info.js'
 import { logBuildDir, logConfig, logConfigPath, logContext } from '../log/messages/config.js'
 import { logConfigOnUpload, logHeadersOnUpload, logRedirectsOnUpload } from '../log/messages/mutations.js'
 import { measureDuration } from '../time/main.js'
@@ -124,7 +124,12 @@ export const loadConfig = measureDuration(tLoadConfig, 'resolve_config')
 // In the buildbot and CLI, we re-use the already parsed `@netlify/config`
 // return value which is passed as `cachedConfig`/`cachedConfigPath`.
 const resolveInitialConfig = async function (configOpts, cachedConfig, defaultConfig, cachedConfigPath, featureFlags) {
-  return await resolveConfig({ ...configOpts, cachedConfig, defaultConfig, cachedConfigPath, featureFlags })
+  try {
+    return await resolveConfig({ ...configOpts, cachedConfig, defaultConfig, cachedConfigPath, featureFlags })
+  } catch (error) {
+    addErrorInfo(error, { type: 'resolveConfig' })
+    throw error
+  }
 }
 
 const logConfigInfo = function ({ logs, configPath, buildDir, netlifyConfig, context, debug }) {

--- a/packages/build/src/core/main.ts
+++ b/packages/build/src/core/main.ts
@@ -148,7 +148,11 @@ export async function buildSite(flags: Partial<BuildFlags> = {}): Promise<{
         testOpts,
         errorParams,
       })
-      await reportError(error, statsdOpts, framework)
+      try {
+        await reportError(error, statsdOpts, framework)
+      } catch (reportingError) {
+        await handleBuildError(reportingError, errorParams)
+      }
 
       return { success, severityCode, logs }
     } finally {

--- a/packages/build/tests/core/fixtures/invalid_edge_functions_path/netlify.toml
+++ b/packages/build/tests/core/fixtures/invalid_edge_functions_path/netlify.toml
@@ -1,0 +1,3 @@
+[[edge_functions]]
+path = ["/*"]
+function = "hello"

--- a/packages/build/tests/core/tests.js
+++ b/packages/build/tests/core/tests.js
@@ -135,6 +135,14 @@ test('Exit code is 2 on user error', async (t) => {
   t.is(exitCode, 2)
 })
 
+test('Invalid initial configuration preserves the validation error', async (t) => {
+  const { output } = await new Fixture(test.meta.file, './fixtures/invalid_edge_functions_path').runBuildBinary()
+
+  t.true(output.includes('Configuration error'))
+  t.true(output.includes('Configuration property edge_functions[0].path must be a string.'))
+  t.false(output.includes("Cannot read properties of undefined (reading 'packageName')"))
+})
+
 test('Exit code is 3 on plugin error', async (t) => {
   const { exitCode } = await new Fixture(test.meta.file, './fixtures/plugin_error').runBuildBinary()
   t.is(exitCode, 3)

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -1,8 +1,6 @@
 import { Fixture, normalizeOutput } from '@netlify/testing'
 import test from 'ava'
 
-import { reportStatuses } from '../../lib/status/report.js'
-
 const STATUS_PATH = '/api/v1/deploys/test/plugin_runs'
 
 // Normalize API request body so it can be snapshot in a stable way
@@ -27,10 +25,6 @@ const WHITESPACE_REGEXP = /\s+/g
 const comparePackage = function ({ body: { package: packageA } }, { body: { package: packageB } }) {
   return packageA < packageB ? -1 : 1
 }
-
-test('reporting statuses tolerates missing plugin initialization data', async (t) => {
-  await t.notThrowsAsync(reportStatuses({ statuses: [] }))
-})
 
 test('utils.status.show() can override a success status', async (t) => {
   const { requests, output } = await new Fixture(test.meta.file, './fixtures/success_status_override')

--- a/packages/build/tests/status/tests.js
+++ b/packages/build/tests/status/tests.js
@@ -1,6 +1,8 @@
 import { Fixture, normalizeOutput } from '@netlify/testing'
 import test from 'ava'
 
+import { reportStatuses } from '../../lib/status/report.js'
+
 const STATUS_PATH = '/api/v1/deploys/test/plugin_runs'
 
 // Normalize API request body so it can be snapshot in a stable way
@@ -25,6 +27,10 @@ const WHITESPACE_REGEXP = /\s+/g
 const comparePackage = function ({ body: { package: packageA } }, { body: { package: packageB } }) {
   return packageA < packageB ? -1 : 1
 }
+
+test('reporting statuses tolerates missing plugin initialization data', async (t) => {
+  await t.notThrowsAsync(reportStatuses({ statuses: [] }))
+})
 
 test('utils.status.show() can override a success status', async (t) => {
   const { requests, output } = await new Fixture(test.meta.file, './fixtures/success_status_override')


### PR DESCRIPTION
Depends on #7211

Preserves initial configuration errors during reporting. The current diff includes the regression-test commit because fork-hosted branches cannot be upstream PR bases; after #7211 merges, the diff narrows to the implementation.

Validation: 141 focused core, status, telemetry, and error-reporting tests; forced TypeScript build; targeted ESLint; and formatting passed.